### PR TITLE
feat: 定期分析の条件付き実行

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -146,6 +146,9 @@ type tuiModel struct {
 
 	// Token optimization
 	projectContextSent bool // projectContextを送信済みかどうか
+
+	// Analysis settings
+	analysisMinMessages int // 分析実行の最小メッセージ数
 }
 
 type agentResponseMsg struct {
@@ -238,22 +241,23 @@ func initialTuiModel(workDir string) tuiModel {
 	mention.SetDefaultChecker(mention.NewChecker(agentNames))
 
 	return tuiModel{
-		agents:           agent.NewAgents(workDir),
-		router:           agentRouter,
-		logMgr:           logger.NewManager(logger.GetDefaultLogDir(), workDir),
-		history:          hist,
-		workDir:          workDir,
-		textInput:        ti,
-		messages:         messages,
-		inputHist:        make([]string, 0),
-		processingAgents: make(map[string]bool),
-		histIdx:          -1,
-		currentView:      viewChat,
-		tasklist:         tasklistModel,
-		taskService:      taskService,
-		taskWatcher:      taskWatcher,
-		prWatcher:        prWatcher,
-		ccusageClient:    ccClient,
+		agents:              agent.NewAgents(workDir),
+		router:              agentRouter,
+		logMgr:              logger.NewManager(logger.GetDefaultLogDir(), workDir),
+		history:             hist,
+		workDir:             workDir,
+		textInput:           ti,
+		messages:            messages,
+		inputHist:           make([]string, 0),
+		processingAgents:    make(map[string]bool),
+		histIdx:             -1,
+		currentView:         viewChat,
+		tasklist:            tasklistModel,
+		taskService:         taskService,
+		taskWatcher:         taskWatcher,
+		prWatcher:           prWatcher,
+		ccusageClient:       ccClient,
+		analysisMinMessages: cfg.GetAnalysisMinMessages(),
 	}
 }
 
@@ -555,8 +559,9 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case analysisTickMsg:
 		// 1時間ごとの軽量分析トリガー
-		// Amaraが処理中でなく、会話がある場合のみ実行
-		if !m.processingAgents["amara"] && len(m.messages) > 0 {
+		// Amaraが処理中でなく、直近のメッセージ数が閾値以上の場合のみ実行
+		recentMessages := m.getRecentMessages(time.Hour)
+		if !m.processingAgents["amara"] && len(recentMessages) >= m.analysisMinMessages {
 			m.processingAgents["amara"] = true
 			return m, tea.Batch(
 				m.runLightweightAnalysis(),
@@ -1188,16 +1193,8 @@ func (m *tuiModel) checkMergedPRs() tea.Cmd {
 // runLightweightAnalysis は1時間ごとの軽量分析を実行
 func (m *tuiModel) runLightweightAnalysis() tea.Cmd {
 	return func() tea.Msg {
-		// 直近1時間のメッセージを取得
+		// 直近1時間のメッセージを取得（閾値チェックは呼び出し元で実施済み）
 		recentMessages := m.getRecentMessages(time.Hour)
-		if len(recentMessages) == 0 {
-			// 分析対象がなければ何もしない
-			return agentResponseMsg{
-				agent:   "amara",
-				content: "", // 空なら表示しない
-				err:     nil,
-			}
-		}
 
 		// 軽量分析用プロンプトを構築
 		prompt := m.buildLightweightAnalysisPrompt(recentMessages)

--- a/cmd/maxam/tui_analysis_test.go
+++ b/cmd/maxam/tui_analysis_test.go
@@ -334,6 +334,57 @@ func TestSelectHistoryMessages(t *testing.T) {
 	}
 }
 
+func TestAnalysisMinMessagesThreshold(t *testing.T) {
+	tests := []struct {
+		name              string
+		messageCount      int
+		minMessages       int
+		expectAnalysis    bool
+	}{
+		{
+			name:           "閾値以上で分析実行",
+			messageCount:   10,
+			minMessages:    10,
+			expectAnalysis: true,
+		},
+		{
+			name:           "閾値超で分析実行",
+			messageCount:   15,
+			minMessages:    10,
+			expectAnalysis: true,
+		},
+		{
+			name:           "閾値未満でスキップ",
+			messageCount:   5,
+			minMessages:    10,
+			expectAnalysis: false,
+		},
+		{
+			name:           "0件でスキップ",
+			messageCount:   0,
+			minMessages:    10,
+			expectAnalysis: false,
+		},
+		{
+			name:           "閾値1で1件あれば実行",
+			messageCount:   1,
+			minMessages:    1,
+			expectAnalysis: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 閾値チェックロジックのテスト
+			shouldRunAnalysis := tt.messageCount >= tt.minMessages
+			if shouldRunAnalysis != tt.expectAnalysis {
+				t.Errorf("messageCount=%d, minMessages=%d: got %v, want %v",
+					tt.messageCount, tt.minMessages, shouldRunAnalysis, tt.expectAnalysis)
+			}
+		})
+	}
+}
+
 func TestGetWorktreePath(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,9 +11,10 @@ import (
 
 // Config represents the MAXAM configuration
 type Config struct {
-	Version      string        `yaml:"version"`
-	DefaultAgent string        `yaml:"default_agent,omitempty"`
-	Agents       []AgentConfig `yaml:"agents"`
+	Version             string        `yaml:"version"`
+	DefaultAgent        string        `yaml:"default_agent,omitempty"`
+	Agents              []AgentConfig `yaml:"agents"`
+	AnalysisMinMessages int           `yaml:"analysis_min_messages,omitempty"`
 }
 
 // AgentConfig represents an agent configuration
@@ -23,11 +24,15 @@ type AgentConfig struct {
 	Role     string `yaml:"role"`
 }
 
+// DefaultAnalysisMinMessages is the default minimum message count for analysis
+const DefaultAnalysisMinMessages = 10
+
 // DefaultConfig returns the default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		Version:      "1",
-		DefaultAgent: "mei",
+		Version:             "1",
+		DefaultAgent:        "mei",
+		AnalysisMinMessages: DefaultAnalysisMinMessages,
 		Agents: []AgentConfig{
 			{Name: "mei", FullName: "Mei Chen", Role: "PM / 要件定義"},
 			{Name: "yuki", FullName: "Yuki Tanaka", Role: "バックエンド / インフラ"},
@@ -37,6 +42,14 @@ func DefaultConfig() *Config {
 			{Name: "amara", FullName: "Amara Okonkwo", Role: "分析"},
 		},
 	}
+}
+
+// GetAnalysisMinMessages returns the analysis minimum messages with default fallback
+func (c *Config) GetAnalysisMinMessages() int {
+	if c.AnalysisMinMessages <= 0 {
+		return DefaultAnalysisMinMessages
+	}
+	return c.AnalysisMinMessages
 }
 
 // ConfigDir returns the path to ~/.maxam/

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,47 @@ func TestDefaultConfig(t *testing.T) {
 	if len(cfg.Agents) != 6 {
 		t.Errorf("Agents count = %d, want 6", len(cfg.Agents))
 	}
+	if cfg.AnalysisMinMessages != DefaultAnalysisMinMessages {
+		t.Errorf("AnalysisMinMessages = %d, want %d", cfg.AnalysisMinMessages, DefaultAnalysisMinMessages)
+	}
+}
+
+func TestGetAnalysisMinMessages(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *Config
+		expected int
+	}{
+		{
+			name:     "デフォルト設定",
+			cfg:      DefaultConfig(),
+			expected: DefaultAnalysisMinMessages,
+		},
+		{
+			name:     "カスタム値",
+			cfg:      &Config{AnalysisMinMessages: 20},
+			expected: 20,
+		},
+		{
+			name:     "0の場合はデフォルト",
+			cfg:      &Config{AnalysisMinMessages: 0},
+			expected: DefaultAnalysisMinMessages,
+		},
+		{
+			name:     "負の値の場合はデフォルト",
+			cfg:      &Config{AnalysisMinMessages: -5},
+			expected: DefaultAnalysisMinMessages,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.GetAnalysisMinMessages()
+			if got != tt.expected {
+				t.Errorf("GetAnalysisMinMessages() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
 }
 
 func TestConfigDir(t *testing.T) {


### PR DESCRIPTION
## Summary
- 会話量が閾値未満の場合は定期分析（1時間毎）をスキップ
- config に `analysis_min_messages` 設定を追加（デフォルト10件）
- トークン消費を削減

## Test plan
- [ ] `go test ./...` 通過確認
- [ ] config テスト（デフォルト値、カスタム値、0/負の値のフォールバック）
- [ ] tui 分析閾値テスト

## 動作確認方法
```yaml
# ~/.maxam/config.yaml
analysis_min_messages: 5  # 5件以上で分析実行
```

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)