### PR TITLE
feat: エージェント返答内の複数メンション検出と並列起動

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -93,8 +93,8 @@ type agentResponseMsg struct {
 	content    string
 	elapsed    time.Duration
 	err        error
-	nextAgent  string // 次に発言するエージェント（連鎖用）
-	chainDepth int    // 連鎖の深さ
+	nextAgents []string // 次に発言するエージェント（連鎖用、複数対応）
+	chainDepth int      // 連鎖の深さ
 }
 
 // analysisTickMsg は1時間ごとの軽量分析トリガー
@@ -337,10 +337,18 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		m.updateViewport()
 
-		// 次のエージェントがいれば連鎖（並列対応）
-		if msg.nextAgent != "" && !m.processingAgents[msg.nextAgent] {
-			m.processingAgents[msg.nextAgent] = true
-			return m, m.runAgentAsync(msg.content, msg.nextAgent, msg.chainDepth+1)
+		// 次のエージェントがいれば連鎖（複数並列対応）
+		if len(msg.nextAgents) > 0 {
+			var cmds []tea.Cmd
+			for _, nextAgent := range msg.nextAgents {
+				if !m.processingAgents[nextAgent] {
+					m.processingAgents[nextAgent] = true
+					cmds = append(cmds, m.runAgentAsync(msg.content, nextAgent, msg.chainDepth+1))
+				}
+			}
+			if len(cmds) > 0 {
+				return m, tea.Batch(cmds...)
+			}
 		}
 
 		return m, nil
@@ -383,10 +391,10 @@ func (m *tuiModel) runAgentAsync(input string, targetAgent string, depth int) te
 
 		result = strings.TrimSpace(result)
 
-		// 返答内の他エージェントへのメンションを検出
-		nextAgent := ""
+		// 返答内の他エージェントへのメンションを検出（複数対応）
+		var nextAgents []string
 		if depth < maxChainDepth && err == nil {
-			nextAgent = detectAgentMention(result, agentName)
+			nextAgents = detectAgentMentions(result, agentName)
 		}
 
 		return agentResponseMsg{
@@ -394,7 +402,7 @@ func (m *tuiModel) runAgentAsync(input string, targetAgent string, depth int) te
 			content:    result,
 			elapsed:    elapsed,
 			err:        err,
-			nextAgent:  nextAgent,
+			nextAgents: nextAgents,
 			chainDepth: depth,
 		}
 	}
@@ -431,12 +439,12 @@ func (m *tuiModel) buildMeiInterventionPrompt() string {
 	return sb.String()
 }
 
