### PR TITLE
fix: CLIチャットで複数メンションに対応

### DIFF
--- a/cmd/maxam/chat.go
+++ b/cmd/maxam/chat.go
@@ -113,7 +113,7 @@ func (s *ChatSession) runAgentChat(agentName string) {
 
 func (s *ChatSession) runTeamChat() {
 	fmt.Println("Chat with MAXAM Team")
-	fmt.Println("Mei will coordinate. Mention others: @yuki, @rin, @shiori, @priya, @amara")
+	fmt.Println("Mei will coordinate. Mention others: @yuki, @rin, @shiori, @priya, @amara, @alex, @hana")
 	fmt.Println("Type 'exit' to quit")
 	fmt.Println(strings.Repeat("-", 50))
 
@@ -136,27 +136,35 @@ func (s *ChatSession) runTeamChat() {
 
 		s.history = append(s.history, chatMessage{role: "user", content: input})
 
-		// Detect mentioned agent or default to Mei
-		agentName := detectMention(input)
-		runner, _ := s.agents.Get(agentName)
-		fullName := getFullName(agentName)
+		// Detect all mentioned agents (returns array)
+		mentionedAgents := detectMentions(input)
 
-		prompt := s.buildPrompt(agentName, input)
+		// Call each mentioned agent sequentially
+		for _, agentName := range mentionedAgents {
+			runner, ok := s.agents.Get(agentName)
+			if !ok {
+				fmt.Printf("\n%s: (agent not configured)\n", getFullName(agentName))
+				continue
+			}
+			fullName := getFullName(agentName)
 
-		fmt.Printf("\n%s: ", fullName)
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		result, err := runner.Run(ctx, prompt)
-		cancel()
+			prompt := s.buildPrompt(agentName, input)
 
-		if err != nil {
-			fmt.Printf("(error: %v)\n", err)
-			continue
+			fmt.Printf("\n%s: ", fullName)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			result, err := runner.Run(ctx, prompt)
+			cancel()
+
+			if err != nil {
+				fmt.Printf("(error: %v)\n", err)
+				continue
+			}
+
+			result = strings.TrimSpace(result)
+			fmt.Println(result)
+
+			s.history = append(s.history, chatMessage{role: agentName, content: result})
 		}
-
-		result = strings.TrimSpace(result)
-		fmt.Println(result)
-
-		s.history = append(s.history, chatMessage{role: agentName, content: result})
 	}
 }
 
@@ -194,24 +202,41 @@ func (s *ChatSession) buildPrompt(agentName, currentInput string) string {
 	return sb.String()
 }
 
-func detectMention(text string) string {
+func detectMentions(text string) []string {
 	lower := strings.ToLower(text)
+	var agents []string
+
+	// Check each agent - order doesn't matter for multiple mentions
+	if strings.Contains(lower, "@mei") || strings.Contains(lower, "めい") {
+		agents = append(agents, "mei")
+	}
 	if strings.Contains(lower, "@yuki") || strings.Contains(lower, "ゆき") {
-		return "yuki"
+		agents = append(agents, "yuki")
 	}
 	if strings.Contains(lower, "@rin") || strings.Contains(lower, "りん") {
-		return "rin"
+		agents = append(agents, "rin")
 	}
 	if strings.Contains(lower, "@shiori") || strings.Contains(lower, "しおり") {
-		return "shiori"
+		agents = append(agents, "shiori")
 	}
 	if strings.Contains(lower, "@priya") || strings.Contains(lower, "プリヤ") {
-		return "priya"
+		agents = append(agents, "priya")
 	}
 	if strings.Contains(lower, "@amara") || strings.Contains(lower, "アマラ") {
-		return "amara"
+		agents = append(agents, "amara")
 	}
-	return "mei" // default
+	if strings.Contains(lower, "@alex") || strings.Contains(lower, "アレックス") {
+		agents = append(agents, "alex")
+	}
+	if strings.Contains(lower, "@hana") || strings.Contains(lower, "ハナ") {
+		agents = append(agents, "hana")
+	}
+
+	// Default to Mei if no mentions
+	if len(agents) == 0 {
+		return []string{"mei"}
+	}
+	return agents
 }
 
 func getFullName(agentName string) string {
@@ -228,6 +253,10 @@ func getFullName(agentName string) string {
 		return "Amara"
 	case "mei":
 		return "Mei"
+	case "alex":
+		return "Alex"
+	case "hana":
+		return "Hana"
 	default:
 		return agentName
 	}

--- a/cmd/maxam/chat_test.go
+++ b/cmd/maxam/chat_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDetectMentions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "single mention @yuki",
+			input:    "@yuki can you help?",
+			expected: []string{"yuki"},
+		},
+		{
+			name:     "single mention @mei",
+			input:    "@mei please review",
+			expected: []string{"mei"},
+		},
+		{
+			name:     "multiple mentions @alex @hana",
+			input:    "@alex @hana please introduce yourselves",
+			expected: []string{"alex", "hana"},
+		},
+		{
+			name:     "multiple mentions with other text",
+			input:    "Hey @yuki and @priya, can you review this?",
+			expected: []string{"yuki", "priya"},
+		},
+		{
+			name:     "no mentions defaults to mei",
+			input:    "Hello everyone!",
+			expected: []string{"mei"},
+		},
+		{
+			name:     "japanese name ゆき",
+			input:    "ゆきさん、お願いします",
+			expected: []string{"yuki"},
+		},
+		{
+			name:     "japanese name アレックス",
+			input:    "アレックスに聞いて",
+			expected: []string{"alex"},
+		},
+		{
+			name:     "japanese name ハナ",
+			input:    "ハナちゃんどう思う？",
+			expected: []string{"hana"},
+		},
+		{
+			name:     "all core agents",
+			input:    "@mei @yuki @rin @shiori @priya @amara",
+			expected: []string{"mei", "yuki", "rin", "shiori", "priya", "amara"},
+		},
+		{
+			name:     "new agents alex and hana",
+			input:    "@alex @hana hello!",
+			expected: []string{"alex", "hana"},
+		},
+		{
+			name:     "case insensitive",
+			input:    "@YUKI @Priya @alex",
+			expected: []string{"yuki", "priya", "alex"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectMentions(tt.input)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("detectMentions(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `detectMention` → `detectMentions` に変更（配列を返す）
- 複数エージェントへの順次呼び出しに対応（`@Alex @Hana` で両方応答）
- AlexとHanaの検出パターンとgetFullNameを追加
- テストケース11件を追加

## 変更内容
- `runTeamChat`でメンションされた全エージェントをループで呼び出し
- 未設定のエージェントは "(agent not configured)" と表示

## Test plan
- [x] `go test ./cmd/maxam/ -v -run TestDetectMentions` 通過（11ケース）
- [x] `go test ./...` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)