### PR TITLE
feat: add agent router for intelligent message routing

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -16,10 +16,12 @@ import (
 
 	"github.com/ytnobody/MAXAM/internal/agent"
 	"github.com/ytnobody/MAXAM/internal/ccusage"
+	"github.com/ytnobody/MAXAM/internal/config"
 	gh "github.com/ytnobody/MAXAM/internal/github"
 	"github.com/ytnobody/MAXAM/internal/history"
 	"github.com/ytnobody/MAXAM/internal/logger"
 	"github.com/ytnobody/MAXAM/internal/mention"
+	"github.com/ytnobody/MAXAM/internal/router"
 	"github.com/ytnobody/MAXAM/internal/taskboard"
 	"github.com/ytnobody/MAXAM/internal/tui/tasklist"
 	"github.com/ytnobody/MAXAM/internal/worktree"
@@ -107,6 +109,7 @@ const (
 
 type tuiModel struct {
 	agents         *agent.Agents
+	router         *router.Router
 	logMgr         *logger.Manager
 	history        *history.History
 	workDir        string
@@ -212,8 +215,23 @@ func initialTuiModel(workDir string) tuiModel {
 	// Setup ccusage client (silently disabled if not available)
 	ccClient := ccusage.NewClient()
 
+	// Setup agent router
+	cfg, err := config.Load()
+	if err != nil {
+		cfg = config.DefaultConfig()
+	}
+	routerAgents := make([]router.AgentInfo, len(cfg.Agents))
+	for i, agentCfg := range cfg.Agents {
+		routerAgents[i] = router.AgentInfo{
+			Name: agentCfg.Name,
+			Role: agentCfg.Role,
+		}
+	}
+	agentRouter := router.New(routerAgents)
+
 	return tuiModel{
 		agents:           agent.NewAgents(workDir),
+		router:           agentRouter,
 		logMgr:           logger.NewManager(logger.GetDefaultLogDir(), workDir),
 		history:          hist,
 		workDir:          workDir,
@@ -852,12 +870,13 @@ func (m tuiModel) View() string {
 }
 
 // detectAgents は入力から対象エージェントを複数検出（並列呼び出し用）
+// メンションがあればバイパス、なければルーターで判定
 func (m *tuiModel) detectAgents(text string) []string {
 	lower := strings.ToLower(text)
 	var agents []string
 	seen := make(map[string]bool)
 
-	// 明示的なメンションを優先的にチェック
+	// 明示的なメンションを優先的にチェック（ルーターをバイパス）
 	if strings.Contains(lower, "@yuki") || strings.Contains(lower, "ゆきちゃん") {
 		agents = append(agents, "yuki")
 		seen["yuki"] = true
@@ -883,24 +902,44 @@ func (m *tuiModel) detectAgents(text string) []string {
 		seen["shiori"] = true
 	}
 
-	// 明示的なメンションがなければキーワードで判定（1人だけ）
-	if len(agents) == 0 {
-		if strings.Contains(lower, "ゆき") || strings.Contains(lower, "実装") || strings.Contains(lower, "コード書") {
-			return []string{"yuki"}
+	// 明示的なメンションがあればそれを返す（ルーターをバイパス）
+	if len(agents) > 0 {
+		return agents
+	}
+
+	// メンションがなければルーターで判定
+	return m.routeMessage(text)
+}
+
+// routeMessage はルーターを使ってメッセージの宛先を決定
+func (m *tuiModel) routeMessage(text string) []string {
+	// 会話履歴をルーター用のフォーマットに変換（直近4メッセージ）
+	var history []router.Message
+	start := 0
+	if len(m.messages) > 4 {
+		start = len(m.messages) - 4
+	}
+	for i := start; i < len(m.messages); i++ {
+		msg := m.messages[i]
+		role := msg.role
+		if role == "user" {
+			role = "オーナー"
+		} else {
+			role = getTuiFullName(role)
 		}
-		if strings.Contains(lower, "プリヤ") || strings.Contains(lower, "レビュー") || strings.Contains(lower, "チェック") {
-			return []string{"priya"}
-		}
-		if strings.Contains(lower, "アマラ") || strings.Contains(lower, "分析") || strings.Contains(lower, "傾向") {
-			return []string{"amara"}
-		}
-		if strings.Contains(lower, "りん") || strings.Contains(lower, "フロントエンド") || strings.Contains(lower, "ui") {
-			return []string{"rin"}
-		}
-		if strings.Contains(lower, "しおり") || strings.Contains(lower, "テスト") || strings.Contains(lower, "ドキュメント") {
-			return []string{"shiori"}
-		}
-		// デフォルトはMei
+		history = append(history, router.Message{
+			Role:    role,
+			Content: msg.content,
+		})
+	}
+
+	// ルーターで判定
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	agents, err := m.router.Route(ctx, text, history)
+	if err != nil || len(agents) == 0 {
+		// フォールバック: Mei
 		return []string{"mei"}
 	}
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,0 +1,201 @@
+// Package router provides an agent router that determines which agent should respond
+package router
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Router routes messages to appropriate agents using LLM
+type Router struct {
+	agents []AgentInfo
+}
+
+// AgentInfo holds basic agent information for routing
+type AgentInfo struct {
+	Name string
+	Role string
+}
+
+// RouteResult contains the routing decision
+type RouteResult struct {
+	Agents []string `json:"agents"`
+}
+
+// New creates a new Router with agent information
+func New(agents []AgentInfo) *Router {
+	return &Router{
+		agents: agents,
+	}
+}
+
+// Message represents a chat message for context
+type Message struct {
+	Role    string
+	Content string
+}
+
+// Route determines which agents should respond to the message
+// It uses Claude Haiku for fast, cost-effective routing decisions
+func (r *Router) Route(ctx context.Context, message string, history []Message) ([]string, error) {
+	prompt := r.buildPrompt(message, history)
+
+	// Use haiku for cost-effective routing
+	args := []string{
+		"--print",
+		"--model", "haiku",
+		"--max-turns", "1",
+		prompt,
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, "claude", args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if runCtx.Err() == context.DeadlineExceeded {
+			return []string{"mei"}, nil // fallback to Mei on timeout
+		}
+		return []string{"mei"}, nil // fallback to Mei on error
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	agents := r.parseResult(result)
+
+	if len(agents) == 0 {
+		return []string{"mei"}, nil // fallback to Mei
+	}
+
+	return agents, nil
+}
+
+func (r *Router) buildPrompt(message string, history []Message) string {
+	var sb strings.Builder
+
+	sb.WriteString(`You are a message router. Determine which team member(s) should respond to the message.
+
+## Team Members
+`)
+
+	for _, agent := range r.agents {
+		sb.WriteString(fmt.Sprintf("- %s: %s\n", agent.Name, agent.Role))
+	}
+
+	sb.WriteString(`
+## Rules
+1. Return ONLY a JSON object with "agents" array containing the agent names (lowercase)
+2. Choose 1-3 most appropriate agents based on the message content
+3. Consider the conversation context to understand ongoing discussions
+4. If unsure, include "mei" as she handles general coordination
+
+## Examples
+- "実装お願い" → {"agents": ["yuki"]}
+- "レビューお願い" → {"agents": ["priya"]}
+- "YukiとPriyaに確認" → {"agents": ["yuki", "priya"]}
+- "こんにちは" → {"agents": ["mei"]}
+- "分析して" → {"agents": ["amara"]}
+- "UIを直して" → {"agents": ["rin"]}
+- "テスト書いて" → {"agents": ["shiori"]}
+
+`)
+
+	// Add recent conversation history (max 4 messages)
+	if len(history) > 0 {
+		sb.WriteString("## Recent Conversation\n")
+		start := 0
+		if len(history) > 4 {
+			start = len(history) - 4
+		}
+		for i := start; i < len(history); i++ {
+			msg := history[i]
+			sb.WriteString(fmt.Sprintf("%s: %s\n", msg.Role, truncate(msg.Content, 200)))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("## Current Message\n")
+	sb.WriteString(message)
+	sb.WriteString("\n\n## Your Response (JSON only)\n")
+
+	return sb.String()
+}
+
+func (r *Router) parseResult(result string) []string {
+	// Try to extract JSON from the result
+	// The LLM might include extra text, so look for JSON pattern
+
+	// First, try direct parse
+	var routeResult RouteResult
+	if err := json.Unmarshal([]byte(result), &routeResult); err == nil {
+		return r.validateAgents(routeResult.Agents)
+	}
+
+	// Try to find JSON in the response
+	start := strings.Index(result, "{")
+	end := strings.LastIndex(result, "}")
+	if start >= 0 && end > start {
+		jsonStr := result[start : end+1]
+		if err := json.Unmarshal([]byte(jsonStr), &routeResult); err == nil {
+			return r.validateAgents(routeResult.Agents)
+		}
+	}
+
+	// Fallback: look for agent names in the response
+	lower := strings.ToLower(result)
+	var agents []string
+	validNames := r.getValidNames()
+
+	for _, name := range validNames {
+		if strings.Contains(lower, name) {
+			agents = append(agents, name)
+		}
+	}
+
+	return agents
+}
+
+func (r *Router) validateAgents(agents []string) []string {
+	validNames := r.getValidNames()
+	validSet := make(map[string]bool)
+	for _, name := range validNames {
+		validSet[name] = true
+	}
+
+	var result []string
+	seen := make(map[string]bool)
+
+	for _, agent := range agents {
+		name := strings.ToLower(strings.TrimSpace(agent))
+		if validSet[name] && !seen[name] {
+			result = append(result, name)
+			seen[name] = true
+		}
+	}
+
+	return result
+}
+
+func (r *Router) getValidNames() []string {
+	names := make([]string, len(r.agents))
+	for i, agent := range r.agents {
+		names[i] = strings.ToLower(agent.Name)
+	}
+	return names
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,0 +1,192 @@
+package router
+
+import (
+	"testing"
+)
+
+func TestParseResult(t *testing.T) {
+	agents := []AgentInfo{
+		{Name: "mei", Role: "PM"},
+		{Name: "yuki", Role: "Backend"},
+		{Name: "priya", Role: "Review"},
+		{Name: "amara", Role: "Analysis"},
+		{Name: "rin", Role: "Frontend"},
+		{Name: "shiori", Role: "Test/Docs"},
+	}
+	r := New(agents)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "valid JSON",
+			input:    `{"agents": ["yuki"]}`,
+			expected: []string{"yuki"},
+		},
+		{
+			name:     "multiple agents",
+			input:    `{"agents": ["yuki", "priya"]}`,
+			expected: []string{"yuki", "priya"},
+		},
+		{
+			name:     "JSON with extra text",
+			input:    `Here is the result: {"agents": ["amara"]} That's all.`,
+			expected: []string{"amara"},
+		},
+		{
+			name:     "fallback to name detection",
+			input:    `I think Yuki should handle this.`,
+			expected: []string{"yuki"},
+		},
+		{
+			name:     "multiple names in text",
+			input:    `Both Yuki and Priya should review this.`,
+			expected: []string{"yuki", "priya"},
+		},
+		{
+			name:     "invalid agent name filtered",
+			input:    `{"agents": ["yuki", "unknown"]}`,
+			expected: []string{"yuki"},
+		},
+		{
+			name:     "empty result",
+			input:    `{}`,
+			expected: []string{},
+		},
+		{
+			name:     "rin and shiori",
+			input:    `{"agents": ["rin", "shiori"]}`,
+			expected: []string{"rin", "shiori"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := r.parseResult(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+				return
+			}
+			for i, agent := range result {
+				if agent != tt.expected[i] {
+					t.Errorf("expected %v, got %v", tt.expected, result)
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAgents(t *testing.T) {
+	agents := []AgentInfo{
+		{Name: "mei", Role: "PM"},
+		{Name: "yuki", Role: "Backend"},
+	}
+	r := New(agents)
+
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "valid agents",
+			input:    []string{"mei", "yuki"},
+			expected: []string{"mei", "yuki"},
+		},
+		{
+			name:     "filter invalid",
+			input:    []string{"mei", "invalid", "yuki"},
+			expected: []string{"mei", "yuki"},
+		},
+		{
+			name:     "remove duplicates",
+			input:    []string{"mei", "mei", "yuki"},
+			expected: []string{"mei", "yuki"},
+		},
+		{
+			name:     "case insensitive",
+			input:    []string{"MEI", "Yuki"},
+			expected: []string{"mei", "yuki"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := r.validateAgents(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+				return
+			}
+			for i, agent := range result {
+				if agent != tt.expected[i] {
+					t.Errorf("expected %v, got %v", tt.expected, result)
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestBuildPrompt(t *testing.T) {
+	agents := []AgentInfo{
+		{Name: "mei", Role: "PM / 要件定義"},
+		{Name: "yuki", Role: "バックエンド / インフラ"},
+	}
+	r := New(agents)
+
+	history := []Message{
+		{Role: "user", Content: "Hello"},
+		{Role: "mei", Content: "Hi!"},
+	}
+
+	prompt := r.buildPrompt("Test message", history)
+
+	// Check prompt contains required sections
+	if !contains(prompt, "mei") {
+		t.Error("prompt should contain agent mei")
+	}
+	if !contains(prompt, "yuki") {
+		t.Error("prompt should contain agent yuki")
+	}
+	if !contains(prompt, "Test message") {
+		t.Error("prompt should contain the message")
+	}
+	if !contains(prompt, "Hello") {
+		t.Error("prompt should contain history")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input    string
+		maxLen   int
+		expected string
+	}{
+		{"short", 10, "short"},
+		{"this is a long string", 10, "this is a ..."},
+		{"exact", 5, "exact"},
+	}
+
+	for _, tt := range tests {
+		result := truncate(tt.input, tt.maxLen)
+		if result != tt.expected {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, result, tt.expected)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- メッセージ内容に基づいて適切なエージェントを選択するルーター追加
- メンションがあればルーターをバイパス（従来動作）
- メンションがなければ Haiku で判定（コスト効率重視）
- 直近4メッセージを文脈として利用
- 判定失敗時は Mei にフォールバック

## Changes
- internal/router/router.go - ルーター本体（200行程度）
- internal/router/router_test.go - ユニットテスト
- cmd/maxam/tui.go - ルーター統合

## Test plan
- [x] go test ./internal/router/... 通過
- [x] go test ./... 全テスト通過
- [ ] 実際のチャットで動作確認