### PR TITLE
docs: update team roles and review flow terminology

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ MAXAMは複数のAIエージェントが協調して開発業務を遂行する�
 |------|------|
 | Mei Chen | 要件定義 + PM |
 | Yuki Tanaka | バックエンド + インフラ |
-| Rin Sato | フロントエンド |
+| Rin Sato | フロントエンド + バックエンド |
 | Shiori Tanaka | テスト + ドキュメント |
 | Priya Sharma | レビュー + セキュリティ + QA |
 | Amara Okonkwo | 分析 |
@@ -65,7 +65,7 @@ type: feat, fix, refactor, docs, test, chore
 ```
 @Yuki PR #XX レビューしました。
 - [MINOR] 変数名のtypo 1箇所
-- LGTM、上記修正後Approve予定
+- LGTM、上記修正後マージOK
 ```
 
 **なぜ両方か：**


### PR DESCRIPTION
## Summary
- Rinの役割に「バックエンド」を追加（Yukiの負荷分散のため）
- レビューフロー用語を「Approve予定」→「マージOK」に変更（GitHubアカウント制約への対応）

## Background
- バックエンド担当がYuki1人だとタスクが並行すると待ちが発生しやすい
- オーナーアカウントで作成したPRは同一アカウントでApproveできない制約がある
- 「Approve」という言葉にこだわらず、マージ可否の判断を明示する形に統一

## Changes
```diff
- | Rin Sato | フロントエンド |
+ | Rin Sato | フロントエンド + バックエンド |

- - LGTM、上記修正後Approve予定
+ - LGTM、上記修正後マージOK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)