### PR TITLE
feat: PRマージ後にworktreeを自動削除

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -15,11 +15,13 @@ import (
 	"github.com/fsnotify/fsnotify"
 
 	"github.com/ytnobody/MAXAM/internal/agent"
+	gh "github.com/ytnobody/MAXAM/internal/github"
 	"github.com/ytnobody/MAXAM/internal/history"
 	"github.com/ytnobody/MAXAM/internal/logger"
 	"github.com/ytnobody/MAXAM/internal/mention"
 	"github.com/ytnobody/MAXAM/internal/taskboard"
 	"github.com/ytnobody/MAXAM/internal/tui/tasklist"
+	"github.com/ytnobody/MAXAM/internal/worktree"
 )
 
 // Theme colors for each agent
@@ -124,6 +126,9 @@ type tuiModel struct {
 
 	// Mention leak warning
 	mentionWarning string
+
+	// PR watcher for worktree cleanup
+	prWatcher *gh.Watcher
 }
 
 type agentResponseMsg struct {
@@ -187,6 +192,12 @@ func initialTuiModel(workDir string) tuiModel {
 		}
 	}
 
+	// Setup PR watcher for worktree cleanup (silently fail if no GitHub access)
+	var prWatcher *gh.Watcher
+	if ghClient, err := gh.NewClient("ytnobody", "MAXAM"); err == nil {
+		prWatcher = gh.NewWatcher(ghClient)
+	}
+
 	return tuiModel{
 		agents:           agent.NewAgents(workDir),
 		logMgr:           logger.NewManager(logger.GetDefaultLogDir(), workDir),
@@ -201,18 +212,37 @@ func initialTuiModel(workDir string) tuiModel {
 		tasklist:         tasklistModel,
 		taskService:      taskService,
 		taskWatcher:      taskWatcher,
+		prWatcher:        prWatcher,
 	}
 }
 
 // taskFileChangedMsg is sent when the task file is modified externally
 type taskFileChangedMsg struct{}
 
+// prCheckTickMsg is sent periodically to check for merged PRs
+type prCheckTickMsg struct{}
+
+// prMergedMsg is sent when PRs are found to be merged
+type prMergedMsg struct {
+	branches []string
+}
+
 func (m tuiModel) Init() tea.Cmd {
 	cmds := []tea.Cmd{textinput.Blink, tea.EnterAltScreen, m.tickAnalysis()}
 	if m.taskWatcher != nil {
 		cmds = append(cmds, m.watchTaskFile())
 	}
+	if m.prWatcher != nil {
+		cmds = append(cmds, m.tickPRCheck())
+	}
 	return tea.Batch(cmds...)
+}
+
+// tickPRCheck returns a command that triggers PR check every 5 minutes
+func (m tuiModel) tickPRCheck() tea.Cmd {
+	return tea.Tick(5*time.Minute, func(t time.Time) tea.Msg {
+		return prCheckTickMsg{}
+	})
 }
 
 // watchTaskFile watches for changes to the task file
@@ -459,6 +489,23 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			)
 		}
 		return m, m.tickAnalysis()
+
+	case prCheckTickMsg:
+		// 5分ごとにPRマージをチェック
+		if m.prWatcher != nil {
+			return m, tea.Batch(
+				m.checkMergedPRs(),
+				m.tickPRCheck(),
+			)
+		}
+		return m, nil
+
+	case prMergedMsg:
+		// マージされたPRのブランチに対応するworktreeを削除（サイレント）
+		for _, branch := range msg.branches {
+			worktree.CleanupForBranch(m.workDir, branch)
+		}
+		return m, nil
 
 	case agentResponseMsg:
 		// エージェントの処理状態をクリア
@@ -983,6 +1030,36 @@ func getAgentStyle(name string) lipgloss.Style {
 		return shioriStyle
 	default:
 		return lipgloss.NewStyle()
+	}
+}
+
+// checkMergedPRs checks for recently merged PRs and returns their branches
+func (m *tuiModel) checkMergedPRs() tea.Cmd {
+	return func() tea.Msg {
+		if m.prWatcher == nil {
+			return nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		events, err := m.prWatcher.CheckEvents(ctx)
+		if err != nil {
+			return nil // silently ignore errors
+		}
+
+		var branches []string
+		for _, event := range events {
+			if event.Action == gh.PRActionMerged && event.HeadBranch != "" {
+				branches = append(branches, event.HeadBranch)
+			}
+		}
+
+		if len(branches) == 0 {
+			return nil
+		}
+
+		return prMergedMsg{branches: branches}
 	}
 }
 

--- a/internal/github/watcher.go
+++ b/internal/github/watcher.go
@@ -10,15 +10,16 @@ import (
 
 // PREvent represents a PR event (merge or close)
 type PREvent struct {
-	Number    int
-	Title     string
-	Author    string
-	Action    PRAction
-	MergedAt  *time.Time
-	ClosedAt  *time.Time
-	URL       string
-	MergedBy  string
-	CreatedAt time.Time
+	Number     int
+	Title      string
+	Author     string
+	Action     PRAction
+	MergedAt   *time.Time
+	ClosedAt   *time.Time
+	URL        string
+	MergedBy   string
+	CreatedAt  time.Time
+	HeadBranch string // source branch name (e.g., "feature/xxx")
 }
 
 // PRAction represents the type of PR event
@@ -102,11 +103,12 @@ func (w *Watcher) fetchPREvents(ctx context.Context, since time.Time) ([]PREvent
 		}
 
 		event := PREvent{
-			Number:    pr.GetNumber(),
-			Title:     pr.GetTitle(),
-			Author:    pr.GetUser().GetLogin(),
-			URL:       pr.GetHTMLURL(),
-			CreatedAt: pr.GetCreatedAt().Time,
+			Number:     pr.GetNumber(),
+			Title:      pr.GetTitle(),
+			Author:     pr.GetUser().GetLogin(),
+			URL:        pr.GetHTMLURL(),
+			CreatedAt:  pr.GetCreatedAt().Time,
+			HeadBranch: pr.GetHead().GetRef(),
 		}
 
 		if pr.MergedAt != nil {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -1,0 +1,116 @@
+package worktree
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const basePath = "/tmp/maxam"
+
+var agentNames = []string{"mei", "yuki", "rin", "shiori", "priya", "amara"}
+
+// CleanupForBranch removes all worktrees associated with the given branch
+// Silently ignores errors (best-effort cleanup)
+func CleanupForBranch(repoPath, branchName string) {
+	for _, agent := range agentNames {
+		worktrees := findWorktreesForAgent(agent, branchName)
+		for _, wt := range worktrees {
+			removeWorktree(repoPath, wt)
+		}
+	}
+}
+
+// findWorktreesForAgent finds worktrees for an agent that match the branch
+func findWorktreesForAgent(agent, branchName string) []string {
+	var result []string
+	agentDir := filepath.Join(basePath, agent)
+
+	entries, err := os.ReadDir(agentDir)
+	if err != nil {
+		return result
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		wtPath := filepath.Join(agentDir, entry.Name())
+		branch := getWorktreeBranch(wtPath)
+		if branch == branchName {
+			result = append(result, wtPath)
+		}
+	}
+
+	return result
+}
+
+// getWorktreeBranch returns the branch name of a worktree
+func getWorktreeBranch(wtPath string) string {
+	gitPath := filepath.Join(wtPath, ".git")
+	content, err := os.ReadFile(gitPath)
+	if err != nil {
+		return ""
+	}
+
+	// .git file contains: gitdir: /path/to/repo/.git/worktrees/name
+	gitdir := strings.TrimPrefix(strings.TrimSpace(string(content)), "gitdir: ")
+	headPath := filepath.Join(gitdir, "HEAD")
+	headContent, err := os.ReadFile(headPath)
+	if err != nil {
+		return ""
+	}
+
+	head := strings.TrimSpace(string(headContent))
+	// HEAD is either a commit hash or ref: refs/heads/branch-name
+	if branch, found := strings.CutPrefix(head, "ref: refs/heads/"); found {
+		return branch
+	}
+
+	return "" // detached HEAD
+}
+
+// removeWorktree removes a worktree silently
+func removeWorktree(repoPath, wtPath string) {
+	// First try git worktree remove
+	cmd := exec.Command("git", "worktree", "remove", "--force", wtPath)
+	cmd.Dir = repoPath
+	_ = cmd.Run()
+
+	// Also clean up the directory if it still exists
+	_ = os.RemoveAll(wtPath)
+
+	// Prune any stale worktree entries
+	pruneCmd := exec.Command("git", "worktree", "prune")
+	pruneCmd.Dir = repoPath
+	_ = pruneCmd.Run()
+}
+
+// ListAll returns all worktrees under /tmp/maxam
+func ListAll() map[string][]string {
+	result := make(map[string][]string)
+
+	for _, agent := range agentNames {
+		agentDir := filepath.Join(basePath, agent)
+		entries, err := os.ReadDir(agentDir)
+		if err != nil {
+			continue
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				wtPath := filepath.Join(agentDir, entry.Name())
+				branch := getWorktreeBranch(wtPath)
+				if branch == "" {
+					branch = "(detached)"
+				}
+				result[agent] = append(result[agent], fmt.Sprintf("%s [%s]", entry.Name(), branch))
+			}
+		}
+	}
+
+	return result
+}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1,0 +1,82 @@
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetWorktreeBranch(t *testing.T) {
+	// Create a temporary directory structure simulating a worktree
+	tmpDir := t.TempDir()
+	wtPath := filepath.Join(tmpDir, "test-worktree")
+	os.MkdirAll(wtPath, 0755)
+
+	// Create .git file pointing to worktree gitdir
+	gitDir := filepath.Join(tmpDir, ".git", "worktrees", "test-worktree")
+	os.MkdirAll(gitDir, 0755)
+
+	gitFile := filepath.Join(wtPath, ".git")
+	os.WriteFile(gitFile, []byte("gitdir: "+gitDir), 0644)
+
+	t.Run("branch ref", func(t *testing.T) {
+		headFile := filepath.Join(gitDir, "HEAD")
+		os.WriteFile(headFile, []byte("ref: refs/heads/feature/test-branch\n"), 0644)
+
+		branch := getWorktreeBranch(wtPath)
+		if branch != "feature/test-branch" {
+			t.Errorf("expected 'feature/test-branch', got '%s'", branch)
+		}
+	})
+
+	t.Run("detached HEAD", func(t *testing.T) {
+		headFile := filepath.Join(gitDir, "HEAD")
+		os.WriteFile(headFile, []byte("abc123def456\n"), 0644)
+
+		branch := getWorktreeBranch(wtPath)
+		if branch != "" {
+			t.Errorf("expected empty string for detached HEAD, got '%s'", branch)
+		}
+	})
+
+	t.Run("no .git file", func(t *testing.T) {
+		nonExistentPath := filepath.Join(tmpDir, "non-existent")
+		branch := getWorktreeBranch(nonExistentPath)
+		if branch != "" {
+			t.Errorf("expected empty string for non-existent path, got '%s'", branch)
+		}
+	})
+}
+
+func TestFindWorktreesForAgent(t *testing.T) {
+	// This test requires /tmp/maxam structure
+	// Skip if running in CI without the structure
+	agentDir := filepath.Join(basePath, "yuki")
+	if _, err := os.Stat(agentDir); os.IsNotExist(err) {
+		t.Skip("skipping: /tmp/maxam/yuki does not exist")
+	}
+
+	// Just verify it doesn't panic
+	result := findWorktreesForAgent("yuki", "non-existent-branch-12345")
+	if len(result) != 0 {
+		t.Logf("found %d worktrees for non-existent branch (expected 0)", len(result))
+	}
+}
+
+func TestListAll(t *testing.T) {
+	// Just verify it doesn't panic
+	result := ListAll()
+	t.Logf("found worktrees for %d agents", len(result))
+}
+
+func TestCleanupForBranch(t *testing.T) {
+	// Create a temporary test setup
+	tmpDir := t.TempDir()
+
+	// Create a fake git repo
+	repoDir := filepath.Join(tmpDir, "repo")
+	os.MkdirAll(filepath.Join(repoDir, ".git"), 0755)
+
+	// CleanupForBranch should not panic even with invalid paths
+	CleanupForBranch(repoDir, "non-existent-branch")
+}


### PR DESCRIPTION
## Summary
- PRがマージされた際、該当ブランチのworktreeを自動削除
- 5分ごとにGitHub APIでマージ済みPRをチェック
- サイレント実行（ログ出力なし、確認なし）

## 変更内容
1. `internal/worktree/` - worktree管理パッケージ新規作成
   - `CleanupForBranch()`: 指定ブランチのworktreeを全エージェント分削除
   - `ListAll()`: 全worktree一覧取得（デバッグ用）
2. `internal/github/watcher.go` - PREventにHeadBranch追加
3. `cmd/maxam/tui.go` - 5分ごとのPRチェックとworktree削除を追加

## Test plan
- [x] `go test ./...` 全パス
- [x] `go build ./...` 成功
- [ ] TUI起動してPRマージ後にworktreeが削除されることを確認

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)