### PR TITLE
feat: エージェントの色設定を設定ファイルで管理

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -124,6 +124,7 @@ type tuiModel struct {
 	history        *history.History
 	workDir        string
 	projectContext string
+	config         *config.Config // config for agent colors
 
 	viewport          viewport.Model
 	textInput         textinput.Model
@@ -235,7 +236,7 @@ func initialTuiModel(workDir string) tuiModel {
 	ccClient := ccusage.NewClient()
 
 	// Setup agent router
-	cfg, err := config.Load()
+	cfg, err := config.LoadWithProject(workDir)
 	if err != nil {
 		cfg = config.DefaultConfig()
 	}
@@ -259,6 +260,7 @@ func initialTuiModel(workDir string) tuiModel {
 		logMgr:              logger.NewManager(logger.GetDefaultLogDir(), workDir),
 		history:             hist,
 		workDir:             workDir,
+		config:              cfg,
 		textInput:           ti,
 		messages:            messages,
 		inputHist:           make([]string, 0),
@@ -813,7 +815,7 @@ func (m *tuiModel) updateViewport() {
 			sb.WriteString(userStyle.Render("You: "))
 			sb.WriteString(msg.content)
 		} else {
-			style := getAgentStyle(msg.role)
+			style := m.getAgentStyle(msg.role)
 			sb.WriteString(style.Render(getTuiFullName(msg.role) + ": "))
 			sb.WriteString(msg.content)
 		}
@@ -1172,7 +1174,18 @@ func getTuiFullName(name string) string {
 	}
 }
 
-func getAgentStyle(name string) lipgloss.Style {
+// getAgentStyle returns the style for an agent based on config color
+func (m *tuiModel) getAgentStyle(name string) lipgloss.Style {
+	// Try to get color from config
+	if m.config != nil {
+		if color := m.config.GetAgentColor(name); color != "" {
+			return lipgloss.NewStyle().
+				Foreground(lipgloss.Color(color)).
+				Bold(true)
+		}
+	}
+
+	// Fallback to hardcoded colors for backwards compatibility
 	switch name {
 	case "mei":
 		return meiStyle

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type AgentConfig struct {
 	FullName string `yaml:"full_name"`
 	Role     string `yaml:"role"`
 	Model    string `yaml:"model,omitempty"` // opus, sonnet, haiku
+	Color    string `yaml:"color,omitempty"` // hex color code (e.g., "#FF9933")
 }
 
 // DefaultAnalysisMinMessages is the default minimum message count for analysis
@@ -280,4 +281,15 @@ func LoadProjectConfig(projectDir string) (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+// GetAgentColor returns the color for the specified agent
+// Returns empty string if not found or not set
+func (c *Config) GetAgentColor(name string) string {
+	for _, agent := range c.Agents {
+		if agent.Name == name {
+			return agent.Color
+		}
+	}
+	return ""
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -575,3 +575,81 @@ func TestGetAgentDirWithProject(t *testing.T) {
 		t.Errorf("GetAgentDirWithProject(yuki) = %q, want %q", dir, projectAgentDir)
 	}
 }
+
+func TestAgentConfigColor(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   AgentConfig
+		hasColor bool
+		color    string
+	}{
+		{
+			name:     "色未指定",
+			config:   AgentConfig{Name: "test", FullName: "Test Agent", Role: "test"},
+			hasColor: false,
+		},
+		{
+			name:     "色指定あり",
+			config:   AgentConfig{Name: "test", FullName: "Test Agent", Role: "test", Color: "#FF9933"},
+			hasColor: true,
+			color:    "#FF9933",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.hasColor && tt.config.Color != tt.color {
+				t.Errorf("Color = %q, want %q", tt.config.Color, tt.color)
+			}
+			if !tt.hasColor && tt.config.Color != "" {
+				t.Error("Expected color to be empty")
+			}
+		})
+	}
+}
+
+func TestGetAgentColor(t *testing.T) {
+	cfg := &Config{
+		Agents: []AgentConfig{
+			{Name: "mei", Color: "#FFB7C5"},
+			{Name: "yuki", Color: "#87CEEB"},
+			{Name: "priya", Color: ""},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		agent    string
+		expected string
+	}{
+		{
+			name:     "色が設定されているエージェント",
+			agent:    "mei",
+			expected: "#FFB7C5",
+		},
+		{
+			name:     "別の色が設定されているエージェント",
+			agent:    "yuki",
+			expected: "#87CEEB",
+		},
+		{
+			name:     "色が空のエージェント",
+			agent:    "priya",
+			expected: "",
+		},
+		{
+			name:     "存在しないエージェント",
+			agent:    "unknown",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cfg.GetAgentColor(tt.agent)
+			if got != tt.expected {
+				t.Errorf("GetAgentColor(%q) = %q, want %q", tt.agent, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- AgentConfigに`color`フィールドを追加
- 設定ファイルでエージェントの表示色を指定可能に
- 未設定時は既存のハードコード色にフォールバック

## 設定例
```yaml
agents:
  - name: "priya"
    color: "#FF9933"
  - name: "amara"
    color: "#9966FF"
```

## Test plan
- [ ] `go test ./...` 通過確認
- [ ] TUIで設定した色が反映されることを確認
- [ ] 色未設定時にデフォルト色が使われることを確認

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)