### PR TITLE
feat: ccusage連携でステータスバーにコスト表示

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 
 	"github.com/ytnobody/MAXAM/internal/agent"
+	"github.com/ytnobody/MAXAM/internal/ccusage"
 	gh "github.com/ytnobody/MAXAM/internal/github"
 	"github.com/ytnobody/MAXAM/internal/history"
 	"github.com/ytnobody/MAXAM/internal/logger"
@@ -135,6 +136,10 @@ type tuiModel struct {
 
 	// PR watcher for worktree cleanup
 	prWatcher *gh.Watcher
+
+	// ccusage integration
+	ccusageClient *ccusage.Client
+	todayCost     float64
 }
 
 type agentResponseMsg struct {
@@ -204,6 +209,9 @@ func initialTuiModel(workDir string) tuiModel {
 		prWatcher = gh.NewWatcher(ghClient)
 	}
 
+	// Setup ccusage client (silently disabled if not available)
+	ccClient := ccusage.NewClient()
+
 	return tuiModel{
 		agents:           agent.NewAgents(workDir),
 		logMgr:           logger.NewManager(logger.GetDefaultLogDir(), workDir),
@@ -219,6 +227,7 @@ func initialTuiModel(workDir string) tuiModel {
 		taskService:      taskService,
 		taskWatcher:      taskWatcher,
 		prWatcher:        prWatcher,
+		ccusageClient:    ccClient,
 	}
 }
 
@@ -233,6 +242,14 @@ type prMergedMsg struct {
 	branches []string
 }
 
+// ccusageUpdateMsg is sent when ccusage cost is updated
+type ccusageUpdateMsg struct {
+	cost float64
+}
+
+// ccusageTickMsg triggers periodic ccusage updates
+type ccusageTickMsg struct{}
+
 func (m tuiModel) Init() tea.Cmd {
 	cmds := []tea.Cmd{textinput.Blink, tea.EnterAltScreen, m.tickAnalysis()}
 	if m.taskWatcher != nil {
@@ -241,7 +258,33 @@ func (m tuiModel) Init() tea.Cmd {
 	if m.prWatcher != nil {
 		cmds = append(cmds, m.tickPRCheck())
 	}
+	if m.ccusageClient != nil {
+		cmds = append(cmds, m.fetchCcusage(), m.tickCcusage())
+	}
 	return tea.Batch(cmds...)
+}
+
+// tickCcusage returns a command that triggers ccusage update every 5 minutes
+func (m tuiModel) tickCcusage() tea.Cmd {
+	return tea.Tick(5*time.Minute, func(t time.Time) tea.Msg {
+		return ccusageTickMsg{}
+	})
+}
+
+// fetchCcusage fetches the current cost from ccusage
+func (m tuiModel) fetchCcusage() tea.Cmd {
+	return func() tea.Msg {
+		if m.ccusageClient == nil {
+			return nil
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		usage := m.ccusageClient.GetTodayUsage(ctx)
+		if !usage.Available {
+			return nil
+		}
+		return ccusageUpdateMsg{cost: usage.TodayCost}
+	}
 }
 
 // tickPRCheck returns a command that triggers PR check every 5 minutes
@@ -513,6 +556,20 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case ccusageTickMsg:
+		// 5分ごとにccusageを更新
+		if m.ccusageClient != nil {
+			return m, tea.Batch(
+				m.fetchCcusage(),
+				m.tickCcusage(),
+			)
+		}
+		return m, nil
+
+	case ccusageUpdateMsg:
+		m.todayCost = msg.cost
+		return m, nil
+
 	case agentResponseMsg:
 		// エージェントの処理状態をクリア
 		delete(m.processingAgents, msg.agent)
@@ -762,7 +819,12 @@ func (m tuiModel) View() string {
 			}
 			statusContent = statusStyle.Render(fmt.Sprintf(" %s 処理中... ", strings.Join(names, ", ")))
 		} else {
-			statusContent = statusStyle.Render(fmt.Sprintf(" 履歴:%d ↑↓:履歴 PgUp/Dn:スクロール ", len(m.inputHist)))
+			// Build status with optional cost display
+			statusText := fmt.Sprintf(" 履歴:%d ↑↓:履歴 PgUp/Dn:スクロール ", len(m.inputHist))
+			if m.ccusageClient != nil && m.todayCost > 0 {
+				statusText += fmt.Sprintf("| %s today ", ccusage.FormatCost(m.todayCost))
+			}
+			statusContent = statusStyle.Render(statusText)
 		}
 		// ステータス行全体に背景色を適用
 		statusLine := footerStyle.Width(m.width).Render(statusContent)

--- a/internal/ccusage/ccusage.go
+++ b/internal/ccusage/ccusage.go
@@ -1,0 +1,90 @@
+// Package ccusage provides integration with ccusage CLI tool for token usage tracking.
+package ccusage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// Usage represents the usage data from ccusage
+type Usage struct {
+	TodayCost float64 // Today's cost in USD
+	Available bool    // Whether ccusage is available
+}
+
+// DailyUsage represents a single day's usage from ccusage JSON output
+type DailyUsage struct {
+	Date      string  `json:"date"`
+	TotalCost float64 `json:"totalCost"`
+}
+
+// ccusageOutput represents the full JSON output from ccusage
+type ccusageOutput struct {
+	Daily []DailyUsage `json:"daily"`
+}
+
+// Client provides methods to interact with ccusage CLI
+type Client struct {
+	timeout time.Duration
+}
+
+// NewClient creates a new ccusage client
+func NewClient() *Client {
+	return &Client{
+		timeout: 10 * time.Second,
+	}
+}
+
+// GetTodayUsage retrieves today's usage from ccusage
+// Returns empty Usage with Available=false if ccusage is not installed or fails
+func (c *Client) GetTodayUsage(ctx context.Context) Usage {
+	// Check if npx is available
+	if _, err := exec.LookPath("npx"); err != nil {
+		return Usage{Available: false}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	// Get today's date in YYYYMMDD format
+	today := time.Now().Format("20060102")
+
+	// Run ccusage with JSON output, filtering to today only
+	cmd := exec.CommandContext(ctx, "npx", "ccusage", "daily", "--since", today, "--json")
+	output, err := cmd.Output()
+	if err != nil {
+		return Usage{Available: false}
+	}
+
+	// Parse JSON output
+	var result ccusageOutput
+	if err := json.Unmarshal(output, &result); err != nil {
+		return Usage{Available: false}
+	}
+
+	// Get today's cost from daily array
+	todayStr := time.Now().Format("2006-01-02")
+	var totalCost float64
+	for _, d := range result.Daily {
+		if d.Date == todayStr {
+			totalCost = d.TotalCost
+			break
+		}
+	}
+
+	return Usage{
+		TodayCost: totalCost,
+		Available: true,
+	}
+}
+
+// FormatCost formats the cost as a string for display
+func FormatCost(cost float64) string {
+	if cost < 0.01 {
+		return "$0.00"
+	}
+	return fmt.Sprintf("$%.2f", cost)
+}

--- a/internal/ccusage/ccusage_test.go
+++ b/internal/ccusage/ccusage_test.go
@@ -1,0 +1,53 @@
+package ccusage
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFormatCost(t *testing.T) {
+	tests := []struct {
+		cost     float64
+		expected string
+	}{
+		{0.0, "$0.00"},
+		{0.005, "$0.00"},
+		{0.01, "$0.01"},
+		{0.50, "$0.50"},
+		{1.0, "$1.00"},
+		{1.23, "$1.23"},
+		{12.34, "$12.34"},
+		{123.45, "$123.45"},
+	}
+
+	for _, tt := range tests {
+		result := FormatCost(tt.cost)
+		if result != tt.expected {
+			t.Errorf("FormatCost(%v) = %q, want %q", tt.cost, result, tt.expected)
+		}
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	client := NewClient()
+	if client == nil {
+		t.Error("NewClient() returned nil")
+	}
+	if client.timeout == 0 {
+		t.Error("Client timeout should not be zero")
+	}
+}
+
+func TestGetTodayUsage_NoNpx(t *testing.T) {
+	// This test checks behavior when ccusage is not available
+	// In CI or environments without npx, should return Available=false
+	client := NewClient()
+	ctx := context.Background()
+	usage := client.GetTodayUsage(ctx)
+
+	// We don't know if npx is installed, but the function should not panic
+	// If npx is not installed, Available should be false
+	// If npx is installed but ccusage fails, Available should be false
+	// The important thing is no panic and graceful degradation
+	_ = usage // Just ensure no panic
+}


### PR DESCRIPTION
## Summary
- TUIステータスバーに今日のClaude APIコストを表示
- ccusage未インストール時は静かに無効化（エラーなし）
- 5分間隔で自動更新

## 変更内容
- `internal/ccusage/` - ccusage CLI連携パッケージ
- `cmd/maxam/tui.go` - ステータスバーにコスト表示追加

## Test plan
- [x] `go test ./...` 全パス（17パッケージ）
- [x] `go build ./cmd/maxam` 成功
- [x] ccusageインストール環境でコスト表示確認

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)