### PR TITLE
refactor: メンションチェッカーをconfigから設定可能に

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -221,13 +221,18 @@ func initialTuiModel(workDir string) tuiModel {
 		cfg = config.DefaultConfig()
 	}
 	routerAgents := make([]router.AgentInfo, len(cfg.Agents))
+	agentNames := make([]string, len(cfg.Agents))
 	for i, agentCfg := range cfg.Agents {
 		routerAgents[i] = router.AgentInfo{
 			Name: agentCfg.Name,
 			Role: agentCfg.Role,
 		}
+		agentNames[i] = agentCfg.Name
 	}
 	agentRouter := router.New(routerAgents)
+
+	// Setup mention checker with agent names from config
+	mention.SetDefaultChecker(mention.NewChecker(agentNames))
 
 	return tuiModel{
 		agents:           agent.NewAgents(workDir),

--- a/internal/mention/checker.go
+++ b/internal/mention/checker.go
@@ -32,18 +32,48 @@ var requestPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`よろしく(お願い|ね|)`),
 }
 
-// メンションパターン
-var mentionPattern = regexp.MustCompile(`@(yuki|priya|amara|mei|rin|shiori|Yuki|Priya|Amara|Mei|Rin|Shiori)`)
+// Checker detects mention leaks in messages
+type Checker struct {
+	mentionPattern *regexp.Regexp
+}
+
+// NewChecker creates a Checker with the given agent names
+func NewChecker(agentNames []string) *Checker {
+	if len(agentNames) == 0 {
+		// fallback: allow any @mention
+		return &Checker{
+			mentionPattern: regexp.MustCompile(`@\w+`),
+		}
+	}
+
+	// Build pattern: @(name1|name2|Name1|Name2|...)
+	var parts []string
+	for _, name := range agentNames {
+		lower := strings.ToLower(name)
+		// Add both lowercase and title case
+		parts = append(parts, lower)
+		if len(lower) > 0 {
+			titled := strings.ToUpper(string(lower[0])) + lower[1:]
+			if titled != lower {
+				parts = append(parts, titled)
+			}
+		}
+	}
+
+	pattern := `@(` + strings.Join(parts, "|") + `)`
+	return &Checker{
+		mentionPattern: regexp.MustCompile(pattern),
+	}
+}
 
 // Check analyzes a message for mention leaks
-// Returns a Result indicating if the message needs a warning
-func Check(message string) Result {
+func (c *Checker) Check(message string) Result {
 	result := Result{
 		Patterns: make([]string, 0),
 	}
 
 	// メンションの検出
-	result.HasMention = mentionPattern.MatchString(message)
+	result.HasMention = c.mentionPattern.MatchString(message)
 
 	// 依頼パターンの検出
 	lower := strings.ToLower(message)
@@ -63,6 +93,24 @@ func Check(message string) Result {
 	result.NeedsWarning = result.HasRequestPattern && !result.HasMention
 
 	return result
+}
+
+// defaultChecker is used by the package-level Check function
+var defaultChecker *Checker
+
+// SetDefaultChecker sets the default checker for package-level Check function
+func SetDefaultChecker(c *Checker) {
+	defaultChecker = c
+}
+
+// Check analyzes a message for mention leaks using the default checker
+// For backward compatibility
+func Check(message string) Result {
+	if defaultChecker == nil {
+		// fallback to hardcoded names for backward compatibility
+		defaultChecker = NewChecker([]string{"mei", "yuki", "rin", "shiori", "priya", "amara"})
+	}
+	return defaultChecker.Check(message)
 }
 
 // FormatWarning returns a warning message for display

--- a/internal/mention/checker_test.go
+++ b/internal/mention/checker_test.go
@@ -177,3 +177,69 @@ func TestFormatWarning(t *testing.T) {
 		t.Error("FormatWarning() returned empty string")
 	}
 }
+
+func TestNewChecker(t *testing.T) {
+	tests := []struct {
+		name       string
+		agentNames []string
+		message    string
+		wantMention bool
+	}{
+		{
+			name:        "custom agents - match",
+			agentNames:  []string{"alice", "bob"},
+			message:     "@alice お願い",
+			wantMention: true,
+		},
+		{
+			name:        "custom agents - no match",
+			agentNames:  []string{"alice", "bob"},
+			message:     "@yuki お願い",
+			wantMention: false,
+		},
+		{
+			name:        "custom agents - title case",
+			agentNames:  []string{"alice"},
+			message:     "@Alice お願い",
+			wantMention: true,
+		},
+		{
+			name:        "empty agents - any mention matches",
+			agentNames:  []string{},
+			message:     "@anyone お願い",
+			wantMention: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := NewChecker(tt.agentNames)
+			result := checker.Check(tt.message)
+			if result.HasMention != tt.wantMention {
+				t.Errorf("NewChecker(%v).Check(%q).HasMention = %v, want %v",
+					tt.agentNames, tt.message, result.HasMention, tt.wantMention)
+			}
+		})
+	}
+}
+
+func TestSetDefaultChecker(t *testing.T) {
+	// Save original
+	original := defaultChecker
+	defer func() { defaultChecker = original }()
+
+	// Set custom checker
+	customChecker := NewChecker([]string{"custom"})
+	SetDefaultChecker(customChecker)
+
+	// Verify it's used
+	result := Check("@custom お願い")
+	if !result.HasMention {
+		t.Error("SetDefaultChecker did not affect package-level Check")
+	}
+
+	result = Check("@yuki お願い")
+	if result.HasMention {
+		t.Error("Custom checker should not match @yuki")
+	}
+}


### PR DESCRIPTION
## Summary
- メンションパターンのハードコードを解消
- `mention.Checker` 構造体を追加、エージェント名を外部から注入可能に
- TUI初期化時に `config.yaml` からエージェント名を読み取り、Checkerをセットアップ

## Test plan
- [x] `go test ./internal/mention/...` - 新規テスト含め全パス
- [x] `go test ./...` - 全テスト通過
- [ ] TUIで `@カスタム名` が動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)