### PR TITLE
feat: タスクボード切り替え時にtasks.jsonを再読み込み

### DIFF
--- a/internal/taskboard/service.go
+++ b/internal/taskboard/service.go
@@ -19,3 +19,8 @@ type Service interface {
 	// Delete removes a task by ID
 	Delete(ctx context.Context, id int) error
 }
+
+// Reloader is an optional interface for services that support reloading from external source
+type Reloader interface {
+	Reload() error
+}

--- a/internal/tui/tasklist/model.go
+++ b/internal/tui/tasklist/model.go
@@ -167,7 +167,12 @@ func (m *Model) refreshTasks() {
 }
 
 // Refresh reloads tasks from the service (public method).
+// If the service supports Reloader interface, it reloads from file first.
 func (m *Model) Refresh() {
+	// Try to reload from file if service supports it
+	if reloader, ok := m.service.(taskboard.Reloader); ok {
+		reloader.Reload()
+	}
 	m.refreshTasks()
 }
 


### PR DESCRIPTION
## Summary
- タブでタスクボードに切り替えたときに`tasks.json`を再読み込みするようにした
- `Reloader`インターフェースを追加し、サービスが対応していれば自動でリロード
- 外部からtasks.jsonを変更しても、再起動なしで反映される

## Test plan
- [x] `go test ./...` 全テストパス
- [x] `go build ./...` ビルド成功
- [ ] 手動確認: MAXAMを起動し、別プロセスでtasks.jsonを編集後、Tabでタスクボードを開くと反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)