### PR TITLE
feat: メンション漏れ検出機能の追加

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ytnobody/MAXAM/internal/agent"
 	"github.com/ytnobody/MAXAM/internal/history"
 	"github.com/ytnobody/MAXAM/internal/logger"
+	"github.com/ytnobody/MAXAM/internal/mention"
 	"github.com/ytnobody/MAXAM/internal/taskboard"
 	"github.com/ytnobody/MAXAM/internal/tui/tasklist"
 )
@@ -71,6 +72,11 @@ var (
 	helpStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("241"))
 
+	// Warning style for mention leak detection
+	warningStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FFD700")).
+			Bold(true)
+
 	statusStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("241")).
 			Background(lipgloss.Color("236")).
@@ -115,6 +121,9 @@ type tuiModel struct {
 
 	// File watcher
 	taskWatcher *fsnotify.Watcher
+
+	// Mention leak warning
+	mentionWarning string
 }
 
 type agentResponseMsg struct {
@@ -506,6 +515,17 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.textInput, tiCmd = m.textInput.Update(msg)
 	cmds = append(cmds, tiCmd)
 
+	// Check for mention leaks in real-time as user types
+	if m.currentView == viewChat {
+		input := m.textInput.Value()
+		result := mention.Check(input)
+		if result.NeedsWarning {
+			m.mentionWarning = mention.FormatWarning()
+		} else {
+			m.mentionWarning = ""
+		}
+	}
+
 	// Update viewport
 	var vpCmd tea.Cmd
 	m.viewport, vpCmd = m.viewport.Update(msg)
@@ -691,7 +711,13 @@ func (m tuiModel) View() string {
 		}
 
 		inputLine := "You: " + m.textInput.View()
-		footer = status + "\n" + inputLine
+
+		// Add mention warning if needed
+		if m.mentionWarning != "" {
+			footer = status + "\n" + warningStyle.Render("⚠️ "+m.mentionWarning) + "\n" + inputLine
+		} else {
+			footer = status + "\n" + inputLine
+		}
 	} else {
 		footer = statusStyle.Render(" Tab:チャットに戻る ")
 	}

--- a/internal/mention/checker.go
+++ b/internal/mention/checker.go
@@ -1,0 +1,71 @@
+// Package mention provides mention leak detection for team chat messages.
+package mention
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Result represents the result of a mention check
+type Result struct {
+	HasRequestPattern bool     // 依頼パターンが検出されたか
+	HasMention        bool     // メンションが含まれているか
+	NeedsWarning      bool     // 警告が必要か
+	Patterns          []string // 検出された依頼パターン
+}
+
+// 依頼パターンの正規表現
+var requestPatterns = []*regexp.Regexp{
+	// 「〜お願い」系
+	regexp.MustCompile(`お願い(します|しま|)|おねがい`),
+	// 「〜して」系
+	regexp.MustCompile(`(確認|チェック|レビュー|実装|修正|追加|削除|更新|作成|調査|分析|対応|検討|共有|報告|連絡|送信)して`),
+	// 「〜してください」系
+	regexp.MustCompile(`して(ください|くれ|ほしい|もらえ)`),
+	// 「〜やって」系
+	regexp.MustCompile(`やって(ください|くれ|ほしい|もらえ|)`),
+	// 「〜頼む」系
+	regexp.MustCompile(`頼(む|みます|んだ)`),
+	// 「〜できる？」系（依頼っぽい疑問）
+	regexp.MustCompile(`(できる|やれる|可能)[?？]`),
+	// 「〜よろしく」系
+	regexp.MustCompile(`よろしく(お願い|ね|)`),
+}
+
+// メンションパターン
+var mentionPattern = regexp.MustCompile(`@(yuki|priya|amara|mei|rin|shiori|Yuki|Priya|Amara|Mei|Rin|Shiori)`)
+
+// Check analyzes a message for mention leaks
+// Returns a Result indicating if the message needs a warning
+func Check(message string) Result {
+	result := Result{
+		Patterns: make([]string, 0),
+	}
+
+	// メンションの検出
+	result.HasMention = mentionPattern.MatchString(message)
+
+	// 依頼パターンの検出
+	lower := strings.ToLower(message)
+	for _, pattern := range requestPatterns {
+		if pattern.MatchString(lower) || pattern.MatchString(message) {
+			result.HasRequestPattern = true
+			// マッチしたパターンを記録（デバッグ用）
+			matches := pattern.FindAllString(message, -1)
+			if len(matches) == 0 {
+				matches = pattern.FindAllString(lower, -1)
+			}
+			result.Patterns = append(result.Patterns, matches...)
+		}
+	}
+
+	// 依頼パターンがあるのにメンションがない場合は警告
+	result.NeedsWarning = result.HasRequestPattern && !result.HasMention
+
+	return result
+}
+
+// FormatWarning returns a warning message for display
+func FormatWarning() string {
+	return "宛先が不明確かも（@名前 で指定してね）"
+}

