### PR TITLE
feat: add file-based taskboard with CLI and TUI integration

### DIFF
--- a/cmd/maxam/main.go
+++ b/cmd/maxam/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	switch cmd {
 	case "task":
-		runTask()
+		runTaskLegacy()
 	case "review":
 		runReview()
 	case "ask":
@@ -54,6 +54,8 @@ Commands:
   (none)               Launch team chat TUI (default)
   chat <agent>         Interactive chat with an agent (mei/yuki/rin/shiori/priya/amara/team)
   task <description>   Submit a task to Yuki for implementation
+  task add <title>     Add a task to the taskboard
+  task list            List all tasks on the taskboard
   review <description> Run a full review cycle (Yuki → Priya)
   ask <agent> <prompt> Ask a specific agent a question
   analyze              Run Amara's weekly analysis
@@ -70,7 +72,9 @@ Agents:
 
 Examples:
   maxam                                           # Start team chat
-  maxam task "Add a login button to the header"
+  maxam task add "Implement user authentication"  # Add task to board
+  maxam task list                                 # List all tasks
+  maxam task "Add a login button to the header"  # Delegate to Yuki
   maxam review "Create unit tests for the auth module"
   maxam ask yuki "How would you implement caching here?"`)
 }
@@ -84,35 +88,6 @@ func getWorkDir() string {
 	return dir
 }
 
-func runTask() {
-	if len(os.Args) < 3 {
-		fmt.Fprintln(os.Stderr, "Usage: maxam task <description>")
-		os.Exit(1)
-	}
-
-	task := strings.Join(os.Args[2:], " ")
-	workDir := getWorkDir()
-
-	fmt.Println("MAXAM Task Runner")
-	fmt.Println("=================")
-	fmt.Printf("Task: %s\n\n", task)
-
-	agents := agent.NewAgents(workDir)
-	yuki := agents.Yuki()
-
-	ctx := context.Background()
-	fmt.Println("[Yuki] Working on it...")
-
-	result, err := yuki.Run(ctx, task)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
-
-	fmt.Println("\n[Yuki] Done.")
-	fmt.Println("\n--- Output ---")
-	fmt.Println(result)
-}
 
 func runReview() {
 	if len(os.Args) < 3 {

--- a/cmd/maxam/taskboard.go
+++ b/cmd/maxam/taskboard.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ytnobody/MAXAM/internal/agent"
+	"github.com/ytnobody/MAXAM/internal/taskboard"
+)
+
+// runTaskboard handles the "task" subcommand for task board operations
+func runTaskboard() {
+	if len(os.Args) < 3 {
+		printTaskboardUsage()
+		os.Exit(1)
+	}
+
+	subCmd := os.Args[2]
+
+	switch subCmd {
+	case "add":
+		runTaskAdd()
+	case "list":
+		runTaskList()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown task command: %s\n", subCmd)
+		printTaskboardUsage()
+		os.Exit(1)
+	}
+}
+
+func printTaskboardUsage() {
+	fmt.Println(`Usage: maxam task <command> [arguments]
+
+Commands:
+  add <title> [--assignee <name>] [--desc <description>]
+                         Add a new task to the taskboard
+  list                   List all tasks
+
+Examples:
+  maxam task add "Implement login feature"
+  maxam task add "Fix bug #42" --assignee yuki
+  maxam task add "Update docs" --desc "Add API documentation"
+  maxam task list`)
+}
+
+func runTaskAdd() {
+	if len(os.Args) < 4 {
+		fmt.Fprintln(os.Stderr, "Usage: maxam task add <title> [--assignee <name>] [--desc <description>]")
+		os.Exit(1)
+	}
+
+	title := os.Args[3]
+	assignee := ""
+	description := ""
+
+	// Parse optional flags
+	for i := 4; i < len(os.Args); i++ {
+		switch os.Args[i] {
+		case "--assignee", "-a":
+			if i+1 < len(os.Args) {
+				assignee = os.Args[i+1]
+				i++
+			}
+		case "--desc", "-d":
+			if i+1 < len(os.Args) {
+				description = os.Args[i+1]
+				i++
+			}
+		}
+	}
+
+	// Create file store
+	store, err := taskboard.NewFileStore("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing task store: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create task
+	task := &taskboard.Task{
+		Title:       title,
+		Assignee:    assignee,
+		Description: description,
+		Status:      taskboard.StatusPending,
+	}
+
+	created, err := store.Create(context.Background(), task)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating task: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Task #%d created: %s\n", created.ID, created.Title)
+	if assignee != "" {
+		fmt.Printf("  Assignee: %s\n", assignee)
+	}
+	fmt.Printf("  File: %s\n", store.FilePath())
+}
+
+func runTaskList() {
+	store, err := taskboard.NewFileStore("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing task store: %v\n", err)
+		os.Exit(1)
+	}
+
+	tasks, err := store.List(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing tasks: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(tasks) == 0 {
+		fmt.Println("No tasks found.")
+		fmt.Printf("  File: %s\n", store.FilePath())
+		return
+	}
+
+	fmt.Println("Tasks:")
+	for _, t := range tasks {
+		status := statusIcon(t.Status)
+		assignee := ""
+		if t.Assignee != "" {
+			assignee = fmt.Sprintf(" (@%s)", t.Assignee)
+		}
+		fmt.Printf("  %s #%d: %s%s\n", status, t.ID, t.Title, assignee)
+	}
+	fmt.Printf("\n  File: %s\n", store.FilePath())
+}
+
+func statusIcon(s taskboard.Status) string {
+	switch s {
+	case taskboard.StatusPending:
+		return "○"
+	case taskboard.StatusInProgress:
+		return "◐"
+	case taskboard.StatusCompleted:
+		return "●"
+	default:
+		return "?"
+	}
+}
+
+// runTask is the legacy task command (for implementation requests)
+func runTaskLegacy() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "Usage: maxam task <description>")
+		os.Exit(1)
+	}
+
+	// Check if it's a taskboard subcommand
+	subCmd := strings.ToLower(os.Args[2])
+	if subCmd == "add" || subCmd == "list" {
+		runTaskboard()
+		return
+	}
+
+	// Legacy behavior: treat as task description for Yuki
+	runTaskImpl()
+}
+
+// runTaskImpl is the original task implementation logic
+func runTaskImpl() {
+	task := strings.Join(os.Args[2:], " ")
+	workDir := getWorkDir()
+
+	fmt.Println("MAXAM Task Runner")
+	fmt.Println("=================")
+	fmt.Printf("Task: %s\n\n", task)
+
+	agents := agent.NewAgents(workDir)
+	yuki := agents.Yuki()
+
+	ctx := context.Background()
+	fmt.Println("[Yuki] Working on it...")
+
+	result, err := yuki.Run(ctx, task)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("\n[Yuki] Done.")
+	fmt.Println("\n--- Output ---")
+	fmt.Println(result)
+}

--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/fsnotify/fsnotify"
 
 	"github.com/ytnobody/MAXAM/internal/agent"
 	"github.com/ytnobody/MAXAM/internal/history"
@@ -110,7 +111,10 @@ type tuiModel struct {
 	// View switching
 	currentView viewMode
 	tasklist    tasklist.Model
-	taskService taskboard.Service
+	taskService *taskboard.FileStore
+
+	// File watcher
+	taskWatcher *fsnotify.Watcher
 }
 
 type agentResponseMsg struct {
@@ -154,9 +158,25 @@ func initialTuiModel(workDir string) tuiModel {
 		}
 	}
 
-	// Initialize taskboard service and tasklist
-	taskService := taskboard.NewMemoryStore()
-	tasklistModel := tasklist.New(taskService)
+	// Initialize taskboard service (file-based) and tasklist
+	taskService, err := taskboard.NewFileStore("")
+	if err != nil {
+		// Fallback: continue without file store
+		taskService = nil
+	}
+	var tasklistModel tasklist.Model
+	if taskService != nil {
+		tasklistModel = tasklist.New(taskService)
+	}
+
+	// Setup file watcher for task file
+	var taskWatcher *fsnotify.Watcher
+	if taskService != nil {
+		taskWatcher, _ = fsnotify.NewWatcher()
+		if taskWatcher != nil {
+			taskWatcher.Add(taskService.FilePath())
+		}
+	}
 
 	return tuiModel{
 		agents:           agent.NewAgents(workDir),
@@ -171,11 +191,40 @@ func initialTuiModel(workDir string) tuiModel {
 		currentView:      viewChat,
 		tasklist:         tasklistModel,
 		taskService:      taskService,
+		taskWatcher:      taskWatcher,
 	}
 }
 
+// taskFileChangedMsg is sent when the task file is modified externally
+type taskFileChangedMsg struct{}
+
 func (m tuiModel) Init() tea.Cmd {
-	return tea.Batch(textinput.Blink, tea.EnterAltScreen, m.tickAnalysis())
+	cmds := []tea.Cmd{textinput.Blink, tea.EnterAltScreen, m.tickAnalysis()}
+	if m.taskWatcher != nil {
+		cmds = append(cmds, m.watchTaskFile())
+	}
+	return tea.Batch(cmds...)
+}
+
+// watchTaskFile watches for changes to the task file
+func (m tuiModel) watchTaskFile() tea.Cmd {
+	return func() tea.Msg {
+		if m.taskWatcher == nil {
+			return nil
+		}
+		select {
+		case event, ok := <-m.taskWatcher.Events:
+			if !ok {
+				return nil
+			}
+			if event.Op&(fsnotify.Write|fsnotify.Create) != 0 {
+				return taskFileChangedMsg{}
+			}
+		case <-m.taskWatcher.Errors:
+			// Ignore errors
+		}
+		return nil
+	}
 }
 
 // tickAnalysis は1時間後に軽量分析をトリガーするtickを設定
@@ -193,6 +242,9 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
 			m.logMgr.Close()
+			if m.taskWatcher != nil {
+				m.taskWatcher.Close()
+			}
 			return m, tea.Quit
 
 		case tea.KeyTab:
@@ -223,6 +275,9 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			if input == "exit" || input == "quit" {
 				m.logMgr.Close()
+				if m.taskWatcher != nil {
+					m.taskWatcher.Close()
+				}
 				return m, tea.Quit
 			}
 
@@ -366,6 +421,18 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.textInput.Width = msg.Width - 8
 		m.updateViewport()
+
+	case taskFileChangedMsg:
+		// Task file was modified externally - reload and refresh
+		if m.taskService != nil {
+			m.taskService.Reload()
+			m.tasklist.Refresh()
+		}
+		// Continue watching
+		if m.taskWatcher != nil {
+			return m, m.watchTaskFile()
+		}
+		return m, nil
 
 	case analysisTickMsg:
 		// 1時間ごとの軽量分析トリガー

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/taskboard/file_store.go
+++ b/internal/taskboard/file_store.go
@@ -1,0 +1,209 @@
+package taskboard
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// FileStore is a file-based implementation of Service
+type FileStore struct {
+	mu       sync.RWMutex
+	filePath string
+	tasks    map[int]*Task
+	nextID   int
+}
+
+// fileData represents the JSON structure for persistence
+type fileData struct {
+	NextID int     `json:"next_id"`
+	Tasks  []*Task `json:"tasks"`
+}
+
+// DefaultTaskFilePath returns the default path for task storage
+func DefaultTaskFilePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "/tmp"
+	}
+	return filepath.Join(home, ".maxam", "tasks.json")
+}
+
+// NewFileStore creates a new file-based task store
+func NewFileStore(filePath string) (*FileStore, error) {
+	if filePath == "" {
+		filePath = DefaultTaskFilePath()
+	}
+
+	// Ensure directory exists
+	dir := filepath.Dir(filePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, err
+	}
+
+	fs := &FileStore{
+		filePath: filePath,
+		tasks:    make(map[int]*Task),
+		nextID:   1,
+	}
+
+	// Load existing data if file exists
+	if err := fs.load(); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	return fs, nil
+}
+
+// FilePath returns the path to the task file
+func (f *FileStore) FilePath() string {
+	return f.filePath
+}
+
+// load reads tasks from the file
+func (f *FileStore) load() error {
+	data, err := os.ReadFile(f.filePath)
+	if err != nil {
+		return err
+	}
+
+	var fd fileData
+	if err := json.Unmarshal(data, &fd); err != nil {
+		return err
+	}
+
+	f.tasks = make(map[int]*Task)
+	for _, t := range fd.Tasks {
+		f.tasks[t.ID] = t
+	}
+	f.nextID = fd.NextID
+
+	return nil
+}
+
+// save writes tasks to the file
+func (f *FileStore) save() error {
+	tasks := make([]*Task, 0, len(f.tasks))
+	for _, t := range f.tasks {
+		tasks = append(tasks, t)
+	}
+
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].ID < tasks[j].ID
+	})
+
+	fd := fileData{
+		NextID: f.nextID,
+		Tasks:  tasks,
+	}
+
+	data, err := json.MarshalIndent(fd, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(f.filePath, data, 0644)
+}
+
+// Reload reloads tasks from the file (for external changes)
+func (f *FileStore) Reload() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.load()
+}
+
+// List returns all tasks sorted by ID (ascending)
+func (f *FileStore) List(ctx context.Context) ([]*Task, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	tasks := make([]*Task, 0, len(f.tasks))
+	for _, t := range f.tasks {
+		tasks = append(tasks, copyTask(t))
+	}
+
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].ID < tasks[j].ID
+	})
+
+	return tasks, nil
+}
+
+// Get returns a task by ID
+func (f *FileStore) Get(ctx context.Context, id int) (*Task, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	t, ok := f.tasks[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	return copyTask(t), nil
+}
+
+// Create creates a new task
+func (f *FileStore) Create(ctx context.Context, task *Task) (*Task, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	now := time.Now()
+	newTask := &Task{
+		ID:          f.nextID,
+		Title:       task.Title,
+		Assignee:    task.Assignee,
+		Status:      task.Status,
+		Description: task.Description,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if newTask.Status == "" {
+		newTask.Status = StatusPending
+	}
+
+	f.tasks[f.nextID] = newTask
+	f.nextID++
+
+	if err := f.save(); err != nil {
+		return nil, err
+	}
+
+	return copyTask(newTask), nil
+}
+
+// Update updates an existing task
+func (f *FileStore) Update(ctx context.Context, task *Task) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	existing, ok := f.tasks[task.ID]
+	if !ok {
+		return ErrNotFound
+	}
+
+	existing.Title = task.Title
+	existing.Assignee = task.Assignee
+	existing.Status = task.Status
+	existing.Description = task.Description
+	existing.UpdatedAt = time.Now()
+
+	return f.save()
+}
+
+// Delete removes a task by ID
+func (f *FileStore) Delete(ctx context.Context, id int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if _, ok := f.tasks[id]; !ok {
+		return ErrNotFound
+	}
+
+	delete(f.tasks, id)
+	return f.save()
+}

--- a/internal/taskboard/file_store_test.go
+++ b/internal/taskboard/file_store_test.go
@@ -1,0 +1,219 @@
+package taskboard
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileStore_CreateAndList(t *testing.T) {
+	// Create temp file
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "tasks.json")
+
+	store, err := NewFileStore(filePath)
+	if err != nil {
+		t.Fatalf("NewFileStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Create tasks
+	task1, err := store.Create(ctx, &Task{Title: "Task 1", Assignee: "yuki"})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if task1.ID != 1 {
+		t.Errorf("Expected ID 1, got %d", task1.ID)
+	}
+	if task1.Status != StatusPending {
+		t.Errorf("Expected status pending, got %s", task1.Status)
+	}
+
+	task2, err := store.Create(ctx, &Task{Title: "Task 2", Status: StatusInProgress})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if task2.ID != 2 {
+		t.Errorf("Expected ID 2, got %d", task2.ID)
+	}
+
+	// List tasks
+	tasks, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("Expected 2 tasks, got %d", len(tasks))
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		t.Error("Task file was not created")
+	}
+}
+
+func TestFileStore_Get(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "tasks.json")
+
+	store, err := NewFileStore(filePath)
+	if err != nil {
+		t.Fatalf("NewFileStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Create a task
+	created, _ := store.Create(ctx, &Task{Title: "Test Task"})
+
+	// Get existing task
+	task, err := store.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if task.Title != "Test Task" {
+		t.Errorf("Expected 'Test Task', got %s", task.Title)
+	}
+
+	// Get non-existing task
+	_, err = store.Get(ctx, 999)
+	if err != ErrNotFound {
+		t.Errorf("Expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestFileStore_Update(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "tasks.json")
+
+	store, err := NewFileStore(filePath)
+	if err != nil {
+		t.Fatalf("NewFileStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Create a task
+	created, _ := store.Create(ctx, &Task{Title: "Original"})
+
+	// Update task
+	created.Title = "Updated"
+	created.Status = StatusCompleted
+	err = store.Update(ctx, created)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Verify update
+	task, _ := store.Get(ctx, created.ID)
+	if task.Title != "Updated" {
+		t.Errorf("Expected 'Updated', got %s", task.Title)
+	}
+	if task.Status != StatusCompleted {
+		t.Errorf("Expected completed, got %s", task.Status)
+	}
+}
+
+func TestFileStore_Delete(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "tasks.json")
+
+	store, err := NewFileStore(filePath)
+	if err != nil {
+		t.Fatalf("NewFileStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Create tasks
+	task1, _ := store.Create(ctx, &Task{Title: "Task 1"})
+	store.Create(ctx, &Task{Title: "Task 2"})
+
+	// Delete first task
+	err = store.Delete(ctx, task1.ID)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Verify deletion
+	tasks, _ := store.List(ctx)
+	if len(tasks) != 1 {
+		t.Errorf("Expected 1 task, got %d", len(tasks))
+	}
+
+	// Delete non-existing task
+	err = store.Delete(ctx, 999)
+	if err != ErrNotFound {
+		t.Errorf("Expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestFileStore_Persistence(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "tasks.json")
+
+	ctx := context.Background()
+
+	// Create store and add tasks
+	store1, _ := NewFileStore(filePath)
+	store1.Create(ctx, &Task{Title: "Persistent Task", Assignee: "mei"})
+
+	// Create new store instance (simulating restart)
+	store2, err := NewFileStore(filePath)
+	if err != nil {
+		t.Fatalf("NewFileStore failed: %v", err)
+	}
+
+	// Verify tasks are loaded
+	tasks, _ := store2.List(ctx)
+	if len(tasks) != 1 {
+		t.Errorf("Expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].Title != "Persistent Task" {
+		t.Errorf("Expected 'Persistent Task', got %s", tasks[0].Title)
+	}
+	if tasks[0].Assignee != "mei" {
+		t.Errorf("Expected 'mei', got %s", tasks[0].Assignee)
+	}
+}
+
+func TestFileStore_Reload(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "tasks.json")
+
+	ctx := context.Background()
+
+	// Create two store instances
+	store1, _ := NewFileStore(filePath)
+	store2, _ := NewFileStore(filePath)
+
+	// Add task via store1
+	store1.Create(ctx, &Task{Title: "New Task"})
+
+	// store2 doesn't see it yet
+	tasks, _ := store2.List(ctx)
+	if len(tasks) != 0 {
+		t.Errorf("Expected 0 tasks before reload, got %d", len(tasks))
+	}
+
+	// Reload store2
+	store2.Reload()
+
+	// Now store2 should see the task
+	tasks, _ = store2.List(ctx)
+	if len(tasks) != 1 {
+		t.Errorf("Expected 1 task after reload, got %d", len(tasks))
+	}
+}
+
+func TestFileStore_DefaultPath(t *testing.T) {
+	path := DefaultTaskFilePath()
+	if path == "" {
+		t.Error("DefaultTaskFilePath returned empty string")
+	}
+	if !filepath.IsAbs(path) {
+		t.Errorf("Expected absolute path, got %s", path)
+	}
+}


### PR DESCRIPTION
## Summary
- ファイルベースのタスク永続化（`~/.maxam/tasks.json`）
- CLIサブコマンド追加: `maxam task add/list`
- TUIでファイル監視→外部変更を自動リロード

エージェント（Meiなど）がCLI経由でタスク追加 → TUIに反映される。

## Test plan
- [ ] `go test ./...` 全テスト通過
- [ ] `maxam task add "テスト"` でタスク追加確認
- [ ] `maxam task list` でリスト表示確認
- [ ] TUI起動中に別ターミナルから `maxam task add` → TUI側に反映確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>