### PR TITLE
feat: add TaskService for task list management

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -86,20 +86,42 @@ func (c *Client) GetIssue(ctx context.Context, number int) (*github.Issue, error
 
 // ListIssues lists open issues
 func (c *Client) ListIssues(ctx context.Context, labels []string) ([]*github.Issue, error) {
+	return c.ListIssuesWithOptions(ctx, "open", "", labels)
+}
+
+// ListIssuesWithOptions lists issues with filtering options
+func (c *Client) ListIssuesWithOptions(ctx context.Context, state, assignee string, labels []string) ([]*github.Issue, error) {
+	if state == "" {
+		state = "open"
+	}
+
 	opts := &github.IssueListByRepoOptions{
-		State:  "open",
+		State:  state,
 		Labels: labels,
 		ListOptions: github.ListOptions{
-			PerPage: 30,
+			PerPage: 100,
 		},
 	}
 
-	issues, _, err := c.client.Issues.ListByRepo(ctx, c.owner, c.repo, opts)
-	if err != nil {
-		return nil, fmt.Errorf("list issues: %w", err)
+	if assignee != "" {
+		opts.Assignee = assignee
 	}
 
-	return issues, nil
+	var allIssues []*github.Issue
+	for {
+		issues, resp, err := c.client.Issues.ListByRepo(ctx, c.owner, c.repo, opts)
+		if err != nil {
+			return nil, fmt.Errorf("list issues: %w", err)
+		}
+		allIssues = append(allIssues, issues...)
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return allIssues, nil
 }
 
 // AssignIssue assigns an issue to users

--- a/internal/task/service.go
+++ b/internal/task/service.go
@@ -1,0 +1,70 @@
+// Package task provides task management functionality
+package task
+
+import (
+	"context"
+	"fmt"
+
+	gh "github.com/ytnobody/MAXAM/internal/github"
+)
+
+// ListOptions specifies options for listing tasks
+type ListOptions struct {
+	State    string // "open", "closed", "all" (default: "open")
+	Assignee string // filter by assignee login (empty = all)
+	Labels   []string
+}
+
+// Service provides task management operations
+type Service struct {
+	client *gh.Client
+}
+
+// NewService creates a new task service
+func NewService(client *gh.Client) *Service {
+	return &Service{client: client}
+}
+
+// List returns tasks matching the options
+func (s *Service) List(ctx context.Context, opts ListOptions) ([]*Task, error) {
+	issues, err := s.client.ListIssuesWithOptions(ctx, opts.State, opts.Assignee, opts.Labels)
+	if err != nil {
+		return nil, fmt.Errorf("list issues: %w", err)
+	}
+
+	tasks := make([]*Task, 0, len(issues))
+	for _, issue := range issues {
+		// Skip PRs - we only want issues
+		if issue.PullRequestLinks != nil {
+			continue
+		}
+		tasks = append(tasks, NewTask(issue))
+	}
+
+	return tasks, nil
+}
+
+// ListByAssignee returns tasks for a specific assignee
+func (s *Service) ListByAssignee(ctx context.Context, assignee string) ([]*Task, error) {
+	return s.List(ctx, ListOptions{
+		State:    "open",
+		Assignee: assignee,
+	})
+}
+
+// ListStale returns tasks older than specified days
+func (s *Service) ListStale(ctx context.Context, days int) ([]*Task, error) {
+	tasks, err := s.List(ctx, ListOptions{State: "open"})
+	if err != nil {
+		return nil, err
+	}
+
+	stale := make([]*Task, 0)
+	for _, t := range tasks {
+		if t.StaleDays >= days {
+			stale = append(stale, t)
+		}
+	}
+
+	return stale, nil
+}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -1,0 +1,91 @@
+// Package task provides task management functionality
+package task
+
+import (
+	"time"
+
+	"github.com/google/go-github/v60/github"
+)
+
+// Task represents a task with additional metadata
+type Task struct {
+	Issue     *github.Issue
+	StaleDays int
+}
+
+// NewTask creates a Task from a GitHub issue
+func NewTask(issue *github.Issue) *Task {
+	staleDays := 0
+	if issue.CreatedAt != nil {
+		staleDays = int(time.Since(issue.CreatedAt.Time).Hours() / 24)
+	}
+	return &Task{
+		Issue:     issue,
+		StaleDays: staleDays,
+	}
+}
+
+// Number returns the issue number
+func (t *Task) Number() int {
+	if t.Issue == nil || t.Issue.Number == nil {
+		return 0
+	}
+	return *t.Issue.Number
+}
+
+// Title returns the issue title
+func (t *Task) Title() string {
+	if t.Issue == nil || t.Issue.Title == nil {
+		return ""
+	}
+	return *t.Issue.Title
+}
+
+// State returns the issue state (open/closed)
+func (t *Task) State() string {
+	if t.Issue == nil || t.Issue.State == nil {
+		return ""
+	}
+	return *t.Issue.State
+}
+
+// Assignee returns the assignee login name
+func (t *Task) Assignee() string {
+	if t.Issue == nil || t.Issue.Assignee == nil || t.Issue.Assignee.Login == nil {
+		return ""
+	}
+	return *t.Issue.Assignee.Login
+}
+
+// Assignees returns all assignee login names
+func (t *Task) Assignees() []string {
+	if t.Issue == nil {
+		return nil
+	}
+	names := make([]string, 0, len(t.Issue.Assignees))
+	for _, a := range t.Issue.Assignees {
+		if a.Login != nil {
+			names = append(names, *a.Login)
+		}
+	}
+	return names
+}
+
+// Labels returns the issue labels
+func (t *Task) Labels() []string {
+	if t.Issue == nil {
+		return nil
+	}
+	labels := make([]string, 0, len(t.Issue.Labels))
+	for _, l := range t.Issue.Labels {
+		if l.Name != nil {
+			labels = append(labels, *l.Name)
+		}
+	}
+	return labels
+}
+
+// IsPullRequest returns true if this issue is actually a PR
+func (t *Task) IsPullRequest() bool {
+	return t.Issue != nil && t.Issue.PullRequestLinks != nil
+}

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -1,0 +1,115 @@
+package task
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v60/github"
+)
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func TestNewTask(t *testing.T) {
+	now := time.Now()
+	fiveDaysAgo := now.Add(-5 * 24 * time.Hour)
+
+	issue := &github.Issue{
+		Number:    ptr(123),
+		Title:     ptr("Test Issue"),
+		State:     ptr("open"),
+		CreatedAt: &github.Timestamp{Time: fiveDaysAgo},
+		Assignee: &github.User{
+			Login: ptr("yuki"),
+		},
+		Assignees: []*github.User{
+			{Login: ptr("yuki")},
+			{Login: ptr("rin")},
+		},
+		Labels: []*github.Label{
+			{Name: ptr("bug")},
+			{Name: ptr("high-priority")},
+		},
+	}
+
+	task := NewTask(issue)
+
+	if task.Number() != 123 {
+		t.Errorf("Number() = %d, want 123", task.Number())
+	}
+
+	if task.Title() != "Test Issue" {
+		t.Errorf("Title() = %s, want Test Issue", task.Title())
+	}
+
+	if task.State() != "open" {
+		t.Errorf("State() = %s, want open", task.State())
+	}
+
+	if task.Assignee() != "yuki" {
+		t.Errorf("Assignee() = %s, want yuki", task.Assignee())
+	}
+
+	assignees := task.Assignees()
+	if len(assignees) != 2 {
+		t.Errorf("Assignees() len = %d, want 2", len(assignees))
+	}
+
+	labels := task.Labels()
+	if len(labels) != 2 {
+		t.Errorf("Labels() len = %d, want 2", len(labels))
+	}
+
+	// StaleDays should be approximately 5
+	if task.StaleDays < 4 || task.StaleDays > 6 {
+		t.Errorf("StaleDays = %d, want ~5", task.StaleDays)
+	}
+}
+
+func TestTask_NilValues(t *testing.T) {
+	task := NewTask(&github.Issue{})
+
+	if task.Number() != 0 {
+		t.Errorf("Number() = %d, want 0", task.Number())
+	}
+
+	if task.Title() != "" {
+		t.Errorf("Title() = %s, want empty", task.Title())
+	}
+
+	if task.Assignee() != "" {
+		t.Errorf("Assignee() = %s, want empty", task.Assignee())
+	}
+
+	if len(task.Assignees()) != 0 {
+		t.Errorf("Assignees() len = %d, want 0", len(task.Assignees()))
+	}
+
+	if len(task.Labels()) != 0 {
+		t.Errorf("Labels() len = %d, want 0", len(task.Labels()))
+	}
+}
+
+func TestTask_IsPullRequest(t *testing.T) {
+	// Regular issue
+	issue := &github.Issue{
+		Number: ptr(1),
+	}
+	task := NewTask(issue)
+	if task.IsPullRequest() {
+		t.Error("IsPullRequest() = true for regular issue")
+	}
+
+	// PR
+	pr := &github.Issue{
+		Number: ptr(2),
+		PullRequestLinks: &github.PullRequestLinks{
+			URL: ptr("https://api.github.com/repos/owner/repo/pulls/2"),
+		},
+	}
+	prTask := NewTask(pr)
+	if !prTask.IsPullRequest() {
+		t.Error("IsPullRequest() = false for PR")
+	}
+}


### PR DESCRIPTION
## Summary
- GitHub clientに `ListIssuesWithOptions` 追加（state/assignee/labelsでフィルタ可能）
- `internal/task` パッケージ新規作成
  - `Task` 構造体: Issue + 滞留日数（StaleDays）
  - `TaskService`: フィルタ、滞留検出などの操作

## Test plan
- [x] `go test ./internal/task/...` パス
- [x] `go test ./...` 全体パス

## For Rin
TUI側は `TaskService.List()` 呼べばOK。

```go
svc := task.NewService(ghClient)
tasks, _ := svc.List(ctx, task.ListOptions{State: "open"})
```

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)