### PR TITLE
chore: add tasks.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ logs/*/*.md
 
 # Local settings
 .claude/settings.local.json
+
+# Task data (stored in ~/.maxam/)
+tasks.json


### PR DESCRIPTION
## Summary
- `tasks.json` を `.gitignore` に追加

## 背景
- タスクデータは `~/.maxam/tasks.json` に保存される実装が既に完了している
- プロジェクト直下に作成された `tasks.json` の誤コミットを防ぐ

## 変更内容
- `.gitignore` に `tasks.json` を追加（1行）

## テスト
- `go test ./internal/taskboard/...` → PASS (7ケース)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)