### PR TITLE
feat: サブプロジェクト（ネストしたgitリポジトリ）の自動検出対応

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,34 +98,60 @@ type: feat, fix, refactor, docs, test, chore
 ### ディレクトリ構成
 
 ```
-/tmp/maxam/{agent-name}/{project-name}/
+/tmp/maxam/{agent-name}/{parent}_{child}/
 ```
+
+親ディレクトリからの相対パスを `_` で連結してフラットに管理する。
 
 | パス | 用途 |
 |------|------|
 | `/home/ubuntu/{project}/` | 元リポジトリ（main）、Meiの作業場所 |
-| `/tmp/maxam/yuki/{project}/` | Yuki用worktree |
+| `/tmp/maxam/yuki/{project}/` | Yuki用worktree（単独リポジトリ） |
+| `/tmp/maxam/yuki/{parent}_{child}/` | Yuki用worktree（ネストしたリポジトリ） |
 | `/tmp/maxam/rin/{project}/` | Rin用worktree |
 | `/tmp/maxam/shiori/{project}/` | Shiori用worktree |
 | `/tmp/maxam/priya/{project}/` | Priya用worktree |
 | `/tmp/maxam/amara/{project}/` | Amara用worktree |
 
-**例：複数プロジェクトを担当する場合**
+**例：単独プロジェクト**
 ```
-/tmp/maxam/yuki/MAXAM/      # YukiのMAXAM作業
-/tmp/maxam/yuki/HOGEHOGE/   # YukiのHOGEHOGE作業
+/tmp/maxam/yuki/MAXAM/      # ~/MAXAMで作業
 /tmp/maxam/priya/MAXAM/     # PriyaのMAXAM作業
-/tmp/maxam/priya/HOGEHOGE/  # PriyaのHOGEHOGE作業
+```
+
+**例：ネストしたサブプロジェクト（親ディレクトリ配下に複数リポジトリ）**
+```
+~/calcium-lang/             # 親ディレクトリ（gitリポジトリではない）
+├── calcium/               # リポジトリ1
+├── boneyard/              # リポジトリ2
+└── json/                  # リポジトリ3
+
+↓ worktreeパス（_で連結）
+
+/tmp/maxam/yuki/calcium-lang_calcium/    # calcium-lang/calcium
+/tmp/maxam/yuki/calcium-lang_boneyard/   # calcium-lang/boneyard
+/tmp/maxam/yuki/calcium-lang_json/       # calcium-lang/json
+```
+
+**例：深いネストの場合**
+```
+~/some/deep/project/ → /tmp/maxam/yuki/project/
+~/parent/child/grandchild/ → /tmp/maxam/yuki/parent_child_grandchild/
 ```
 
 ### 運用ルール
 
 1. **作業開始時**: worktreeが存在しなければ作成
    ```bash
+   # 単独リポジトリ
    git worktree add /tmp/maxam/{name}/{project} {branch}
+
+   # ネストしたリポジトリ（親ディレクトリ名を含める）
+   git worktree add /tmp/maxam/{name}/{parent}_{child} {branch}
    ```
 2. **ブランチ管理**: worktree内で自由に切り替えOK
 3. **マシン再起動時**: `/tmp`は消えるので再作成
+4. **サブプロジェクト検出**: MAXAMは起動時に配下のgitリポジトリを自動検出
 
 ### 備考
 
@@ -133,6 +159,7 @@ type: feat, fix, refactor, docs, test, chore
 - 他メンバーは自分のworktreeで独立して作業可能
 - 衝突を気にせず並列作業できる
 - `/tmp/maxam/` 配下はMAXAMチーム共通の作業場所として、複数プロジェクトを管理
+- **サブプロジェクト対応**: 親ディレクトリ配下のgitリポジトリを再帰的に検出し、コンテキストに含める
 
 ## 学習事項
 

--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -707,6 +707,35 @@ func (m *tuiModel) analyzeProject() {
 	}
 	sb.WriteString("```\n")
 
