### PR TITLE
feat: add PR event watcher

### DIFF
--- a/internal/github/watcher.go
+++ b/internal/github/watcher.go
@@ -1,0 +1,145 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-github/v60/github"
+)
+
+// PREvent represents a PR event (merge or close)
+type PREvent struct {
+	Number    int
+	Title     string
+	Author    string
+	Action    PRAction
+	MergedAt  *time.Time
+	ClosedAt  *time.Time
+	URL       string
+	MergedBy  string
+	CreatedAt time.Time
+}
+
+// PRAction represents the type of PR event
+type PRAction string
+
+const (
+	PRActionMerged PRAction = "merged"
+	PRActionClosed PRAction = "closed" // closed without merge (rejected/abandoned)
+)
+
+// Watcher monitors PR events
+type Watcher struct {
+	client    *Client
+	lastCheck time.Time
+}
+
+// NewWatcher creates a new PR event watcher
+func NewWatcher(client *Client) *Watcher {
+	return &Watcher{
+		client:    client,
+		lastCheck: time.Now().Add(-24 * time.Hour), // Default: check last 24 hours
+	}
+}
+
+// NewWatcherWithSince creates a watcher with custom start time
+func NewWatcherWithSince(client *Client, since time.Time) *Watcher {
+	return &Watcher{
+		client:    client,
+		lastCheck: since,
+	}
+}
+
+// CheckEvents fetches recent PR events since last check
+func (w *Watcher) CheckEvents(ctx context.Context) ([]PREvent, error) {
+	events, err := w.fetchPREvents(ctx, w.lastCheck)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update last check time
+	w.lastCheck = time.Now()
+
+	return events, nil
+}
+
+// CheckEventsSince fetches PR events since a specific time
+func (w *Watcher) CheckEventsSince(ctx context.Context, since time.Time) ([]PREvent, error) {
+	return w.fetchPREvents(ctx, since)
+}
+
+// fetchPREvents fetches merged and closed PRs since the given time
+func (w *Watcher) fetchPREvents(ctx context.Context, since time.Time) ([]PREvent, error) {
+	opts := &github.PullRequestListOptions{
+		State:     "closed",
+		Sort:      "updated",
+		Direction: "desc",
+		ListOptions: github.ListOptions{
+			PerPage: 30,
+		},
+	}
+
+	prs, _, err := w.client.client.PullRequests.List(ctx, w.client.owner, w.client.repo, opts)
+	if err != nil {
+		return nil, fmt.Errorf("list closed PRs: %w", err)
+	}
+
+	var events []PREvent
+	for _, pr := range prs {
+		// Skip PRs that were closed before our threshold
+		var eventTime time.Time
+		if pr.MergedAt != nil {
+			eventTime = pr.MergedAt.Time
+		} else if pr.ClosedAt != nil {
+			eventTime = pr.ClosedAt.Time
+		} else {
+			continue
+		}
+
+		if eventTime.Before(since) {
+			continue
+		}
+
+		event := PREvent{
+			Number:    pr.GetNumber(),
+			Title:     pr.GetTitle(),
+			Author:    pr.GetUser().GetLogin(),
+			URL:       pr.GetHTMLURL(),
+			CreatedAt: pr.GetCreatedAt().Time,
+		}
+
+		if pr.MergedAt != nil {
+			event.Action = PRActionMerged
+			mergedAt := pr.MergedAt.Time
+			event.MergedAt = &mergedAt
+			if pr.MergedBy != nil {
+				event.MergedBy = pr.MergedBy.GetLogin()
+			}
+		} else {
+			event.Action = PRActionClosed
+			closedAt := pr.ClosedAt.Time
+			event.ClosedAt = &closedAt
+		}
+
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+// FormatEvent formats a PREvent for display
+func FormatEvent(e PREvent) string {
+	switch e.Action {
+	case PRActionMerged:
+		mergedBy := e.MergedBy
+		if mergedBy == "" {
+			mergedBy = "unknown"
+		}
+		return fmt.Sprintf("🟢 PR #%d merged: %s (by %s)", e.Number, e.Title, mergedBy)
+	case PRActionClosed:
+		return fmt.Sprintf("🔴 PR #%d closed without merge: %s", e.Number, e.Title)
+	default:
+		return fmt.Sprintf("PR #%d: %s (%s)", e.Number, e.Title, e.Action)
+	}
+}

--- a/internal/github/watcher_test.go
+++ b/internal/github/watcher_test.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatEvent(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    PREvent
+		expected string
+	}{
+		{
+			name: "merged PR",
+			event: PREvent{
+				Number:   42,
+				Title:    "Add new feature",
+				Action:   PRActionMerged,
+				MergedBy: "ytnobody",
+			},
+			expected: "🟢 PR #42 merged: Add new feature (by ytnobody)",
+		},
+		{
+			name: "merged PR without merger info",
+			event: PREvent{
+				Number:   42,
+				Title:    "Add new feature",
+				Action:   PRActionMerged,
+				MergedBy: "",
+			},
+			expected: "🟢 PR #42 merged: Add new feature (by unknown)",
+		},
+		{
+			name: "closed PR",
+			event: PREvent{
+				Number: 43,
+				Title:  "Rejected feature",
+				Action: PRActionClosed,
+			},
+			expected: "🔴 PR #43 closed without merge: Rejected feature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatEvent(tt.event)
+			if result != tt.expected {
+				t.Errorf("FormatEvent() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewWatcher(t *testing.T) {
+	// Create a minimal client for testing
+	client := &Client{
+		owner: "test",
+		repo:  "repo",
+	}
+
+	watcher := NewWatcher(client)
+
+	if watcher.client != client {
+		t.Error("NewWatcher() client not set correctly")
+	}
+
+	// lastCheck should be approximately 24 hours ago
+	expectedStart := time.Now().Add(-25 * time.Hour)
+	expectedEnd := time.Now().Add(-23 * time.Hour)
+
+	if watcher.lastCheck.Before(expectedStart) || watcher.lastCheck.After(expectedEnd) {
+		t.Errorf("NewWatcher() lastCheck = %v, want between %v and %v",
+			watcher.lastCheck, expectedStart, expectedEnd)
+	}
+}
+
+func TestNewWatcherWithSince(t *testing.T) {
+	client := &Client{
+		owner: "test",
+		repo:  "repo",
+	}
+
+	customTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	watcher := NewWatcherWithSince(client, customTime)
+
+	if !watcher.lastCheck.Equal(customTime) {
+		t.Errorf("NewWatcherWithSince() lastCheck = %v, want %v",
+			watcher.lastCheck, customTime)
+	}
+}
+
+func TestPRAction(t *testing.T) {
+	if PRActionMerged != "merged" {
+		t.Errorf("PRActionMerged = %q, want %q", PRActionMerged, "merged")
+	}
+
+	if PRActionClosed != "closed" {
+		t.Errorf("PRActionClosed = %q, want %q", PRActionClosed, "closed")
+	}
+}

--- a/internal/github/webhook.go
+++ b/internal/github/webhook.go
@@ -22,11 +22,11 @@ type EventHandler func(payload json.RawMessage) error
 
 // Event types
 const (
-	EventIssues             = "issues"
-	EventIssueComment       = "issue_comment"
-	EventPullRequest        = "pull_request"
-	EventPullRequestReview  = "pull_request_review"
-	EventPush               = "push"
+	EventIssues            = "issues"
+	EventIssueComment      = "issue_comment"
+	EventPullRequest       = "pull_request"
+	EventPullRequestReview = "pull_request_review"
+	EventPush              = "push"
 )
 
 // IssuesEvent represents an issues event payload


### PR DESCRIPTION
## Summary
- PRのマージ/クローズ（差し戻し）イベントを検知するWatcher追加
- GitHub APIでclosed状態のPRを取得し、merge/closeを判別
- FormatEventでチャット通知用のフォーマット関数を提供

## Changes
- `internal/github/watcher.go`: Watcher本体
- `internal/github/watcher_test.go`: テスト4件
- `internal/github/webhook.go`: gofmt整形のみ

## Test plan
- [x] `go test ./internal/github/...` 通過
- [x] `go build ./...` 通過

## Next steps
TUIへの統合は別PRで実施予定（起動時チェック or /check-eventsコマンド）

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)