### PR TITLE
refactor: CLAUDE.mdを配布用に汎用化、開発用設定を分離

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,26 @@ type: feat, fix, refactor, docs, test, chore
 | `/tmp/maxam/{agent}/{project}/` | 各エージェント用worktree（単独リポジトリ） |
 | `/tmp/maxam/{agent}/{parent}_{child}/` | 各エージェント用worktree（ネストしたリポジトリ） |
 
+**例：単独プロジェクト**
+```
+/tmp/maxam/agent1/project/      # ~/projectで作業
+/tmp/maxam/agent2/project/      # agent2のproject作業
+```
+
+**例：ネストしたサブプロジェクト（親ディレクトリ配下に複数リポジトリ）**
+```
+~/parent/                       # 親ディレクトリ（gitリポジトリではない）
+├── repo1/                      # リポジトリ1
+├── repo2/                      # リポジトリ2
+└── repo3/                      # リポジトリ3
+
+↓ worktreeパス（_で連結）
+
+/tmp/maxam/agent1/parent_repo1/    # parent/repo1
+/tmp/maxam/agent1/parent_repo2/    # parent/repo2
+/tmp/maxam/agent1/parent_repo3/    # parent/repo3
+```
+
 ### 運用ルール
 
 1. **作業開始時**: worktreeが存在しなければ作成
@@ -173,7 +193,7 @@ type: feat, fix, refactor, docs, test, chore
 - PMは元リポジトリで要件定義・ドキュメント作業
 - 他メンバーは自分のworktreeで独立して作業可能
 - 衝突を気にせず並列作業できる
-- `/tmp/maxam/` 配下はMAXAMチーム共通の作業場所として、複数プロジェクトを管理
+- `/tmp/maxam/` 配下はチーム共通の作業場所として、複数プロジェクトを管理
 - **サブプロジェクト対応**: 親ディレクトリ配下のgitリポジトリを再帰的に検出し、コンテキストに含める
 
 ## 分析サイクル（イベント駆動）


### PR DESCRIPTION
## Summary
- CLAUDE.mdから開発チーム固有の情報を分離し、配布可能な汎用ファイルに変更
- チーム固有情報は `CLAUDE.local.md` で管理（`.gitignore`に追加済み）
- チームメンバー情報と学習事項のテンプレートのみCLAUDE.mdに残す

## Changes
- `.gitignore`: `CLAUDE.local.md`を追加
- `CLAUDE.md`: 汎用化（-238行、+33行）

## Test plan
- [ ] `CLAUDE.md`が汎用的な内容のみになっていることを確認
- [ ] `CLAUDE.local.md`が`.gitignore`に含まれていることを確認

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)