+	// サブプロジェクト（ネストしたgitリポジトリ）を検出
+	subProjects := findGitRepos(m.workDir)
+	if len(subProjects) > 0 {
+		sb.WriteString("\n### 検出されたサブプロジェクト\n\n")
+		for _, proj := range subProjects {
+			// プロジェクトタイプを表示
+			var types []string
+			if proj.hasGoMod {
+				types = append(types, "Go")
+			}
+			if proj.hasPackageJSON {
+				types = append(types, "Node.js")
+			}
+			typeStr := ""
+			if len(types) > 0 {
+				typeStr = fmt.Sprintf(" (%s)", strings.Join(types, ", "))
+			}
+
+			sb.WriteString(fmt.Sprintf("#### %s%s\n", proj.path, typeStr))
+			sb.WriteString(fmt.Sprintf("- パス: `%s`\n", proj.absPath))
+			sb.WriteString(fmt.Sprintf("- worktree例: `%s`\n", getWorktreePath("yuki", m.workDir, proj.path)))
+
+			if proj.readme != "" {
+				sb.WriteString(fmt.Sprintf("- README概要:\n```\n%s\n```\n", proj.readme))
+			}
+			sb.WriteString("\n")
+		}
+	}
+
 	m.projectContext = sb.String()
 }
 
@@ -855,6 +884,99 @@ func isNoIssueResponse(response string) bool {
 		}
 	}
 	return false