-// detectAgentMention は返答内の他エージェントへのメンションを検出
-func detectAgentMention(text string, currentAgent string) string {
+// detectAgentMentions は返答内の他エージェントへのメンションを複数検出
+func detectAgentMentions(text string, currentAgent string) []string {
 	lower := strings.ToLower(text)
 
 	// 他のエージェントへの呼びかけパターンを検出
-	agents := []struct {
+	agentPatterns := []struct {
 		name     string
 		patterns []string
 	}{
@@ -444,20 +452,30 @@ func detectAgentMention(text string, currentAgent string) string {
 		{"priya", []string{"@priya", "priya、", "priya,", "プリヤ、", "プリヤ,", "priyaさん", "プリヤさん", "priyaに", "プリヤに", "priyaお願い", "プリヤお願い", "レビューお願い", "チェックお願い"}},
 		{"amara", []string{"@amara", "amara、", "amara,", "アマラ、", "アマラ,", "amaraさん", "アマラさん", "amaraに", "アマラに", "amaraお願い", "アマラお願い", "分析お願い"}},
 		{"mei", []string{"@mei", "mei、", "mei,", "メイ、", "メイ,", "meiさん", "メイさん", "meiに", "メイに", "meiお願い", "メイお願い"}},
+		{"rin", []string{"@rin", "rin、", "rin,", "りん、", "りん,", "rinさん", "りんさん", "rinに", "りんに", "rinお願い", "りんお願い"}},
+		{"shiori", []string{"@shiori", "shiori、", "shiori,", "しおり、", "しおり,", "shioriさん", "しおりさん", "shioriに", "しおりに", "shioriお願い", "しおりお願い"}},
 	}
 
-	for _, a := range agents {
+	var result []string
+	seen := make(map[string]bool)
+
+	for _, a := range agentPatterns {
 		if a.name == currentAgent {
 			continue // 自分自身へのメンションは無視
 		}
+		if seen[a.name] {
+			continue // 重複は除外
+		}
 		for _, pattern := range a.patterns {
 			if strings.Contains(lower, pattern) {
-				return a.name
+				result = append(result, a.name)
+				seen[a.name] = true
+				break
 			}
 		}
 	}
 
-	return ""
+	return result
 }
 
 func (m *tuiModel) updateViewport() {
@@ -807,7 +825,7 @@ func (m *tuiModel) runLightweightAnalysis() tea.Cmd {
 			content:    result,
 			elapsed:    elapsed,
 			err:        err,
-			nextAgent:  "",
+			nextAgents: nil,
 			chainDepth: 0,
 		}
 	}

--- a/cmd/maxam/tui_analysis_test.go
+++ b/cmd/maxam/tui_analysis_test.go
@@ -147,6 +147,79 @@ func TestFindGitRepos(t *testing.T) {
 	}
 }
 
+func TestDetectAgentMentions(t *testing.T) {
+	tests := []struct {
+		name         string
+		text         string
+		currentAgent string
+		want         []string
+	}{
+		{
+			name:         "単一メンション @yuki",
+			text:         "@Yuki これやっといて",
+			currentAgent: "mei",
+			want:         []string{"yuki"},
+		},
+		{
+			name:         "複数メンション @yuki @priya",
+			text:         "@Yuki 実装して、@Priya レビューお願い",
+			currentAgent: "mei",
+			want:         []string{"yuki", "priya"},
+		},
+		{
+			name:         "全員メンション",
+			text:         "@Yuki @Priya @Amara @Rin @Shiori みんな集まって",
+			currentAgent: "mei",
+			want:         []string{"yuki", "priya", "amara", "rin", "shiori"},
+		},
+		{
+			name:         "自分へのメンションは無視",
+			text:         "@Mei 確認して",
+			currentAgent: "mei",
+			want:         []string{},
+		},
+		{
+			name:         "メンションなし",
+			text:         "これで完了です",
+			currentAgent: "yuki",
+			want:         []string{},
+		},
+		{
+			name:         "日本語パターン ゆきさん",
+			text:         "ゆきさんにお願いしますね",
+			currentAgent: "mei",
+			want:         []string{"yuki"},
+		},
+		{
+			name:         "重複メンションは1回だけ",
+			text:         "@Yuki やって、yukiさんよろしく",
+			currentAgent: "mei",
+			want:         []string{"yuki"},
+		},
+		{
+			name:         "新人エージェント rin shiori",
+			text:         "@Rin フロント、@Shiori テストよろしく",
+			currentAgent: "mei",
+			want:         []string{"rin", "shiori"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectAgentMentions(tt.text, tt.currentAgent)
+			if len(got) != len(tt.want) {
+				t.Errorf("detectAgentMentions(%q, %q) = %v, want %v", tt.text, tt.currentAgent, got, tt.want)
+				return
+			}
+			for i, v := range got {
+				if v != tt.want[i] {
+					t.Errorf("detectAgentMentions(%q, %q)[%d] = %q, want %q", tt.text, tt.currentAgent, i, v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestGetWorktreePath(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Summary
- エージェントの返答内で複数エージェントがメンションされた場合、全員を並列起動するように変更
- `detectAgentMention` → `detectAgentMentions` に変更（複数検出対応）
- `agentResponseMsg.nextAgent` → `nextAgents []string` に変更
- Rin, Shioriのメンションパターンを追加

## Test plan
- [x] `go test ./cmd/maxam/` 通過
- [x] `go build ./cmd/maxam/` 通過
- [ ] 実際にMeiから複数エージェントを呼び出して並列起動されることを確認

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)