### PR TITLE
Move logs to ~/.maxam/logs directory

### DIFF
--- a/cmd/maxam/chat.go
+++ b/cmd/maxam/chat.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -38,7 +37,7 @@ func runChat() {
 
 	session := &ChatSession{
 		agents:  agent.NewAgents(workDir),
-		logMgr:  logger.NewManager(filepath.Join(workDir, "logs"), workDir),
+		logMgr:  logger.NewManager(logger.GetDefaultLogDir(), workDir),
 		workDir: workDir,
 		history: make([]chatMessage, 0),
 	}

--- a/cmd/maxam/main.go
+++ b/cmd/maxam/main.go
@@ -126,7 +126,7 @@ func runReview() {
 	fmt.Printf("Task: %s\n", task)
 
 	agents := agent.NewAgents(workDir)
-	logMgr := logger.NewManager(filepath.Join(workDir, "logs"), workDir)
+	logMgr := logger.NewManager(logger.GetDefaultLogDir(), workDir)
 	defer logMgr.Close()
 
 	reviewCycle := workflow.NewReviewCycle(agents, logMgr)
@@ -187,7 +187,7 @@ func runAnalyze() {
 	fmt.Println("=====================")
 
 	agents := agent.NewAgents(workDir)
-	logMgr := logger.NewManager(filepath.Join(workDir, "logs"), workDir)
+	logMgr := logger.NewManager(logger.GetDefaultLogDir(), workDir)
 	defer logMgr.Close()
 
 	analysisCycle := workflow.NewAnalysisCycle(agents, logMgr, workDir)
@@ -238,11 +238,13 @@ func showStatus() {
 
 	// Check logs
 	fmt.Println("\nLogs:")
-	logsDir := filepath.Join(workDir, "logs")
+	projectName := logger.ProjectNameFromPath(workDir)
+	logsDir := filepath.Join(logger.GetDefaultLogDir(), projectName)
 	for _, name := range agentNames {
 		agentLogDir := filepath.Join(logsDir, name)
 		if entries, err := os.ReadDir(agentLogDir); err == nil {
 			fmt.Printf("  %s: %d log files\n", name, len(entries))
 		}
 	}
+	fmt.Printf("  (location: %s)\n", logsDir)
 }

--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -127,7 +127,7 @@ func initialTuiModel(workDir string) tuiModel {
 
 	return tuiModel{
 		agents:     agent.NewAgents(workDir),
-		logMgr:     logger.NewManager(filepath.Join(workDir, "logs"), workDir),
+		logMgr:     logger.NewManager(logger.GetDefaultLogDir(), workDir),
 		history:    hist,
 		workDir:    workDir,
 		textInput:  ti,

--- a/cmd/workflow-test/main.go
+++ b/cmd/workflow-test/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/ytnobody/MAXAM/internal/agent"
 	"github.com/ytnobody/MAXAM/internal/logger"
@@ -23,7 +22,7 @@ func main() {
 
 	// Initialize components
 	agents := agent.NewAgents(workDir)
-	logMgr := logger.NewManager(filepath.Join(workDir, "logs"), workDir)
+	logMgr := logger.NewManager(logger.GetDefaultLogDir(), workDir)
 	defer logMgr.Close()
 
 	// Create review cycle workflow

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -5,9 +5,21 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
+
+// GetDefaultLogDir returns the default log directory (~/.maxam/logs)
+func GetDefaultLogDir() string {
+	var home string
+	if runtime.GOOS == "windows" {
+		home = os.Getenv("USERPROFILE")
+	} else {
+		home = os.Getenv("HOME")
+	}
+	return filepath.Join(home, ".maxam", "logs")
+}
 
 // ProjectNameFromPath converts a directory path to a project name.
 // Example: /home/ubuntu/my-project -> home_ubuntu_my-project
@@ -116,13 +128,16 @@ type Manager struct {
 }
 
 // NewManager creates a new logger manager with project-specific subdirectory.
-// baseDir: logs directory (e.g., /path/to/MAXAM/logs)
+// baseDir: logs directory (e.g., ~/.maxam/logs)
 // projectDir: working directory for the project (used to generate project name)
 func NewManager(baseDir, projectDir string) *Manager {
 	projectName := ProjectNameFromPath(projectDir)
 	fullDir := filepath.Join(baseDir, projectName)
 
-	// Migrate existing logs if needed
+	// Migrate from project-local logs/ to ~/.maxam/logs/
+	migrateFromProjectLocal(projectDir, fullDir)
+
+	// Migrate existing logs if needed (old style in baseDir)
 	migrateExistingLogs(baseDir, projectName)
 
 	// Ensure directory exists
@@ -131,6 +146,89 @@ func NewManager(baseDir, projectDir string) *Manager {
 	return &Manager{
 		baseDir: fullDir,
 		loggers: make(map[string]*Logger),
+	}
+}
+
+// migrateFromProjectLocal moves logs from project/logs/ to ~/.maxam/logs/{project}/
+func migrateFromProjectLocal(projectDir, targetDir string) {
+	localLogsDir := filepath.Join(projectDir, "logs")
+
+	// Check if local logs directory exists
+	info, err := os.Stat(localLogsDir)
+	if err != nil || !info.IsDir() {
+		return
+	}
+
+	// Ensure target directory exists
+	os.MkdirAll(targetDir, 0755)
+
+	agents := []string{"mei", "yuki", "priya", "amara"}
+	projectName := ProjectNameFromPath(projectDir)
+
+	for _, agent := range agents {
+		// Check both direct agent dir and project-named subdir
+		paths := []string{
+			filepath.Join(localLogsDir, agent),
+			filepath.Join(localLogsDir, projectName, agent),
+		}
+
+		for _, oldPath := range paths {
+			info, err := os.Stat(oldPath)
+			if err != nil || !info.IsDir() {
+				continue
+			}
+
+			newPath := filepath.Join(targetDir, agent)
+			if _, err := os.Stat(newPath); os.IsNotExist(err) {
+				// Move directory
+				if err := os.Rename(oldPath, newPath); err != nil {
+					// If rename fails, try copying files
+					copyDir(oldPath, newPath)
+				}
+			} else {
+				// Merge: copy files that don't exist in target
+				mergeDir(oldPath, newPath)
+			}
+		}
+	}
+}
+
+// copyDir copies all files from src to dst
+func copyDir(src, dst string) {
+	os.MkdirAll(dst, 0755)
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+		if data, err := os.ReadFile(srcPath); err == nil {
+			os.WriteFile(dstPath, data, 0644)
+		}
+	}
+}
+
+// mergeDir copies files from src to dst that don't exist in dst
+func mergeDir(src, dst string) {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+		if _, err := os.Stat(dstPath); os.IsNotExist(err) {
+			if data, err := os.ReadFile(srcPath); err == nil {
+				os.WriteFile(dstPath, data, 0644)
+			}
+		}
 	}
 }
 

--- a/internal/workflow/analysis.go
+++ b/internal/workflow/analysis.go
@@ -77,7 +77,8 @@ func (ac *AnalysisCycle) Run(ctx context.Context) (*AnalysisResult, error) {
 }
 
 func (ac *AnalysisCycle) collectLogs() (string, error) {
-	logsDir := filepath.Join(ac.workDir, "logs")
+	projectName := logger.ProjectNameFromPath(ac.workDir)
+	logsDir := filepath.Join(logger.GetDefaultLogDir(), projectName)
 	var content strings.Builder
 
 	agents := []string{"mei", "yuki", "priya", "amara"}


### PR DESCRIPTION
## Summary
- ログ出力先を `~/.maxam/logs/{プロジェクト名}/` に変更
- プロジェクトローカルの `logs/` から自動マイグレーション
- `maxam status` でログの保存場所を表示

## Test plan
- [ ] `go build ./...` が通る
- [ ] `go test ./...` が通る
- [ ] 新規ログが `~/.maxam/logs/` に作成される
- [ ] 既存のプロジェクトローカルログがマイグレーションされる

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)