### PR TITLE
refactor: AgentConfigにFullNameを追加し単一ソース化

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,48 @@ Closes #XX
 - 多様な意見を尊重してください
 - 初心者にも優しく接してください
 
+## チームメンバーの追加
+
+新しいAIエージェントをチームに追加する際のチェックリスト。
+
+### 変更が必要なファイル
+
+1. **`internal/config/config.go`** - `DefaultConfig()` に新メンバーを追加
+   ```go
+   {Name: "name", FullName: "Full Name", Role: "役割"},
+   ```
+
+2. **`agents/{name}/CLAUDE.md`** - エージェントのペルソナファイルを作成
+   - 既存エージェントのファイルを参考に
+   - 性格、役割、行動規範を定義
+
+3. **`internal/agent/rules/CLAUDE.md`** - 共通規約のチームメンバー表を更新
+
+4. **`CLAUDE.md`** - ルートの共通規約のチームメンバー表を更新
+
+5. **`README.md`** - チームメンバー表を更新
+
+### 手順
+
+```bash
+# 1. ブランチ作成
+git checkout -b feature/add-agent-{name}
+
+# 2. config.go を編集（DefaultConfig に追加）
+# 3. agents/{name}/CLAUDE.md を作成
+# 4. 各ドキュメントのチームメンバー表を更新
+# 5. ビルド・テスト
+go build ./... && go test ./...
+
+# 6. コミット・PR作成
+```
+
+### 備考
+
+- `FullName` は必須。省略すると `Name` がそのまま使われる
+- ペルソナファイルは `agents/` 配下に配置
+- ビルド時に `agents/` は `~/.maxam/agents/` へ自動展開される
+
 ## 質問がある場合
 
 Issue を作成するか、Discussion でお気軽にどうぞ！

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -162,21 +162,13 @@ func NewAgents(workDir string) *Agents {
 	}
 
 	runners := make(map[string]*Runner)
-	agentNames := map[string]string{
-		"mei":    "Mei Chen",
-		"yuki":   "Yuki Tanaka",
-		"rin":    "Rin Sato",
-		"shiori": "Shiori Tanaka",
-		"priya":  "Priya Sharma",
-		"amara":  "Amara Okonkwo",
-	}
 
 	// Create runners for configured agents
 	for _, agentCfg := range cfg.Agents {
 		name := agentCfg.Name
-		fullName := agentNames[name]
+		fullName := agentCfg.FullName
 		if fullName == "" {
-			fullName = name // Use agent name if not in map
+			fullName = name // Use agent name if FullName not set
 		}
 
 		agentDir := filepath.Join(agentsDir, name)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,8 +17,9 @@ type Config struct {
 
 // AgentConfig represents an agent configuration
 type AgentConfig struct {
-	Name string `yaml:"name"`
-	Role string `yaml:"role"`
+	Name     string `yaml:"name"`
+	FullName string `yaml:"full_name"`
+	Role     string `yaml:"role"`
 }
 
 // DefaultConfig returns the default configuration
@@ -26,12 +27,12 @@ func DefaultConfig() *Config {
 	return &Config{
 		Version: "1",
 		Agents: []AgentConfig{
-			{Name: "mei", Role: "PM / 要件定義"},
-			{Name: "yuki", Role: "バックエンド / インフラ"},
-			{Name: "rin", Role: "フロントエンド"},
-			{Name: "shiori", Role: "テスト / ドキュメント"},
-			{Name: "priya", Role: "レビュー / セキュリティ / QA"},
-			{Name: "amara", Role: "分析"},
+			{Name: "mei", FullName: "Mei Chen", Role: "PM / 要件定義"},
+			{Name: "yuki", FullName: "Yuki Tanaka", Role: "バックエンド / インフラ"},
+			{Name: "rin", FullName: "Rin Sato", Role: "フロントエンド"},
+			{Name: "shiori", FullName: "Shiori Tanaka", Role: "テスト / ドキュメント"},
+			{Name: "priya", FullName: "Priya Sharma", Role: "レビュー / セキュリティ / QA"},
+			{Name: "amara", FullName: "Amara Okonkwo", Role: "分析"},
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- `config.AgentConfig` に `FullName` フィールドを追加
- `runner.go` の `agentNames` マップを削除し、設定から取得するように変更
- CONTRIBUTING.md にチームメンバー追加手順のチェックリストを追加

## Test plan
- [x] `go build ./...` 通過
- [x] `go test ./...` 通過

## 動作確認
```bash
go build ./... && go test ./...
```

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)