--- a/internal/mention/checker_test.go
+++ b/internal/mention/checker_test.go
@@ -1,0 +1,179 @@
+package mention
+
+import (
+	"testing"
+)
+
+func TestCheck(t *testing.T) {
+	tests := []struct {
+		name         string
+		message      string
+		wantWarning  bool
+		wantRequest  bool
+		wantMention  bool
+	}{
+		// 警告が必要なケース（依頼あり、メンションなし）
+		{
+			name:        "request without mention - onegai",
+			message:     "これお願い",
+			wantWarning: true,
+			wantRequest: true,
+			wantMention: false,
+		},
+		{
+			name:        "request without mention - shite",
+			message:     "確認して",
+			wantWarning: true,
+			wantRequest: true,
+			wantMention: false,
+		},
+		{
+			name:        "request without mention - review",
+			message:     "レビューしてください",
+			wantWarning: true,
+			wantRequest: true,
+			wantMention: false,
+		},
+		{
+			name:        "request without mention - yoroshiku",
+			message:     "よろしくお願いします",
+			wantWarning: true,
+			wantRequest: true,
+			wantMention: false,
+		},
+		{
+			name:        "request without mention - tanomu",
+			message:     "実装頼む",
+			wantWarning: true,
+			wantRequest: true,
+			wantMention: false,
+		},
+		{
+			name:        "request without mention - dekiru",
+			message:     "これできる?",
+			wantWarning: true,
+			wantRequest: true,
+			wantMention: false,
+		},
+
+		// 警告不要なケース（依頼あり、メンションあり）
+		{
+			name:        "request with mention yuki",
+			message:     "@yuki これお願い",
+			wantWarning: false,
+			wantRequest: true,
+			wantMention: true,
+		},
+		{
+			name:        "request with mention priya",
+			message:     "@priya レビューして",
+			wantWarning: false,
+			wantRequest: true,
+			wantMention: true,
+		},
+		{
+			name:        "request with mention amara",
+			message:     "@amara 分析してほしい",
+			wantWarning: false,
+			wantRequest: true,
+			wantMention: true,
+		},
+		{
+			name:        "request with mention mei",
+			message:     "@mei 確認お願いします",
+			wantWarning: false,
+			wantRequest: true,
+			wantMention: true,
+		},
+		{
+			name:        "request with mention rin",
+			message:     "@rin UI作成して",
+			wantWarning: false,
+			wantRequest: true,
+			wantMention: true,
+		},
+		{
+			name:        "request with mention shiori",
+			message:     "@shiori テストお願い",
+			wantWarning: false,
+			wantRequest: true,
+			wantMention: true,
+		},
+
+		// 警告不要なケース（依頼なし）
+		{
+			name:        "no request pattern",
+			message:     "これはただのコメントです",
+			wantWarning: false,
+			wantRequest: false,
+			wantMention: false,
+		},
+		{
+			name:        "question without request",
+			message:     "どう思う？",
+			wantWarning: false,
+			wantRequest: false,
+			wantMention: false,
+		},
+		{
+			name:        "statement",
+			message:     "実装完了しました",
+			wantWarning: false,
+			wantRequest: false,
+			wantMention: false,
+		},
+		{
+			name:        "mention without request",
+			message:     "@yuki 完了したよ",
+			wantWarning: false,
+			wantRequest: false,
+			wantMention: true,
+		},
+
+		// エッジケース
+		{
+			name:        "empty message",
+			message:     "",
+			wantWarning: false,
+			wantRequest: false,
+			wantMention: false,
+		},
+		{
+			name:        "multiple mentions with request",
+			message:     "@yuki @priya これ確認してください",
+			wantWarning: false,
+			wantRequest: true,
+			wantMention: true,
+		},
+		{
+			name:        "uppercase mention",
+			message:     "@Yuki お願い",
+			wantWarning: false,
+			wantRequest: true,
+			wantMention: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Check(tt.message)
+
+			if result.NeedsWarning != tt.wantWarning {
+				t.Errorf("Check(%q).NeedsWarning = %v, want %v", tt.message, result.NeedsWarning, tt.wantWarning)
+			}
+			if result.HasRequestPattern != tt.wantRequest {
+				t.Errorf("Check(%q).HasRequestPattern = %v, want %v", tt.message, result.HasRequestPattern, tt.wantRequest)
+			}
+			if result.HasMention != tt.wantMention {
+				t.Errorf("Check(%q).HasMention = %v, want %v", tt.message, result.HasMention, tt.wantMention)
+			}
+		})
+	}
+}
+
+func TestFormatWarning(t *testing.T) {
+	warning := FormatWarning()
+	if warning == "" {
+		t.Error("FormatWarning() returned empty string")
+	}
+}


### PR DESCRIPTION
## Summary
- 依頼パターン（「〜お願い」「〜して」「〜確認」等）を正規表現で検出
- `@名前` メンションがない場合、入力欄上に警告を表示
- Claude API呼び出しなし、トークンコストゼロでローカル完結

## 変更内容
- `internal/mention/checker.go` - 検出ロジック（テスト可能な形で分離）
- `internal/mention/checker_test.go` - テスト19ケース
- `cmd/maxam/tui.go` - リアルタイム警告表示の統合

## Test plan
- [x] `go test ./internal/mention/...` - 19ケース全パス
- [x] `go build ./cmd/maxam` - ビルド成功
- [ ] TUIで依頼系メッセージ入力時に警告表示を確認
- [ ] `@名前` を含めると警告が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)