### PR TITLE
feat: トークン消費最適化

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -143,6 +143,9 @@ type tuiModel struct {
 	// ccusage integration
 	ccusageClient *ccusage.Client
 	todayCost     float64
+
+	// Token optimization
+	projectContextSent bool // projectContextを送信済みかどうか
 }
 
 type agentResponseMsg struct {
@@ -611,6 +614,9 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			content: msg.content,
 		})
 
+		// projectContextを初回送信済みとしてマーク
+		m.projectContextSent = true
+
 		// Save to persistent history
 		if m.history != nil {
 			m.history.Add(msg.agent, msg.content)
@@ -721,11 +727,8 @@ func (m *tuiModel) buildMeiInterventionPrompt() string {
 	sb.WriteString("短く、わかりやすくまとめてください。\n")
 	sb.WriteString("オーナーへの確認は必ず含めてください。\n\n")
 
-	// Add project context
-	if m.projectContext != "" {
-		sb.WriteString(m.projectContext)
-		sb.WriteString("\n")
-	}
+	// Add project context (Mei介入時は要約のみ)
+	sb.WriteString(fmt.Sprintf("## プロジェクト情報\n\n作業ディレクトリ: %s\n\n", m.workDir))
 
 	sb.WriteString("## これまでの会話\n\n")
 	for _, msg := range m.messages {
@@ -977,20 +980,22 @@ func (m *tuiModel) buildPrompt(agentName, input string) string {
 	sb.WriteString("- 他のメンバーに作業を依頼するときは「@名前」で呼びかけてください\n")
 	sb.WriteString("- 呼びかけられたら、その依頼に応答してください\n\n")
 
-	// Add project context
+	// Add project context (初回のみフル、以降は要約)
 	if m.projectContext != "" {
-		sb.WriteString(m.projectContext)
-		sb.WriteString("\n")
+		if !m.projectContextSent {
+			sb.WriteString(m.projectContext)
+			sb.WriteString("\n")
+		} else {
+			// 要約版を渡す
+			sb.WriteString(fmt.Sprintf("## プロジェクト情報\n\n作業ディレクトリ: %s\n\n", m.workDir))
+		}
 	}
 
 	if len(m.messages) > 0 {
 		sb.WriteString("## 会話履歴\n\n")
-		start := 0
-		if len(m.messages) > 15 {
-			start = len(m.messages) - 15
-		}
-		for i := start; i < len(m.messages); i++ {
-			msg := m.messages[i]
+		// 動的に履歴数を調整（長いメッセージが多ければ少なく）
+		historyMessages := m.selectHistoryMessages()
+		for _, msg := range historyMessages {
 			if msg.role == "user" {
 				sb.WriteString(fmt.Sprintf("オーナー: %s\n\n", msg.content))
 			} else {
@@ -1013,6 +1018,75 @@ func (m *tuiModel) buildPrompt(agentName, input string) string {
 	}
 
 	return sb.String()
+}
+
+// selectHistoryMessages は履歴メッセージを動的に選択
+// メッセージ長に応じて数を調整し、雑談は除外
+func (m *tuiModel) selectHistoryMessages() []tuiMessage {
+	if len(m.messages) == 0 {
+		return nil
+	}
+
+	// 基本は8件、メッセージ長によって調整
+	baseCount := 8
+	totalChars := 0
+	const maxChars = 8000 // 目安の上限
+
+	var selected []tuiMessage
+	start := len(m.messages) - 1
+
+	for i := start; i >= 0 && len(selected) < baseCount; i-- {
+		msg := m.messages[i]
+
+		// 雑談フィルタ（重要度判定）
+		if isLowPriorityMessage(msg.content) {
+			continue
+		}
+
+		msgLen := len(msg.content)
+		// 文字数上限に達したら早めに切り上げ
+		if totalChars+msgLen > maxChars && len(selected) >= 4 {
+			break
+		}
+
+		// 先頭に追加（時系列を維持）
+		selected = append([]tuiMessage{msg}, selected...)
+		totalChars += msgLen
+	}
+
+	return selected
+}
+
+// isLowPriorityMessage は雑談や低重要度メッセージを判定
+func isLowPriorityMessage(content string) bool {
+	lower := strings.ToLower(content)
+
+	// 雑談パターン
+	chatPatterns := []string{
+		"好きな食べ物",
+		"パンケーキ",
+		"おはよう",
+		"こんにちは",
+		"こんばんは",
+		"ありがとう",
+		"お疲れ様",
+		"good morning",
+		"hello",
+		"thanks",
+	}
+
+	for _, pattern := range chatPatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+
+	// 短すぎるメッセージ（10文字以下）も低優先
+	if len(content) <= 10 {
+		return true
+	}
+
+	return false
 }
 
 func (m *tuiModel) analyzeProject() {

--- a/cmd/maxam/tui_analysis_test.go
+++ b/cmd/maxam/tui_analysis_test.go
@@ -220,6 +220,120 @@ func TestDetectAgentMentions(t *testing.T) {
 	}
 }
 
+func TestIsLowPriorityMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "雑談: 好きな食べ物",
+			content: "好きな食べ物は何？",
+			want:    true,
+		},
+		{
+			name:    "雑談: パンケーキ",
+			content: "パンケーキ食べたい！",
+			want:    true,
+		},
+		{
+			name:    "雑談: おはよう",
+			content: "おはよう！",
+			want:    true,
+		},
+		{
+			name:    "雑談: ありがとう",
+			content: "ありがとう！",
+			want:    true,
+		},
+		{
+			name:    "短いメッセージ (10文字以下)",
+			content: "うん",
+			want:    true,
+		},
+		{
+			name:    "短いメッセージ2 (10文字以下)",
+			content: "できた",
+			want:    true,
+		},
+		{
+			name:    "技術的な内容",
+			content: "buildPrompt関数でメッセージ履歴を動的に調整する実装を追加しました",
+			want:    false,
+		},
+		{
+			name:    "作業指示",
+			content: "@Yuki これ実装してほしい。15→8に減らして",
+			want:    false,
+		},
+		{
+			name:    "レビュー依頼",
+			content: "@Priya PR #80 レビューお願いします",
+			want:    false,
+		},
+		{
+			name:    "設計議論",
+			content: "トークン消費を減らすには、projectContextを初回のみ渡す方法が効果的",
+			want:    false,
+		},
+		{
+			name:    "英語: thanks",
+			content: "Thanks for the update!",
+			want:    true,
+		},
+		{
+			name:    "英語: good morning",
+			content: "Good morning everyone!",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isLowPriorityMessage(tt.content)
+			if got != tt.want {
+				t.Errorf("isLowPriorityMessage(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectHistoryMessages(t *testing.T) {
+	// モデル作成（簡易版）
+	m := &tuiModel{
+		messages: []tuiMessage{
+			{role: "user", content: "おはよう"},                        // 低優先 (雑談)
+			{role: "mei", content: "おはようございます"},                // 低優先 (雑談)
+			{role: "user", content: "トークン消費を減らしたい。調整案ある？"},
+			{role: "yuki", content: "調整案として4つ提案する。1. 15→8に減らす..."},
+			{role: "user", content: "うん"},                           // 低優先 (短い)
+			{role: "user", content: "これは全部やろう。実装よろしく"},
+			{role: "yuki", content: "了解。4つ全部やる。作業入る。"},
+		},
+	}
+
+	selected := m.selectHistoryMessages()
+
+	// 雑談・短いメッセージが除外されていることを確認
+	for _, msg := range selected {
+		if msg.content == "おはよう" || msg.content == "おはようございます" || msg.content == "うん" {
+			t.Errorf("low priority message should be excluded: %q", msg.content)
+		}
+	}
+
+	// 技術的な内容は含まれていることを確認
+	hasImportant := false
+	for _, msg := range selected {
+		if msg.content == "トークン消費を減らしたい。調整案ある？" {
+			hasImportant = true
+			break
+		}
+	}
+	if !hasImportant {
+		t.Error("important message should be included")
+	}
+}
+
 func TestGetWorktreePath(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Summary
- 履歴メッセージ数を15→8件(基本)に削減、動的調整で文字数上限(8000文字)も考慮
- projectContextは初回のみフル送信、以降は要約版（作業ディレクトリのみ）
- 雑談・短いメッセージ(10文字以下)を低優先として履歴から除外
- テスト追加: `isLowPriorityMessage`(12ケース)、`selectHistoryMessages`(1ケース)

## 変更の効果
| 項目 | Before | After |
|------|--------|-------|
| 履歴メッセージ数 | 固定15件 | 動的4-8件 |
| projectContext | 毎回フル | 初回のみフル、以降要約 |
| 雑談含む | 全メッセージ | 重要度でフィルタ |

## Test plan
- [x] go test ./cmd/maxam/... 通過
- [x] go test ./... 全テスト通過
- [ ] 実際のチャットで動作確認（雑談がフィルタされること、履歴が動的に調整されること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)