### PR TITLE
feat: add cross-compile and packaging targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
-.PHONY: build test lint clean run
+.PHONY: build test lint clean run dist dist-all
 
 # Variables
 BINARY_NAME := maxam
 BINARY_DIR := bin
+DIST_DIR := dist
 CMD_DIR := ./cmd/maxam
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+
+# Target platforms
+PLATFORMS := linux/amd64 darwin/amd64 darwin/arm64 windows/amd64
 
 # Build the binary
 build:
@@ -19,8 +24,33 @@ lint:
 
 # Clean build artifacts
 clean:
-	rm -rf $(BINARY_DIR)
+	rm -rf $(BINARY_DIR) $(DIST_DIR)
 
 # Build and run
 run: build
 	./$(BINARY_DIR)/$(BINARY_NAME)
+
+# Cross-compile for a single platform
+# Usage: make dist GOOS=linux GOARCH=amd64
+dist:
+	@if [ -z "$(GOOS)" ] || [ -z "$(GOARCH)" ]; then \
+		echo "Usage: make dist GOOS=<os> GOARCH=<arch>"; \
+		exit 1; \
+	fi
+	$(eval EXT := $(if $(filter windows,$(GOOS)),.exe,))
+	$(eval PKG_NAME := $(BINARY_NAME)-$(VERSION)-$(GOOS)-$(GOARCH))
+	@echo "Building $(PKG_NAME)..."
+	@mkdir -p $(DIST_DIR)/$(PKG_NAME)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags="-s -w" -o $(DIST_DIR)/$(PKG_NAME)/$(BINARY_NAME)$(EXT) $(CMD_DIR)
+	@cp CLAUDE.md $(DIST_DIR)/$(PKG_NAME)/
+	@cp -r agents $(DIST_DIR)/$(PKG_NAME)/
+	@cd $(DIST_DIR) && zip -r $(PKG_NAME).zip $(PKG_NAME)
+	@rm -rf $(DIST_DIR)/$(PKG_NAME)
+	@echo "Created $(DIST_DIR)/$(PKG_NAME).zip"
+
+# Build for all platforms
+dist-all:
+	@for platform in $(PLATFORMS); do \
+		GOOS=$${platform%/*} GOARCH=$${platform#*/} $(MAKE) dist; \
+	done
+	@echo "All packages created in $(DIST_DIR)/"


### PR DESCRIPTION
## Summary
- `make dist GOOS=linux GOARCH=amd64` で単一プラットフォーム向けzipパッケージ作成
- `make dist-all` で4プラットフォーム一括ビルド
- パッケージにはバイナリ + CLAUDE.md + agents/ を含む

## 対象プラットフォーム
- Linux (amd64)
- macOS (amd64, arm64)
- Windows (amd64)

## Test plan
- [ ] `make dist GOOS=linux GOARCH=amd64` が動作する
- [ ] `make dist-all` で4つのzipが生成される
- [ ] 生成されたzipにバイナリとCLAUDE.md、agents/が含まれる

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)