+}
+
+// subProject はサブプロジェクトの情報を保持
+type subProject struct {
+	path     string // 相対パス
+	absPath  string // 絶対パス
+	readme   string // README.mdの内容（あれば）
+	hasGoMod bool
+	hasPackageJSON bool
+}
+
+// findGitRepos は指定ディレクトリ配下のgitリポジトリを再帰的に検出
+func findGitRepos(rootDir string) []subProject {
+	var projects []subProject
+
+	var walk func(dir string, depth int)
+	walk = func(dir string, depth int) {
+		// 深すぎる場合は探索しない（安全策）
+		if depth > 10 {
+			return
+		}
+
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+
+			name := entry.Name()
+			// 隠しディレクトリ、node_modules、vendorはスキップ
+			if strings.HasPrefix(name, ".") || name == "node_modules" || name == "vendor" {
+				continue
+			}
+
+			subDir := filepath.Join(dir, name)
+			gitPath := filepath.Join(subDir, ".git")
+
+			// .gitがあればサブプロジェクトとして登録
+			if info, err := os.Stat(gitPath); err == nil && (info.IsDir() || info.Mode().IsRegular()) {
+				relPath, _ := filepath.Rel(rootDir, subDir)
+				proj := subProject{
+					path:    relPath,
+					absPath: subDir,
+				}
+
+				// README.mdを読む
+				readmePath := filepath.Join(subDir, "README.md")
+				if content, err := os.ReadFile(readmePath); err == nil {
+					readme := string(content)
+					if len(readme) > 500 {
+						readme = readme[:500] + "..."
+					}
+					proj.readme = readme
+				}
+
+				// プロジェクトタイプを検出
+				if _, err := os.Stat(filepath.Join(subDir, "go.mod")); err == nil {
+					proj.hasGoMod = true
+				}
+				if _, err := os.Stat(filepath.Join(subDir, "package.json")); err == nil {
+					proj.hasPackageJSON = true
+				}
+
+				projects = append(projects, proj)
+				// このディレクトリ配下はこれ以上探索しない（gitリポジトリ内のサブモジュールは除外）
+				continue
+			}
+
+			// .gitがなければさらに深く探索
+			walk(subDir, depth+1)
+		}
+	}
+
+	walk(rootDir, 0)
+	return projects
+}
+
+// getWorktreePath はサブプロジェクトのworktreeパスを生成
+// 親ディレクトリからの相対パスを_で連結
+func getWorktreePath(agentName, rootDir, subProjectPath string) string {
+	// rootDirの最後のディレクトリ名を取得
+	rootName := filepath.Base(rootDir)
+
+	// サブプロジェクトのパスを_で連結
+	pathParts := strings.Split(subProjectPath, string(filepath.Separator))
+	allParts := append([]string{rootName}, pathParts...)
+	projectName := strings.Join(allParts, "_")
+
+	return filepath.Join("/tmp/maxam", agentName, projectName)
 }
 
 func runTeamChat() {

--- a/cmd/maxam/tui_analysis_test.go
+++ b/cmd/maxam/tui_analysis_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -62,6 +64,126 @@ func TestIsNoIssueResponse(t *testing.T) {
 			got := isNoIssueResponse(tt.response)
 			if got != tt.want {
 				t.Errorf("isNoIssueResponse(%q) = %v, want %v", tt.response, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindGitRepos(t *testing.T) {
+	// テスト用の一時ディレクトリを作成
+	tmpDir, err := os.MkdirTemp("", "maxam-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// サブプロジェクト構造を作成
+	// tmpDir/
+	//   ├── project1/
+	//   │   └── .git/
+	//   ├── project2/
+	//   │   ├── .git/
+	//   │   └── README.md
+	//   ├── nested/
+	//   │   └── deep/
+	//   │       └── .git/
+	//   └── not-a-repo/
+
+	// project1 (.git ディレクトリ)
+	project1 := filepath.Join(tmpDir, "project1")
+	os.MkdirAll(filepath.Join(project1, ".git"), 0755)
+
+	// project2 (.git ディレクトリ + README)
+	project2 := filepath.Join(tmpDir, "project2")
+	os.MkdirAll(filepath.Join(project2, ".git"), 0755)
+	os.WriteFile(filepath.Join(project2, "README.md"), []byte("# Project 2\nTest project"), 0644)
+	os.WriteFile(filepath.Join(project2, "go.mod"), []byte("module example.com/project2"), 0644)
+
+	// nested/deep (深いネスト)
+	nested := filepath.Join(tmpDir, "nested", "deep")
+	os.MkdirAll(filepath.Join(nested, ".git"), 0755)
+
+	// not-a-repo (gitリポジトリではない)
+	notRepo := filepath.Join(tmpDir, "not-a-repo")
+	os.MkdirAll(notRepo, 0755)
+
+	// テスト実行
+	repos := findGitRepos(tmpDir)
+
+	if len(repos) != 3 {
+		t.Errorf("expected 3 repos, got %d", len(repos))
+		for _, r := range repos {
+			t.Logf("  found: %s", r.path)
+		}
+	}
+
+	// 各リポジトリの検証
+	pathMap := make(map[string]subProject)
+	for _, r := range repos {
+		pathMap[r.path] = r
+	}
+
+	// project1
+	if _, ok := pathMap["project1"]; !ok {
+		t.Error("project1 not found")
+	}
+
+	// project2 (README and go.mod)
+	if p2, ok := pathMap["project2"]; ok {
+		if p2.readme == "" {
+			t.Error("project2 should have readme")
+		}
+		if !p2.hasGoMod {
+			t.Error("project2 should have go.mod")
+		}
+	} else {
+		t.Error("project2 not found")
+	}
+
+	// nested/deep
+	nestedPath := filepath.Join("nested", "deep")
+	if _, ok := pathMap[nestedPath]; !ok {
+		t.Errorf("nested/deep not found, expected path: %s", nestedPath)
+	}
+}
+
+func TestGetWorktreePath(t *testing.T) {
+	tests := []struct {
+		name           string
+		agentName      string
+		rootDir        string
+		subProjectPath string
+		want           string
+	}{
+		{
+			name:           "単純なサブプロジェクト",
+			agentName:      "yuki",
+			rootDir:        "/home/ubuntu/calcium-lang",
+			subProjectPath: "calcium",
+			want:           "/tmp/maxam/yuki/calcium-lang_calcium",
+		},
+		{
+			name:           "深いネスト",
+			agentName:      "yuki",
+			rootDir:        "/home/ubuntu/parent",
+			subProjectPath: filepath.Join("child", "grandchild"),
+			want:           "/tmp/maxam/yuki/parent_child_grandchild",
+		},
+		{
+			name:           "別のエージェント",
+			agentName:      "priya",
+			rootDir:        "/home/ubuntu/calcium-lang",
+			subProjectPath: "boneyard",
+			want:           "/tmp/maxam/priya/calcium-lang_boneyard",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getWorktreePath(tt.agentName, tt.rootDir, tt.subProjectPath)
+			if got != tt.want {
+				t.Errorf("getWorktreePath(%q, %q, %q) = %q, want %q",
+					tt.agentName, tt.rootDir, tt.subProjectPath, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- 親ディレクトリ配下のgitリポジトリを再帰的に検出する機能を追加
- worktreeパスの命名規則を `_` 区切りに変更（例: `calcium-lang_calcium`）
- CLAUDE.mdのworktree運用セクションを更新

## 変更内容
1. `findGitRepos()` - 再帰的に.gitを持つディレクトリを検出
2. `getWorktreePath()` - 親パスを_で連結したworktreeパスを生成
3. `analyzeProject()` - サブプロジェクト情報をコンテキストに含める
4. テスト追加（3パターン）

## テスト方法
```bash
go test ./cmd/maxam/... -v
```

または `~/calcium-lang` でMAXAMを起動して、サブプロジェクトが検出されることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)