### PR TITLE
feat: maxam team サブコマンドの実装

### DIFF
--- a/cmd/maxam/main.go
+++ b/cmd/maxam/main.go
@@ -24,6 +24,8 @@ func main() {
 	switch cmd {
 	case "task":
 		runTaskLegacy()
+	case "team":
+		runTeam()
 	case "review":
 		runReview()
 	case "ask":
@@ -58,6 +60,10 @@ Commands:
   task list            List all tasks on the taskboard
   task delete <id>     Delete a task by ID
   task status <id> <s> Change task status (pending/in_progress/completed)
+  team init            Initialize team configuration interactively
+  team add <n> <role>  Add a team member
+  team list            List team members
+  team remove <name>   Remove a team member
   review <description> Run a full review cycle (Yuki → Priya)
   ask <agent> <prompt> Ask a specific agent a question
   analyze              Run Amara's weekly analysis

--- a/cmd/maxam/team.go
+++ b/cmd/maxam/team.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ytnobody/MAXAM/internal/config"
+)
+
+// runTeam handles the "team" subcommand
+func runTeam() {
+	if len(os.Args) < 3 {
+		printTeamUsage()
+		os.Exit(1)
+	}
+
+	subCmd := os.Args[2]
+
+	switch subCmd {
+	case "init":
+		runTeamInit()
+	case "add":
+		runTeamAdd()
+	case "list":
+		runTeamList()
+	case "remove", "rm":
+		runTeamRemove()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown team command: %s\n", subCmd)
+		printTeamUsage()
+		os.Exit(1)
+	}
+}
+
+func printTeamUsage() {
+	fmt.Println(`Usage: maxam team <command> [arguments]
+
+Commands:
+  init                     Initialize team configuration interactively
+  add <name> <role>        Add a new team member
+  list                     List current team members
+  remove <name>            Remove a team member (alias: rm)
+
+Examples:
+  maxam team init
+  maxam team add koji "Frontend / Backend"
+  maxam team list
+  maxam team remove koji`)
+}
+
+func runTeamInit() {
+	workDir := getWorkDir()
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Println("MAXAM Team Configuration")
+	fmt.Println("========================")
+	fmt.Println()
+	fmt.Println("Add team members interactively.")
+	fmt.Println("Enter member details, or press Enter with empty name to finish.")
+	fmt.Println()
+
+	var agents []config.AgentConfig
+
+	for {
+		fmt.Print("Name (e.g., koji): ")
+		name, _ := reader.ReadString('\n')
+		name = strings.TrimSpace(name)
+
+		if name == "" {
+			break
+		}
+
+		fmt.Print("Full name (e.g., Koji Yamamoto): ")
+		fullName, _ := reader.ReadString('\n')
+		fullName = strings.TrimSpace(fullName)
+		if fullName == "" {
+			fullName = name
+		}
+
+		fmt.Print("Role (e.g., Backend / Frontend): ")
+		role, _ := reader.ReadString('\n')
+		role = strings.TrimSpace(role)
+
+		agents = append(agents, config.AgentConfig{
+			Name:     strings.ToLower(name),
+			FullName: fullName,
+			Role:     role,
+		})
+
+		fmt.Printf("  Added: %s (%s) - %s\n\n", name, fullName, role)
+	}
+
+	if len(agents) == 0 {
+		fmt.Println("No members added. Exiting.")
+		return
+	}
+
+	// Load existing project config or create new
+	cfg, err := config.LoadProjectConfig(workDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Set default agent if not set
+	if cfg.DefaultAgent == "" && len(agents) > 0 {
+		cfg.DefaultAgent = agents[0].Name
+	}
+
+	cfg.Agents = agents
+
+	if err := config.SaveToProject(workDir, cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println()
+	fmt.Printf("Team configuration saved to: %s\n", config.ProjectConfigDir(workDir)+"/config.yaml")
+	fmt.Printf("Default agent: %s\n", cfg.DefaultAgent)
+	fmt.Printf("Team size: %d members\n", len(agents))
+}
+
+func runTeamAdd() {
+	if len(os.Args) < 5 {
+		fmt.Fprintln(os.Stderr, "Usage: maxam team add <name> <role>")
+		fmt.Fprintln(os.Stderr, "Example: maxam team add koji \"Frontend / Backend\"")
+		os.Exit(1)
+	}
+
+	name := strings.ToLower(os.Args[3])
+	role := os.Args[4]
+
+	// Parse optional full name
+	fullName := name
+	for i := 5; i < len(os.Args); i++ {
+		if os.Args[i] == "--full-name" && i+1 < len(os.Args) {
+			fullName = os.Args[i+1]
+			break
+		}
+	}
+
+	workDir := getWorkDir()
+
+	cfg, err := config.LoadProjectConfig(workDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Check if already exists
+	for _, a := range cfg.Agents {
+		if a.Name == name {
+			fmt.Fprintf(os.Stderr, "Member '%s' already exists\n", name)
+			os.Exit(1)
+		}
+	}
+
+	cfg.Agents = append(cfg.Agents, config.AgentConfig{
+		Name:     name,
+		FullName: fullName,
+		Role:     role,
+	})
+
+	// Set default if first member
+	if cfg.DefaultAgent == "" {
+		cfg.DefaultAgent = name
+	}
+
+	if err := config.SaveToProject(workDir, cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Added: %s (%s)\n", name, role)
+	fmt.Printf("Config: %s\n", config.ProjectConfigDir(workDir)+"/config.yaml")
+}
+
+func runTeamList() {
+	workDir := getWorkDir()
+
+	cfg, err := config.LoadProjectConfig(workDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(cfg.Agents) == 0 {
+		fmt.Println("No team members configured.")
+		fmt.Println("Use 'maxam team init' or 'maxam team add' to add members.")
+		return
+	}
+
+	fmt.Println("Team Members:")
+	fmt.Println()
+	for _, a := range cfg.Agents {
+		defaultMark := ""
+		if a.Name == cfg.DefaultAgent {
+			defaultMark = " (default)"
+		}
+		fmt.Printf("  @%-12s %-20s %s%s\n", a.Name, a.FullName, a.Role, defaultMark)
+	}
+	fmt.Println()
+	fmt.Printf("Config: %s\n", config.ProjectConfigDir(workDir)+"/config.yaml")
+}
+
+func runTeamRemove() {
+	if len(os.Args) < 4 {
+		fmt.Fprintln(os.Stderr, "Usage: maxam team remove <name>")
+		os.Exit(1)
+	}
+
+	name := strings.ToLower(os.Args[3])
+	workDir := getWorkDir()
+
+	cfg, err := config.LoadProjectConfig(workDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	found := false
+	var newAgents []config.AgentConfig
+	for _, a := range cfg.Agents {
+		if a.Name == name {
+			found = true
+		} else {
+			newAgents = append(newAgents, a)
+		}
+	}
+
+	if !found {
+		fmt.Fprintf(os.Stderr, "Member '%s' not found\n", name)
+		os.Exit(1)
+	}
+
+	cfg.Agents = newAgents
+
+	// Update default if removed
+	if cfg.DefaultAgent == name {
+		if len(newAgents) > 0 {
+			cfg.DefaultAgent = newAgents[0].Name
+		} else {
+			cfg.DefaultAgent = ""
+		}
+	}
+
+	if err := config.SaveToProject(workDir, cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Removed: %s\n", name)
+}

--- a/cmd/maxam/team_test.go
+++ b/cmd/maxam/team_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ytnobody/MAXAM/internal/config"
+)
+
+func TestTeamAdd(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "maxam-team-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Change to temp dir
+	oldDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+	defer os.Chdir(oldDir)
+
+	// Test adding a member
+	cfg := &config.Config{
+		Version: "1",
+		Agents: []config.AgentConfig{
+			{Name: "koji", FullName: "Koji Yamamoto", Role: "Backend"},
+		},
+		DefaultAgent: "koji",
+	}
+
+	if err := config.SaveToProject(tmpDir, cfg); err != nil {
+		t.Fatalf("Failed to save config: %v", err)
+	}
+
+	// Verify config was saved
+	loadedCfg, err := config.LoadProjectConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if len(loadedCfg.Agents) != 1 {
+		t.Errorf("Expected 1 agent, got %d", len(loadedCfg.Agents))
+	}
+
+	if loadedCfg.Agents[0].Name != "koji" {
+		t.Errorf("Expected agent name 'koji', got '%s'", loadedCfg.Agents[0].Name)
+	}
+
+	if loadedCfg.DefaultAgent != "koji" {
+		t.Errorf("Expected default agent 'koji', got '%s'", loadedCfg.DefaultAgent)
+	}
+}
+
+func TestTeamRemove(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "maxam-team-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Setup initial config with 2 members
+	cfg := &config.Config{
+		Version: "1",
+		Agents: []config.AgentConfig{
+			{Name: "koji", FullName: "Koji Yamamoto", Role: "Backend"},
+			{Name: "yuki", FullName: "Yuki Tanaka", Role: "Frontend"},
+		},
+		DefaultAgent: "koji",
+	}
+
+	if err := config.SaveToProject(tmpDir, cfg); err != nil {
+		t.Fatalf("Failed to save config: %v", err)
+	}
+
+	// Simulate removing koji
+	loadedCfg, err := config.LoadProjectConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	// Remove koji
+	var newAgents []config.AgentConfig
+	for _, a := range loadedCfg.Agents {
+		if a.Name != "koji" {
+			newAgents = append(newAgents, a)
+		}
+	}
+	loadedCfg.Agents = newAgents
+
+	// Update default if removed
+	if loadedCfg.DefaultAgent == "koji" && len(newAgents) > 0 {
+		loadedCfg.DefaultAgent = newAgents[0].Name
+	}
+
+	if err := config.SaveToProject(tmpDir, loadedCfg); err != nil {
+		t.Fatalf("Failed to save config: %v", err)
+	}
+
+	// Verify
+	finalCfg, err := config.LoadProjectConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if len(finalCfg.Agents) != 1 {
+		t.Errorf("Expected 1 agent after removal, got %d", len(finalCfg.Agents))
+	}
+
+	if finalCfg.Agents[0].Name != "yuki" {
+		t.Errorf("Expected remaining agent 'yuki', got '%s'", finalCfg.Agents[0].Name)
+	}
+
+	if finalCfg.DefaultAgent != "yuki" {
+		t.Errorf("Expected default agent updated to 'yuki', got '%s'", finalCfg.DefaultAgent)
+	}
+}
+
+func TestConfigSaveToProject(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "maxam-config-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cfg := &config.Config{
+		Version:      "1",
+		DefaultAgent: "test",
+		Agents: []config.AgentConfig{
+			{Name: "test", FullName: "Test User", Role: "Testing"},
+		},
+	}
+
+	if err := config.SaveToProject(tmpDir, cfg); err != nil {
+		t.Fatalf("SaveToProject failed: %v", err)
+	}
+
+	// Verify file exists
+	configPath := filepath.Join(tmpDir, ".maxam", "config.yaml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Errorf("Config file was not created at %s", configPath)
+	}
+
+	// Verify content
+	loadedCfg, err := config.LoadProjectConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig failed: %v", err)
+	}
+
+	if loadedCfg.Version != "1" {
+		t.Errorf("Expected version '1', got '%s'", loadedCfg.Version)
+	}
+
+	if loadedCfg.DefaultAgent != "test" {
+		t.Errorf("Expected default agent 'test', got '%s'", loadedCfg.DefaultAgent)
+	}
+}
+
+func TestLoadProjectConfigNotExist(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "maxam-config-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Should return empty config when file doesn't exist
+	cfg, err := config.LoadProjectConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig failed: %v", err)
+	}
+
+	if cfg.Version != "1" {
+		t.Errorf("Expected version '1' for new config, got '%s'", cfg.Version)
+	}
+
+	if len(cfg.Agents) != 0 {
+		t.Errorf("Expected 0 agents for new config, got %d", len(cfg.Agents))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -241,3 +241,43 @@ func Save(cfg *Config) error {
 
 	return nil
 }
+
+// SaveToProject writes configuration to project/.maxam/config.yaml
+func SaveToProject(projectDir string, cfg *Config) error {
+	configDir := ProjectConfigDir(projectDir)
+
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("create project config dir: %w", err)
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		return fmt.Errorf("write project config: %w", err)
+	}
+
+	return nil
+}
+
+// LoadProjectConfig loads only the project-local config (not merged)
+func LoadProjectConfig(projectDir string) (*Config, error) {
+	projectConfigPath := filepath.Join(ProjectConfigDir(projectDir), "config.yaml")
+	data, err := os.ReadFile(projectConfigPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Config{Version: "1"}, nil
+		}
+		return nil, fmt.Errorf("read project config: %w", err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse project config: %w", err)
+	}
+
+	return &cfg, nil
+}


### PR DESCRIPTION
## Summary
- `maxam team init` - 対話的にチーム構成
- `maxam team add <name> <role>` - メンバー追加
- `maxam team list` - 現在のチーム表示
- `maxam team remove <name>` - メンバー削除

## 技術詳細
- `config.SaveToProject()` / `config.LoadProjectConfig()` 追加
- プロジェクトローカルの `.maxam/config.yaml` に保存
- テスト4ケース追加

## Test plan
- [x] `go test ./...` 全テスト通過
- [x] `maxam team add` → `maxam team list` で確認
- [x] `maxam team remove` → default agent更新確認

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)