### PR TITLE
feat: 動的メンション検出とマルチメンション対応

### DIFF
--- a/cmd/maxam/chat.go
+++ b/cmd/maxam/chat.go
@@ -10,11 +10,13 @@ import (
 
 	"github.com/ytnobody/MAXAM/internal/agent"
 	"github.com/ytnobody/MAXAM/internal/logger"
+	"github.com/ytnobody/MAXAM/internal/member"
 )
 
 // ChatSession manages an interactive conversation with an agent
 type ChatSession struct {
 	agents  *agent.Agents
+	members *member.Members
 	logMgr  *logger.Manager
 	workDir string
 	history []chatMessage
@@ -37,6 +39,7 @@ func runChat() {
 
 	session := &ChatSession{
 		agents:  agent.NewAgents(workDir),
+		members: member.NewMembers(workDir),
 		logMgr:  logger.NewManager(logger.GetDefaultLogDir(), workDir),
 		workDir: workDir,
 		history: make([]chatMessage, 0),
@@ -57,7 +60,7 @@ func (s *ChatSession) runAgentChat(agentName string) {
 		os.Exit(1)
 	}
 
-	fullName := getFullName(agentName)
+	fullName := s.members.GetFullName(agentName)
 	fmt.Printf("Chat with %s\n", fullName)
 	fmt.Println("Type 'exit' to quit, 'clear' to reset conversation")
 	fmt.Println(strings.Repeat("-", 50))
@@ -113,7 +116,8 @@ func (s *ChatSession) runAgentChat(agentName string) {
 
 func (s *ChatSession) runTeamChat() {
 	fmt.Println("Chat with MAXAM Team")
-	fmt.Println("Mei will coordinate. Mention others: @yuki, @rin, @shiori, @priya, @amara")
+	fmt.Println("Mention members with @name. Example: @yuki, @priya")
+	fmt.Println("Default: Mei will respond if no mention.")
 	fmt.Println("Type 'exit' to quit")
 	fmt.Println(strings.Repeat("-", 50))
 
@@ -136,27 +140,39 @@ func (s *ChatSession) runTeamChat() {
 
 		s.history = append(s.history, chatMessage{role: "user", content: input})
 
-		// Detect mentioned agent or default to Mei
-		agentName := detectMention(input)
-		runner, _ := s.agents.Get(agentName)
-		fullName := getFullName(agentName)
-
-		prompt := s.buildPrompt(agentName, input)
-
-		fmt.Printf("\n%s: ", fullName)
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		result, err := runner.Run(ctx, prompt)
-		cancel()
-
-		if err != nil {
-			fmt.Printf("(error: %v)\n", err)
-			continue
+		// Detect all mentioned agents
+		mentioned := s.members.DetectMentions(input)
+		if len(mentioned) == 0 {
+			// Default to Mei if no one is mentioned
+			mentioned = []string{"mei"}
 		}
 
-		result = strings.TrimSpace(result)
-		fmt.Println(result)
+		// Call each mentioned agent in order
+		for _, agentName := range mentioned {
+			runner, ok := s.agents.Get(agentName)
+			if !ok {
+				fmt.Printf("\n(%s is not available)\n", agentName)
+				continue
+			}
 
-		s.history = append(s.history, chatMessage{role: agentName, content: result})
+			fullName := s.members.GetFullName(agentName)
+			prompt := s.buildPrompt(agentName, input)
+
+			fmt.Printf("\n%s: ", fullName)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			result, err := runner.Run(ctx, prompt)
+			cancel()
+
+			if err != nil {
+				fmt.Printf("(error: %v)\n", err)
+				continue
+			}
+
+			result = strings.TrimSpace(result)
+			fmt.Println(result)
+
+			s.history = append(s.history, chatMessage{role: agentName, content: result})
+		}
 	}
 }
 
@@ -182,7 +198,7 @@ func (s *ChatSession) buildPrompt(agentName, currentInput string) string {
 			if msg.role == "user" {
 				sb.WriteString(fmt.Sprintf("ユーザー: %s\n\n", msg.content))
 			} else {
-				sb.WriteString(fmt.Sprintf("%s: %s\n\n", getFullName(msg.role), msg.content))
+				sb.WriteString(fmt.Sprintf("%s: %s\n\n", s.members.GetFullName(msg.role), msg.content))
 			}
 		}
 	}
@@ -192,43 +208,4 @@ func (s *ChatSession) buildPrompt(agentName, currentInput string) string {
 	sb.WriteString("あなたの返答:")
 
 	return sb.String()
-}
-
-func detectMention(text string) string {
-	lower := strings.ToLower(text)
-	if strings.Contains(lower, "@yuki") || strings.Contains(lower, "ゆき") {
-		return "yuki"
-	}
-	if strings.Contains(lower, "@rin") || strings.Contains(lower, "りん") {
-		return "rin"
-	}
-	if strings.Contains(lower, "@shiori") || strings.Contains(lower, "しおり") {
-		return "shiori"
-	}
-	if strings.Contains(lower, "@priya") || strings.Contains(lower, "プリヤ") {
-		return "priya"
-	}
-	if strings.Contains(lower, "@amara") || strings.Contains(lower, "アマラ") {
-		return "amara"
-	}
-	return "mei" // default
-}
-
-func getFullName(agentName string) string {
-	switch agentName {
-	case "yuki":
-		return "Yuki"
-	case "rin":
-		return "Rin"
-	case "shiori":
-		return "Shiori"
-	case "priya":
-		return "Priya"
-	case "amara":
-		return "Amara"
-	case "mei":
-		return "Mei"
-	default:
-		return agentName
-	}
 }

--- a/internal/member/member.go
+++ b/internal/member/member.go
@@ -1,0 +1,170 @@
+// Package member extracts team members from CLAUDE.md
+package member
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/ytnobody/MAXAM/internal/config"
+)
+
+// Member represents a team member
+type Member struct {
+	Name     string // Short name (e.g., "yuki")
+	FullName string // Full name (e.g., "Yuki Tanaka")
+	Role     string // Role description
+}
+
+// Members holds all team members
+type Members struct {
+	members map[string]*Member // key: lowercase short name
+}
+
+// NewMembers creates a Members instance from config and CLAUDE.md
+func NewMembers(workDir string) *Members {
+	m := &Members{
+		members: make(map[string]*Member),
+	}
+
+	// 1. Load from config (base)
+	cfg, err := config.Load()
+	if err != nil {
+		cfg = config.DefaultConfig()
+	}
+	for _, ac := range cfg.Agents {
+		m.members[strings.ToLower(ac.Name)] = &Member{
+			Name:     ac.Name,
+			FullName: ac.FullName,
+			Role:     ac.Role,
+		}
+	}
+
+	// 2. Parse CLAUDE.md and merge (CLAUDE.md can add new members)
+	claudeMDPath := filepath.Join(workDir, "CLAUDE.md")
+	if data, err := os.ReadFile(claudeMDPath); err == nil {
+		parsed := ParseMemberTable(string(data))
+		for _, pm := range parsed {
+			key := strings.ToLower(pm.Name)
+			if _, exists := m.members[key]; !exists {
+				// New member from CLAUDE.md
+				m.members[key] = pm
+			}
+			// Note: config.yaml takes priority, so we don't overwrite existing
+		}
+	}
+
+	return m
+}
+
+// Get returns a member by name (case-insensitive)
+func (m *Members) Get(name string) (*Member, bool) {
+	member, ok := m.members[strings.ToLower(name)]
+	return member, ok
+}
+
+// All returns all members
+func (m *Members) All() []*Member {
+	result := make([]*Member, 0, len(m.members))
+	for _, member := range m.members {
+		result = append(result, member)
+	}
+	return result
+}
+
+// Names returns all member names (short names, lowercase)
+func (m *Members) Names() []string {
+	result := make([]string, 0, len(m.members))
+	for name := range m.members {
+		result = append(result, name)
+	}
+	return result
+}
+
+// ParseMemberTable extracts members from CLAUDE.md table format
+// Expects format:
+// | Name | Role |
+// |------|------|
+// | Mei Chen | PM |
+func ParseMemberTable(content string) []*Member {
+	var result []*Member
+
+	lines := strings.Split(content, "\n")
+	inTable := false
+	headerPassed := false
+
+	// Match table rows: | content | content | ...
+	tableRowRe := regexp.MustCompile(`^\s*\|(.+)\|\s*$`)
+	// Match separator: |---|---|
+	separatorRe := regexp.MustCompile(`^\s*\|[-:\s|]+\|\s*$`)
+
+	for _, line := range lines {
+		// Check for table row
+		if match := tableRowRe.FindStringSubmatch(line); match != nil {
+			// Check if it's a separator line
+			if separatorRe.MatchString(line) {
+				if inTable {
+					headerPassed = true
+				}
+				continue
+			}
+
+			// Split by |
+			cells := strings.Split(match[1], "|")
+			if len(cells) < 2 {
+				continue
+			}
+
+			name := strings.TrimSpace(cells[0])
+			role := strings.TrimSpace(cells[1])
+
+			// Skip header row (usually "Name" or "名前")
+			if !inTable {
+				if isHeaderCell(name) {
+					inTable = true
+					continue
+				}
+			}
+
+			if !headerPassed {
+				continue
+			}
+
+			// Extract short name from full name
+			shortName := extractShortName(name)
+			if shortName == "" {
+				continue
+			}
+
+			result = append(result, &Member{
+				Name:     shortName,
+				FullName: name,
+				Role:     role,
+			})
+		} else if inTable {
+			// Non-table line after we were in table = table ended
+			break
+		}
+	}
+
+	return result
+}
+
+// isHeaderCell checks if a cell looks like a header
+func isHeaderCell(cell string) bool {
+	lower := strings.ToLower(cell)
+	return lower == "name" || lower == "名前" || lower == "member" || lower == "メンバー"
+}
+
+// extractShortName extracts a short name from full name
+// "Mei Chen" -> "mei"
+// "Yuki Tanaka" -> "yuki"
+func extractShortName(fullName string) string {
+	parts := strings.Fields(fullName)
+	if len(parts) == 0 {
+		return ""
+	}
+	// Use first name as short name
+	return strings.ToLower(parts[0])
+}

--- a/internal/member/member_test.go
+++ b/internal/member/member_test.go
@@ -1,0 +1,146 @@
+package member
+
+import (
+	"testing"
+)
+
+func TestParseMemberTable(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected []struct {
+			shortName string
+			fullName  string
+			role      string
+		}
+	}{
+		{
+			name: "standard table",
+			content: `# Team
+
+| Name | Role |
+|------|------|
+| Mei Chen | PM |
+| Yuki Tanaka | Backend |
+`,
+			expected: []struct {
+				shortName string
+				fullName  string
+				role      string
+			}{
+				{"mei", "Mei Chen", "PM"},
+				{"yuki", "Yuki Tanaka", "Backend"},
+			},
+		},
+		{
+			name: "japanese header",
+			content: `## チームメンバー
+
+| 名前 | 役割 |
+|------|------|
+| Alex Johnson | Frontend |
+| Hana Kim | Designer |
+`,
+			expected: []struct {
+				shortName string
+				fullName  string
+				role      string
+			}{
+				{"alex", "Alex Johnson", "Frontend"},
+				{"hana", "Hana Kim", "Designer"},
+			},
+		},
+		{
+			name: "with extra columns",
+			content: `| Name | Role | Notes |
+|------|------|-------|
+| Priya Sharma | QA | Expert |
+`,
+			expected: []struct {
+				shortName string
+				fullName  string
+				role      string
+			}{
+				{"priya", "Priya Sharma", "QA"},
+			},
+		},
+		{
+			name: "no table",
+			content: `# Just some markdown
+No table here.
+`,
+			expected: nil,
+		},
+		{
+			name: "MAXAM style table",
+			content: `## チームメンバー
+
+| 名前 | 役割 |
+|------|------|
+| Mei Chen | 要件定義 + PM |
+| Yuki Tanaka | バックエンド + インフラ |
+| Rin Sato | フロントエンド + バックエンド |
+| Shiori Tanaka | テスト + ドキュメント |
+| Priya Sharma | レビュー + セキュリティ + QA |
+| Amara Okonkwo | 分析 + 法的基礎知識 |
+`,
+			expected: []struct {
+				shortName string
+				fullName  string
+				role      string
+			}{
+				{"mei", "Mei Chen", "要件定義 + PM"},
+				{"yuki", "Yuki Tanaka", "バックエンド + インフラ"},
+				{"rin", "Rin Sato", "フロントエンド + バックエンド"},
+				{"shiori", "Shiori Tanaka", "テスト + ドキュメント"},
+				{"priya", "Priya Sharma", "レビュー + セキュリティ + QA"},
+				{"amara", "Amara Okonkwo", "分析 + 法的基礎知識"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseMemberTable(tt.content)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("got %d members, want %d", len(result), len(tt.expected))
+				return
+			}
+
+			for i, exp := range tt.expected {
+				if result[i].Name != exp.shortName {
+					t.Errorf("member[%d].Name = %q, want %q", i, result[i].Name, exp.shortName)
+				}
+				if result[i].FullName != exp.fullName {
+					t.Errorf("member[%d].FullName = %q, want %q", i, result[i].FullName, exp.fullName)
+				}
+				if result[i].Role != exp.role {
+					t.Errorf("member[%d].Role = %q, want %q", i, result[i].Role, exp.role)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractShortName(t *testing.T) {
+	tests := []struct {
+		fullName  string
+		shortName string
+	}{
+		{"Mei Chen", "mei"},
+		{"Yuki Tanaka", "yuki"},
+		{"Alex", "alex"},
+		{"", ""},
+		{"  Priya  Sharma  ", "priya"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fullName, func(t *testing.T) {
+			got := extractShortName(tt.fullName)
+			if got != tt.shortName {
+				t.Errorf("extractShortName(%q) = %q, want %q", tt.fullName, got, tt.shortName)
+			}
+		})
+	}
+}

--- a/internal/member/mention.go
+++ b/internal/member/mention.go
@@ -1,0 +1,49 @@
+package member
+
+import (
+	"strings"
+)
+
+// DetectMentions extracts all mentioned member names from text
+// Returns lowercase short names of mentioned members
+func (m *Members) DetectMentions(text string) []string {
+	lower := strings.ToLower(text)
+	var mentioned []string
+	seen := make(map[string]bool)
+
+	for name := range m.members {
+		// Check @mention pattern
+		pattern := "@" + name
+		if strings.Contains(lower, pattern) {
+			if !seen[name] {
+				mentioned = append(mentioned, name)
+				seen[name] = true
+			}
+		}
+	}
+
+	// If no explicit mentions, return nil (caller should use default)
+	return mentioned
+}
+
+// DetectMention returns the first mentioned member, or default if none
+// Kept for backward compatibility
+func (m *Members) DetectMention(text string, defaultMember string) string {
+	mentions := m.DetectMentions(text)
+	if len(mentions) == 0 {
+		return defaultMember
+	}
+	return mentions[0]
+}
+
+// GetFullName returns the full name for a short name
+func (m *Members) GetFullName(shortName string) string {
+	if member, ok := m.Get(shortName); ok {
+		return member.FullName
+	}
+	// Return capitalized version as fallback
+	if len(shortName) > 0 {
+		return strings.ToUpper(shortName[:1]) + shortName[1:]
+	}
+	return shortName
+}

--- a/internal/member/mention_test.go
+++ b/internal/member/mention_test.go
@@ -1,0 +1,147 @@
+package member
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestDetectMentions(t *testing.T) {
+	// Create members with test data
+	m := &Members{
+		members: map[string]*Member{
+			"mei":    {Name: "mei", FullName: "Mei Chen", Role: "PM"},
+			"yuki":   {Name: "yuki", FullName: "Yuki Tanaka", Role: "Backend"},
+			"priya":  {Name: "priya", FullName: "Priya Sharma", Role: "QA"},
+			"alex":   {Name: "alex", FullName: "Alex Johnson", Role: "Frontend"},
+			"hana":   {Name: "hana", FullName: "Hana Kim", Role: "Designer"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		text     string
+		expected []string
+	}{
+		{
+			name:     "single mention",
+			text:     "Hey @yuki, can you check this?",
+			expected: []string{"yuki"},
+		},
+		{
+			name:     "multiple mentions",
+			text:     "@alex @hana please collaborate on this",
+			expected: []string{"alex", "hana"},
+		},
+		{
+			name:     "no mentions",
+			text:     "Just a regular message",
+			expected: nil,
+		},
+		{
+			name:     "case insensitive",
+			text:     "@YUKI @Priya hello",
+			expected: []string{"yuki", "priya"},
+		},
+		{
+			name:     "duplicate mentions",
+			text:     "@yuki please @yuki can you help",
+			expected: []string{"yuki"},
+		},
+		{
+			name:     "mention in sentence",
+			text:     "I think @mei should review this",
+			expected: []string{"mei"},
+		},
+		{
+			name:     "three mentions",
+			text:     "@yuki @priya @alex all hands meeting",
+			expected: []string{"alex", "priya", "yuki"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := m.DetectMentions(tt.text)
+
+			// Sort for comparison
+			sort.Strings(result)
+			sort.Strings(tt.expected)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("got %v, want %v", result, tt.expected)
+				return
+			}
+
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("got %v, want %v", result, tt.expected)
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestDetectMention(t *testing.T) {
+	m := &Members{
+		members: map[string]*Member{
+			"mei":  {Name: "mei", FullName: "Mei Chen", Role: "PM"},
+			"yuki": {Name: "yuki", FullName: "Yuki Tanaka", Role: "Backend"},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		text    string
+		def     string
+		want    string
+	}{
+		{
+			name: "with mention",
+			text: "@yuki check this",
+			def:  "mei",
+			want: "yuki",
+		},
+		{
+			name: "no mention uses default",
+			text: "hello everyone",
+			def:  "mei",
+			want: "mei",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := m.DetectMention(tt.text, tt.def)
+			if got != tt.want {
+				t.Errorf("DetectMention() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetFullName(t *testing.T) {
+	m := &Members{
+		members: map[string]*Member{
+			"yuki": {Name: "yuki", FullName: "Yuki Tanaka", Role: "Backend"},
+		},
+	}
+
+	tests := []struct {
+		shortName string
+		want      string
+	}{
+		{"yuki", "Yuki Tanaka"},
+		{"unknown", "Unknown"}, // fallback to capitalized
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.shortName, func(t *testing.T) {
+			got := m.GetFullName(tt.shortName)
+			if got != tt.want {
+				t.Errorf("GetFullName(%q) = %q, want %q", tt.shortName, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- CLAUDE.mdからチームメンバー表を動的にパースする `internal/member` パッケージを追加
- `@alex @hana` のように複数メンション時、全員が順次応答するよう改修
- ハードコードされていた `detectMention` / `getFullName` を廃止し、動的なメンバー管理に移行

## 変更内容

### 新規ファイル
- `internal/member/member.go` - メンバー管理とCLAUDE.mdパース
- `internal/member/mention.go` - メンション検出ロジック
- `internal/member/member_test.go` - パーステスト (5ケース)
- `internal/member/mention_test.go` - メンション検出テスト (10ケース)

### 修正ファイル
- `cmd/maxam/chat.go` - memberパッケージを使用するよう改修

## Test plan

- [x] `go test ./internal/member/...` 全テスト通過
- [x] `go build ./...` ビルド成功
- [ ] `maxam chat team` で複数メンション動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)