### PR TITLE
feat: レビューサイクルのモデル最適化

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -101,6 +101,59 @@ func (r *Runner) Run(ctx context.Context, prompt string) (string, error) {
 	})
 }
 
+// Model represents the Claude model to use
+type Model string
+
+const (
+	ModelDefault Model = ""       // Use claude's default
+	ModelHaiku   Model = "haiku"  // Fast, lightweight
+	ModelSonnet  Model = "sonnet" // Balanced
+	ModelOpus    Model = "opus"   // Most capable
+)
+
+// RunWithModel executes a task with a specific model
+func (r *Runner) RunWithModel(ctx context.Context, prompt string, model Model) (string, error) {
+	systemPrompt, err := r.buildSystemPrompt()
+	if err != nil {
+		return "", fmt.Errorf("build system prompt: %w", err)
+	}
+
+	args := []string{
+		"--print",
+		"--system-prompt", systemPrompt,
+		"--permission-mode", "bypassPermissions",
+	}
+
+	if model != ModelDefault {
+		args = append(args, "--model", string(model))
+	}
+
+	args = append(args, prompt)
+
+	cfg := retry.DefaultConfig()
+
+	return retry.DoWithResult(ctx, cfg, func() (string, error) {
+		runCtx, cancel := context.WithTimeout(ctx, r.Timeout)
+		defer cancel()
+
+		cmd := exec.CommandContext(runCtx, "claude", args...)
+		cmd.Dir = r.WorkDir
+
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		if err := cmd.Run(); err != nil {
+			if runCtx.Err() == context.DeadlineExceeded {
+				return "", fmt.Errorf("timeout after %v", r.Timeout)
+			}
+			return "", fmt.Errorf("run claude: %w\nstderr: %s", err, stderr.String())
+		}
+
+		return stdout.String(), nil
+	})
+}
+
 // RunWithAllowedTools executes with specific tools enabled
 func (r *Runner) RunWithAllowedTools(ctx context.Context, prompt string, tools []string) (string, error) {
 	systemPrompt, err := r.buildSystemPrompt()

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -1,0 +1,21 @@
+package agent
+
+import "testing"
+
+func TestModelConstants(t *testing.T) {
+	tests := []struct {
+		model Model
+		want  string
+	}{
+		{ModelDefault, ""},
+		{ModelHaiku, "haiku"},
+		{ModelSonnet, "sonnet"},
+		{ModelOpus, "opus"},
+	}
+
+	for _, tt := range tests {
+		if got := string(tt.model); got != tt.want {
+			t.Errorf("Model %v = %q, want %q", tt.model, got, tt.want)
+		}
+	}
+}

--- a/internal/workflow/review.go
+++ b/internal/workflow/review.go
@@ -11,6 +11,9 @@ import (
 	"github.com/ytnobody/MAXAM/internal/logger"
 )
 
+// Threshold for determining if implementation is "lightweight"
+const lightweightThreshold = 100
+
 // ReviewCycle represents a Yuki -> Priya review cycle
 type ReviewCycle struct {
 	agents *agent.Agents
@@ -81,7 +84,14 @@ func (rc *ReviewCycle) Run(ctx context.Context, task string) (*ReviewResult, err
 		}
 
 		// Priya reviews
-		fmt.Println("[Priya] Reviewing...")
+		// Use Haiku for follow-up reviews (round > 1) with lightweight changes
+		reviewModel := selectReviewModel(i, impl)
+		modelInfo := ""
+		if reviewModel != agent.ModelDefault {
+			modelInfo = fmt.Sprintf(" (model: %s)", reviewModel)
+		}
+		fmt.Printf("[Priya] Reviewing...%s\n", modelInfo)
+
 		reviewPrompt := fmt.Sprintf(`以下の実装をレビューしてください。
 
 ## タスク
@@ -95,7 +105,12 @@ func (rc *ReviewCycle) Run(ctx context.Context, task string) (*ReviewResult, err
 - 問題があれば「[MINOR]」「[DESIGN]」「[REQUIREMENTS]」「[SEC-CRITICAL]」のいずれかのタグをつけて指摘してください`, task, impl)
 
 		start = time.Now()
-		review, err := priya.Run(ctx, reviewPrompt)
+		var review string
+		if reviewModel != agent.ModelDefault {
+			review, err = priya.RunWithModel(ctx, reviewPrompt, reviewModel)
+		} else {
+			review, err = priya.Run(ctx, reviewPrompt)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("priya review: %w", err)
 		}
@@ -158,4 +173,20 @@ func parseTags(review string) []string {
 	}
 
 	return tags
+}
+
+// selectReviewModel chooses model based on review round and implementation size
+// - Round 1: Always use default (full review)
+// - Round 2+: Use Haiku if implementation is lightweight
+func selectReviewModel(round int, impl string) agent.Model {
+	if round == 1 {
+		return agent.ModelDefault
+	}
+
+	lines := strings.Count(impl, "\n") + 1
+	if lines <= lightweightThreshold {
+		return agent.ModelHaiku
+	}
+
+	return agent.ModelDefault
 }

--- a/internal/workflow/review_test.go
+++ b/internal/workflow/review_test.go
@@ -1,0 +1,121 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ytnobody/MAXAM/internal/agent"
+)
+
+func TestSelectReviewModel(t *testing.T) {
+	tests := []struct {
+		name  string
+		round int
+		impl  string
+		want  agent.Model
+	}{
+		{
+			name:  "round 1 always default",
+			round: 1,
+			impl:  "short impl",
+			want:  agent.ModelDefault,
+		},
+		{
+			name:  "round 1 with long impl still default",
+			round: 1,
+			impl:  strings.Repeat("line\n", 200),
+			want:  agent.ModelDefault,
+		},
+		{
+			name:  "round 2 with short impl uses haiku",
+			round: 2,
+			impl:  "short impl",
+			want:  agent.ModelHaiku,
+		},
+		{
+			name:  "round 2 with exactly threshold lines uses haiku",
+			round: 2,
+			impl:  strings.Repeat("line\n", lightweightThreshold-1),
+			want:  agent.ModelHaiku,
+		},
+		{
+			name:  "round 2 with over threshold uses default",
+			round: 2,
+			impl:  strings.Repeat("line\n", lightweightThreshold+50),
+			want:  agent.ModelDefault,
+		},
+		{
+			name:  "round 3 with short impl uses haiku",
+			round: 3,
+			impl:  strings.Repeat("line\n", 50),
+			want:  agent.ModelHaiku,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectReviewModel(tt.round, tt.impl)
+			if got != tt.want {
+				t.Errorf("selectReviewModel(%d, impl) = %v, want %v", tt.round, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTags(t *testing.T) {
+	tests := []struct {
+		review string
+		want   []string
+	}{
+		{
+			review: "APPROVED",
+			want:   []string{},
+		},
+		{
+			review: "[MINOR] typo fix needed",
+			want:   []string{"MINOR"},
+		},
+		{
+			review: "[DESIGN] needs refactor\n[MINOR] also typo",
+			want:   []string{"MINOR", "DESIGN"},
+		},
+		{
+			review: "[SEC-CRITICAL] security issue!",
+			want:   []string{"SEC-CRITICAL"},
+		},
+		{
+			review: "[REQUIREMENTS] unclear spec",
+			want:   []string{"REQUIREMENTS"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.review[:min(len(tt.review), 20)], func(t *testing.T) {
+			got := parseTags(tt.review)
+			if len(got) != len(tt.want) {
+				t.Errorf("parseTags() = %v, want %v", got, tt.want)
+				return
+			}
+			// Check all expected tags are present
+			for _, want := range tt.want {
+				found := false
+				for _, g := range got {
+					if g == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("parseTags() missing tag %q, got %v", want, got)
+				}
+			}
+		})
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## Summary
- 2回目以降のレビューで軽微な変更（100行以下）の場合、Haikuモデルを使用
- `Model`型と`RunWithModel()`メソッドを`runner.go`に追加
- `selectReviewModel()`で判定ロジック実装

## Test plan
- [x] `TestModelConstants` - Model定数のテスト
- [x] `TestSelectReviewModel` - モデル選択ロジックのテスト（6ケース）
- [x] `TestParseTags` - タグパースのテスト（5ケース）
- [x] `go test ./...` 全パス

## 動作確認
\`\`\`bash
go test ./internal/agent/... ./internal/workflow/... -v
\`\`\`

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)