### PR TITLE
feat: エージェントごとにモデル指定を可能にする

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -20,6 +20,7 @@ type Runner struct {
 	WorkDir     string
 	ClaudeMDDir string
 	Timeout     time.Duration
+	Model       Model // Model to use for this agent
 }
 
 // NewRunner creates a new agent runner
@@ -74,8 +75,14 @@ func (r *Runner) Run(ctx context.Context, prompt string) (string, error) {
 		"--print",
 		"--system-prompt", systemPrompt,
 		"--permission-mode", "bypassPermissions",
-		prompt,
 	}
+
+	// Use agent's configured model if set
+	if r.Model != ModelDefault {
+		args = append(args, "--model", string(r.Model))
+	}
+
+	args = append(args, prompt)
 
 	cfg := retry.DefaultConfig()
 
@@ -236,7 +243,12 @@ func NewAgents(workDir string) *Agents {
 		agentDir := filepath.Join(agentsDir, name)
 		// Only add if CLAUDE.md exists
 		if _, err := os.Stat(filepath.Join(agentDir, "CLAUDE.md")); err == nil {
-			runners[name] = NewRunner(fullName, workDir, agentDir)
+			runner := NewRunner(fullName, workDir, agentDir)
+			// Set model from config if specified
+			if agentCfg.Model != "" {
+				runner.Model = Model(agentCfg.Model)
+			}
+			runners[name] = runner
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type AgentConfig struct {
 	Name     string `yaml:"name"`
 	FullName string `yaml:"full_name"`
 	Role     string `yaml:"role"`
+	Model    string `yaml:"model,omitempty"` // opus, sonnet, haiku
 }
 
 // DefaultAnalysisMinMessages is the default minimum message count for analysis

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -165,3 +165,43 @@ func TestListAgents(t *testing.T) {
 		t.Errorf("ListAgents() returned %d agents, want %d", len(list), len(DefaultAgents))
 	}
 }
+
+func TestAgentConfigModel(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   AgentConfig
+		hasModel bool
+	}{
+		{
+			name:     "モデル未指定",
+			config:   AgentConfig{Name: "test", FullName: "Test Agent", Role: "test"},
+			hasModel: false,
+		},
+		{
+			name:     "Sonnet指定",
+			config:   AgentConfig{Name: "test", FullName: "Test Agent", Role: "test", Model: "sonnet"},
+			hasModel: true,
+		},
+		{
+			name:     "Opus指定",
+			config:   AgentConfig{Name: "test", FullName: "Test Agent", Role: "test", Model: "opus"},
+			hasModel: true,
+		},
+		{
+			name:     "Haiku指定",
+			config:   AgentConfig{Name: "test", FullName: "Test Agent", Role: "test", Model: "haiku"},
+			hasModel: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.hasModel && tt.config.Model == "" {
+				t.Error("Expected model to be set")
+			}
+			if !tt.hasModel && tt.config.Model != "" {
+				t.Error("Expected model to be empty")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- AgentConfigにModelフィールド追加
- runner.goで--modelオプション対応
- config.yamlでエージェント個別にmodel指定可能に

## 動作確認
1. ~/.maxam/config.yamlでshioriにmodel: sonnet設定
2. チャットでShioriにタスク振る
3. claudeコマンドに--model sonnetが渡される

## Test plan
- [x] `go test ./internal/config/... ./internal/agent/...` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #73