### PR TITLE
feat: replace LLM routing with mention-based routing

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -232,7 +232,7 @@ func initialTuiModel(workDir string) tuiModel {
 		}
 		agentNames[i] = agentCfg.Name
 	}
-	agentRouter := router.New(routerAgents)
+	agentRouter := router.New(routerAgents, cfg.DefaultAgent)
 
 	// Setup mention checker with agent names from config
 	mention.SetDefaultChecker(mention.NewChecker(agentNames))
@@ -877,82 +877,12 @@ func (m tuiModel) View() string {
 	)
 }
 
-// detectAgents は入力から対象エージェントを複数検出（並列呼び出し用）
-// メンションがあればバイパス、なければルーターで判定
+// detectAgents は入力から対象エージェントを検出
+// @メンションがあればその人へ、なければデフォルトエージェントへルーティング
 func (m *tuiModel) detectAgents(text string) []string {
-	lower := strings.ToLower(text)
-	var agents []string
-	seen := make(map[string]bool)
-
-	// 明示的なメンションを優先的にチェック（ルーターをバイパス）
-	if strings.Contains(lower, "@yuki") || strings.Contains(lower, "ゆきちゃん") {
-		agents = append(agents, "yuki")
-		seen["yuki"] = true
-	}
-	if strings.Contains(lower, "@priya") || strings.Contains(lower, "プリヤちゃん") {
-		agents = append(agents, "priya")
-		seen["priya"] = true
-	}
-	if strings.Contains(lower, "@amara") || strings.Contains(lower, "アマラちゃん") {
-		agents = append(agents, "amara")
-		seen["amara"] = true
-	}
-	if strings.Contains(lower, "@mei") || strings.Contains(lower, "メイちゃん") {
-		agents = append(agents, "mei")
-		seen["mei"] = true
-	}
-	if strings.Contains(lower, "@rin") || strings.Contains(lower, "りんちゃん") {
-		agents = append(agents, "rin")
-		seen["rin"] = true
-	}
-	if strings.Contains(lower, "@shiori") || strings.Contains(lower, "しおりちゃん") {
-		agents = append(agents, "shiori")
-		seen["shiori"] = true
-	}
-
-	// 明示的なメンションがあればそれを返す（ルーターをバイパス）
-	if len(agents) > 0 {
-		return agents
-	}
-
-	// メンションがなければルーターで判定
-	return m.routeMessage(text)
+	return m.router.Route(text)
 }
 
-// routeMessage はルーターを使ってメッセージの宛先を決定
-func (m *tuiModel) routeMessage(text string) []string {
-	// 会話履歴をルーター用のフォーマットに変換（直近4メッセージ）
-	var history []router.Message
-	start := 0
-	if len(m.messages) > 4 {
-		start = len(m.messages) - 4
-	}
-	for i := start; i < len(m.messages); i++ {
-		msg := m.messages[i]
-		role := msg.role
-		if role == "user" {
-			role = "オーナー"
-		} else {
-			role = getTuiFullName(role)
-		}
-		history = append(history, router.Message{
-			Role:    role,
-			Content: msg.content,
-		})
-	}
-
-	// ルーターで判定
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	agents, err := m.router.Route(ctx, text, history)
-	if err != nil || len(agents) == 0 {
-		// フォールバック: Mei
-		return []string{"mei"}
-	}
-
-	return agents
-}
 
 // detectAgent は互換性のため残す（単一検出）
 func (m *tuiModel) detectAgent(text string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,8 +11,9 @@ import (
 
 // Config represents the MAXAM configuration
 type Config struct {
-	Version string        `yaml:"version"`
-	Agents  []AgentConfig `yaml:"agents"`
+	Version      string        `yaml:"version"`
+	DefaultAgent string        `yaml:"default_agent,omitempty"`
+	Agents       []AgentConfig `yaml:"agents"`
 }
 
 // AgentConfig represents an agent configuration
@@ -25,7 +26,8 @@ type AgentConfig struct {
 // DefaultConfig returns the default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		Version: "1",
+		Version:      "1",
+		DefaultAgent: "mei",
 		Agents: []AgentConfig{
 			{Name: "mei", FullName: "Mei Chen", Role: "PM / 要件定義"},
 			{Name: "yuki", FullName: "Yuki Tanaka", Role: "バックエンド / インフラ"},

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -2,18 +2,15 @@
 package router
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"fmt"
-	"os/exec"
+	"regexp"
 	"strings"
-	"time"
 )
 
-// Router routes messages to appropriate agents using LLM
+// Router routes messages to appropriate agents based on mentions
 type Router struct {
-	agents []AgentInfo
+	agents       []AgentInfo
+	defaultAgent string
+	mentionRegex *regexp.Regexp
 }
 
 // AgentInfo holds basic agent information for routing
@@ -28,9 +25,13 @@ type RouteResult struct {
 }
 
 // New creates a new Router with agent information
-func New(agents []AgentInfo) *Router {
+func New(agents []AgentInfo, defaultAgent string) *Router {
+	// Build regex pattern for @mentions
+	// Matches @name (case insensitive)
 	return &Router{
-		agents: agents,
+		agents:       agents,
+		defaultAgent: defaultAgent,
+		mentionRegex: regexp.MustCompile(`(?i)@(\w+)`),
 	}
 }
 
@@ -41,148 +42,52 @@ type Message struct {
 }
 
 // Route determines which agents should respond to the message
-// It uses Claude Haiku for fast, cost-effective routing decisions
-func (r *Router) Route(ctx context.Context, message string, history []Message) ([]string, error) {
-	prompt := r.buildPrompt(message, history)
+// It extracts @mentions from the message and routes to those agents
+// If no valid mentions found, routes to the default agent
+func (r *Router) Route(message string) []string {
+	mentions := r.extractMentions(message)
 
-	// Use haiku for cost-effective routing
-	args := []string{
-		"--print",
-		"--model", "haiku",
-		"--max-turns", "1",
-		prompt,
+	if len(mentions) > 0 {
+		return mentions
 	}
 
-	runCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(runCtx, "claude", args...)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		if runCtx.Err() == context.DeadlineExceeded {
-			return []string{"mei"}, nil // fallback to Mei on timeout
-		}
-		return []string{"mei"}, nil // fallback to Mei on error
+	// No valid mentions - use default agent
+	if r.defaultAgent != "" {
+		return []string{r.defaultAgent}
 	}
 
-	result := strings.TrimSpace(stdout.String())
-	agents := r.parseResult(result)
-
-	if len(agents) == 0 {
-		return []string{"mei"}, nil // fallback to Mei
-	}
-
-	return agents, nil
+	// Fallback to mei if no default configured
+	return []string{"mei"}
 }
 
-func (r *Router) buildPrompt(message string, history []Message) string {
-	var sb strings.Builder
-
-	sb.WriteString(`You are a message router. Determine which team member(s) should respond to the message.
-
-## Team Members
-`)
-
-	for _, agent := range r.agents {
-		sb.WriteString(fmt.Sprintf("- %s: %s\n", agent.Name, agent.Role))
+// extractMentions finds all @mentions in the message and returns valid agent names
+func (r *Router) extractMentions(message string) []string {
+	matches := r.mentionRegex.FindAllStringSubmatch(message, -1)
+	if len(matches) == 0 {
+		return nil
 	}
 
-	sb.WriteString(`
-## Rules
-1. Return ONLY a JSON object with "agents" array containing the agent names (lowercase)
-2. Choose 1-3 most appropriate agents based on the message content
-3. Consider the conversation context to understand ongoing discussions
-4. If unsure, include "mei" as she handles general coordination
-
-## Examples
-- "実装お願い" → {"agents": ["yuki"]}
-- "レビューお願い" → {"agents": ["priya"]}
-- "YukiとPriyaに確認" → {"agents": ["yuki", "priya"]}
-- "こんにちは" → {"agents": ["mei"]}
-- "分析して" → {"agents": ["amara"]}
-- "UIを直して" → {"agents": ["rin"]}
-- "テスト書いて" → {"agents": ["shiori"]}
-
-`)
-
-	// Add recent conversation history (max 4 messages)
-	if len(history) > 0 {
-		sb.WriteString("## Recent Conversation\n")
-		start := 0
-		if len(history) > 4 {
-			start = len(history) - 4
-		}
-		for i := start; i < len(history); i++ {
-			msg := history[i]
-			sb.WriteString(fmt.Sprintf("%s: %s\n", msg.Role, truncate(msg.Content, 200)))
-		}
-		sb.WriteString("\n")
-	}
-
-	sb.WriteString("## Current Message\n")
-	sb.WriteString(message)
-	sb.WriteString("\n\n## Your Response (JSON only)\n")
-
-	return sb.String()
-}
-
-func (r *Router) parseResult(result string) []string {
-	// Try to extract JSON from the result
-	// The LLM might include extra text, so look for JSON pattern
-
-	// First, try direct parse
-	var routeResult RouteResult
-	if err := json.Unmarshal([]byte(result), &routeResult); err == nil {
-		return r.validateAgents(routeResult.Agents)
-	}
-
-	// Try to find JSON in the response
-	start := strings.Index(result, "{")
-	end := strings.LastIndex(result, "}")
-	if start >= 0 && end > start {
-		jsonStr := result[start : end+1]
-		if err := json.Unmarshal([]byte(jsonStr), &routeResult); err == nil {
-			return r.validateAgents(routeResult.Agents)
-		}
-	}
-
-	// Fallback: look for agent names in the response
-	lower := strings.ToLower(result)
-	var agents []string
-	validNames := r.getValidNames()
-
-	for _, name := range validNames {
-		if strings.Contains(lower, name) {
-			agents = append(agents, name)
-		}
-	}
-
-	return agents
-}
-
-func (r *Router) validateAgents(agents []string) []string {
 	validNames := r.getValidNames()
 	validSet := make(map[string]bool)
 	for _, name := range validNames {
 		validSet[name] = true
 	}
 
-	var result []string
+	var agents []string
 	seen := make(map[string]bool)
 
-	for _, agent := range agents {
-		name := strings.ToLower(strings.TrimSpace(agent))
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		name := strings.ToLower(match[1])
 		if validSet[name] && !seen[name] {
-			result = append(result, name)
+			agents = append(agents, name)
 			seen[name] = true
 		}
 	}
 
-	return result
+	return agents
 }
 
 func (r *Router) getValidNames() []string {
@@ -191,11 +96,4 @@ func (r *Router) getValidNames() []string {
 		names[i] = strings.ToLower(agent.Name)
 	}
 	return names
-}
-
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestParseResult(t *testing.T) {
+func TestRoute(t *testing.T) {
 	agents := []AgentInfo{
 		{Name: "mei", Role: "PM"},
 		{Name: "yuki", Role: "Backend"},
@@ -13,58 +13,92 @@ func TestParseResult(t *testing.T) {
 		{Name: "rin", Role: "Frontend"},
 		{Name: "shiori", Role: "Test/Docs"},
 	}
-	r := New(agents)
 
 	tests := []struct {
-		name     string
-		input    string
-		expected []string
+		name         string
+		message      string
+		defaultAgent string
+		expected     []string
 	}{
 		{
-			name:     "valid JSON",
-			input:    `{"agents": ["yuki"]}`,
-			expected: []string{"yuki"},
+			name:         "single mention",
+			message:      "@yuki 実装お願い",
+			defaultAgent: "mei",
+			expected:     []string{"yuki"},
 		},
 		{
-			name:     "multiple agents",
-			input:    `{"agents": ["yuki", "priya"]}`,
-			expected: []string{"yuki", "priya"},
+			name:         "multiple mentions",
+			message:      "@yuki と @priya に確認お願い",
+			defaultAgent: "mei",
+			expected:     []string{"yuki", "priya"},
 		},
 		{
-			name:     "JSON with extra text",
-			input:    `Here is the result: {"agents": ["amara"]} That's all.`,
-			expected: []string{"amara"},
+			name:         "case insensitive",
+			message:      "@YUKI 実装して",
+			defaultAgent: "mei",
+			expected:     []string{"yuki"},
 		},
 		{
-			name:     "fallback to name detection",
-			input:    `I think Yuki should handle this.`,
-			expected: []string{"yuki"},
+			name:         "invalid mention ignored",
+			message:      "@unknown この人いない",
+			defaultAgent: "mei",
+			expected:     []string{"mei"},
 		},
 		{
-			name:     "multiple names in text",
-			input:    `Both Yuki and Priya should review this.`,
-			expected: []string{"yuki", "priya"},
+			name:         "no mention - use default",
+			message:      "こんにちは",
+			defaultAgent: "mei",
+			expected:     []string{"mei"},
 		},
 		{
-			name:     "invalid agent name filtered",
-			input:    `{"agents": ["yuki", "unknown"]}`,
-			expected: []string{"yuki"},
+			name:         "no mention - custom default",
+			message:      "レビューお願い",
+			defaultAgent: "priya",
+			expected:     []string{"priya"},
 		},
 		{
-			name:     "empty result",
-			input:    `{}`,
-			expected: []string{},
+			name:         "mention at end",
+			message:      "実装お願い @yuki",
+			defaultAgent: "mei",
+			expected:     []string{"yuki"},
 		},
 		{
-			name:     "rin and shiori",
-			input:    `{"agents": ["rin", "shiori"]}`,
-			expected: []string{"rin", "shiori"},
+			name:         "mention in middle",
+			message:      "ちょっと @priya さんに聞きたい",
+			defaultAgent: "mei",
+			expected:     []string{"priya"},
+		},
+		{
+			name:         "duplicate mentions",
+			message:      "@yuki @yuki 二回書いた",
+			defaultAgent: "mei",
+			expected:     []string{"yuki"},
+		},
+		{
+			name:         "all agents mentioned",
+			message:      "@mei @yuki @priya @amara @rin @shiori 全員集合",
+			defaultAgent: "mei",
+			expected:     []string{"mei", "yuki", "priya", "amara", "rin", "shiori"},
+		},
+		{
+			name:         "mixed valid and invalid",
+			message:      "@yuki @invalid @priya お願い",
+			defaultAgent: "mei",
+			expected:     []string{"yuki", "priya"},
+		},
+		{
+			name:         "empty default fallback to mei",
+			message:      "誰かお願い",
+			defaultAgent: "",
+			expected:     []string{"mei"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := r.parseResult(tt.input)
+			r := New(agents, tt.defaultAgent)
+			result := r.Route(tt.message)
+
 			if len(result) != len(tt.expected) {
 				t.Errorf("expected %v, got %v", tt.expected, result)
 				return
@@ -79,43 +113,43 @@ func TestParseResult(t *testing.T) {
 	}
 }
 
-func TestValidateAgents(t *testing.T) {
+func TestExtractMentions(t *testing.T) {
 	agents := []AgentInfo{
 		{Name: "mei", Role: "PM"},
 		{Name: "yuki", Role: "Backend"},
 	}
-	r := New(agents)
+	r := New(agents, "mei")
 
 	tests := []struct {
 		name     string
-		input    []string
+		input    string
 		expected []string
 	}{
 		{
-			name:     "valid agents",
-			input:    []string{"mei", "yuki"},
-			expected: []string{"mei", "yuki"},
+			name:     "no mentions",
+			input:    "普通のメッセージ",
+			expected: nil,
 		},
 		{
-			name:     "filter invalid",
-			input:    []string{"mei", "invalid", "yuki"},
-			expected: []string{"mei", "yuki"},
+			name:     "one mention",
+			input:    "@yuki",
+			expected: []string{"yuki"},
 		},
 		{
-			name:     "remove duplicates",
-			input:    []string{"mei", "mei", "yuki"},
-			expected: []string{"mei", "yuki"},
+			name:     "mention with text",
+			input:    "Hello @mei how are you",
+			expected: []string{"mei"},
 		},
 		{
-			name:     "case insensitive",
-			input:    []string{"MEI", "Yuki"},
-			expected: []string{"mei", "yuki"},
+			name:     "invalid mention only",
+			input:    "@unknown",
+			expected: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := r.validateAgents(tt.input)
+			result := r.extractMentions(tt.input)
 			if len(result) != len(tt.expected) {
 				t.Errorf("expected %v, got %v", tt.expected, result)
 				return
@@ -130,63 +164,24 @@ func TestValidateAgents(t *testing.T) {
 	}
 }
 
-func TestBuildPrompt(t *testing.T) {
+func TestGetValidNames(t *testing.T) {
 	agents := []AgentInfo{
-		{Name: "mei", Role: "PM / 要件定義"},
-		{Name: "yuki", Role: "バックエンド / インフラ"},
+		{Name: "Mei", Role: "PM"},
+		{Name: "YUKI", Role: "Backend"},
 	}
-	r := New(agents)
+	r := New(agents, "mei")
 
-	history := []Message{
-		{Role: "user", Content: "Hello"},
-		{Role: "mei", Content: "Hi!"},
-	}
+	names := r.getValidNames()
+	expected := []string{"mei", "yuki"}
 
-	prompt := r.buildPrompt("Test message", history)
-
-	// Check prompt contains required sections
-	if !contains(prompt, "mei") {
-		t.Error("prompt should contain agent mei")
+	if len(names) != len(expected) {
+		t.Errorf("expected %v, got %v", expected, names)
+		return
 	}
-	if !contains(prompt, "yuki") {
-		t.Error("prompt should contain agent yuki")
-	}
-	if !contains(prompt, "Test message") {
-		t.Error("prompt should contain the message")
-	}
-	if !contains(prompt, "Hello") {
-		t.Error("prompt should contain history")
-	}
-}
-
-func TestTruncate(t *testing.T) {
-	tests := []struct {
-		input    string
-		maxLen   int
-		expected string
-	}{
-		{"short", 10, "short"},
-		{"this is a long string", 10, "this is a ..."},
-		{"exact", 5, "exact"},
-	}
-
-	for _, tt := range tests {
-		result := truncate(tt.input, tt.maxLen)
-		if result != tt.expected {
-			t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, result, tt.expected)
+	for i, name := range names {
+		if name != expected[i] {
+			t.Errorf("expected %v, got %v", expected, names)
+			return
 		}
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
-}
-
-func containsHelper(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary
- LLM呼び出しを廃止し、@メンションベースのルーティングに変更
- 設定ファイル（`~/.maxam/config.yaml`）で`default_agent`を指定可能に
- メンションなしの場合はデフォルトエージェント（初期値: mei）へルーティング

## 変更点
- `internal/router/router.go`: LLM呼び出しを削除、正規表現でメンション抽出
- `internal/config/config.go`: `DefaultAgent`フィールド追加
- `cmd/maxam/tui.go`: 呼び出し側を新しいAPIに対応
- `internal/router/router_test.go`: テストを新ロジックに対応（12ケース）

## Test plan
- [ ] `make test` で全テスト通過
- [ ] `@yuki` 等のメンションで正しくルーティングされる
- [ ] メンションなしでデフォルトエージェント（mei）に届く

🤖 Generated with [Claude Code](https://claude.com/claude-code)