### PR TITLE
feat: add approval timeout management package

### DIFF
--- a/internal/approval/approval.go
+++ b/internal/approval/approval.go
@@ -1,0 +1,194 @@
+// Package approval manages pending approval requests with timeout
+package approval
+
+import (
+	"sync"
+	"time"
+)
+
+// DefaultTimeout is the default timeout for approval requests
+const DefaultTimeout = 3 * time.Minute
+
+// Status represents the status of an approval request
+type Status string
+
+const (
+	StatusPending   Status = "pending"
+	StatusApproved  Status = "approved"
+	StatusCancelled Status = "cancelled"
+	StatusTimedOut  Status = "timedout"
+)
+
+// PendingApproval represents a pending approval request
+type PendingApproval struct {
+	ID          string
+	RequestedAt time.Time
+	Context     string // What is being requested
+	Requester   string // Who requested it
+	Status      Status
+}
+
+// Manager manages pending approval requests
+type Manager struct {
+	mu       sync.RWMutex
+	pending  map[string]*PendingApproval
+	timeout  time.Duration
+	onExpire func(approval *PendingApproval) // Callback when approval expires
+}
+
+// NewManager creates a new approval manager
+func NewManager() *Manager {
+	return &Manager{
+		pending: make(map[string]*PendingApproval),
+		timeout: DefaultTimeout,
+	}
+}
+
+// SetTimeout sets the timeout duration
+func (m *Manager) SetTimeout(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.timeout = d
+}
+
+// SetOnExpire sets the callback for when approvals expire
+func (m *Manager) SetOnExpire(fn func(*PendingApproval)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onExpire = fn
+}
+
+// Request creates a new pending approval request
+func (m *Manager) Request(id, context, requester string) *PendingApproval {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	approval := &PendingApproval{
+		ID:          id,
+		RequestedAt: time.Now(),
+		Context:     context,
+		Requester:   requester,
+		Status:      StatusPending,
+	}
+
+	m.pending[id] = approval
+	return approval
+}
+
+// Cancel cancels a pending approval (owner responded)
+func (m *Manager) Cancel(id string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	approval, ok := m.pending[id]
+	if !ok {
+		return false
+	}
+
+	approval.Status = StatusCancelled
+	delete(m.pending, id)
+	return true
+}
+
+// Approve marks an approval as approved
+func (m *Manager) Approve(id string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	approval, ok := m.pending[id]
+	if !ok {
+		return false
+	}
+
+	approval.Status = StatusApproved
+	delete(m.pending, id)
+	return true
+}
+
+// Get returns a pending approval by ID
+func (m *Manager) Get(id string) (*PendingApproval, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	approval, ok := m.pending[id]
+	if !ok {
+		return nil, false
+	}
+	return approval, true
+}
+
+// CheckTimeout checks if an approval has timed out
+func (m *Manager) CheckTimeout(id string) bool {
+	m.mu.RLock()
+	approval, ok := m.pending[id]
+	timeout := m.timeout
+	m.mu.RUnlock()
+
+	if !ok {
+		return false
+	}
+
+	return time.Since(approval.RequestedAt) >= timeout
+}
+
+// CheckAll checks all pending approvals for timeout and handles them
+// Returns list of timed out approvals
+func (m *Manager) CheckAll() []*PendingApproval {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var timedOut []*PendingApproval
+
+	for id, approval := range m.pending {
+		if time.Since(approval.RequestedAt) >= m.timeout {
+			approval.Status = StatusTimedOut
+			timedOut = append(timedOut, approval)
+			delete(m.pending, id)
+
+			if m.onExpire != nil {
+				m.onExpire(approval)
+			}
+		}
+	}
+
+	return timedOut
+}
+
+// Pending returns all pending approvals
+func (m *Manager) Pending() []*PendingApproval {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var result []*PendingApproval
+	for _, approval := range m.pending {
+		result = append(result, approval)
+	}
+	return result
+}
+
+// RemainingTime returns the remaining time for a pending approval
+func (m *Manager) RemainingTime(id string) time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	approval, ok := m.pending[id]
+	if !ok {
+		return 0
+	}
+
+	elapsed := time.Since(approval.RequestedAt)
+	remaining := m.timeout - elapsed
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// GenerateTimeoutMessage generates a notification message for PM
+func GenerateTimeoutMessage(approval *PendingApproval, pmName string) string {
+	return "@" + pmName + " オーナー確認待ちがタイムアウトしました。\n" +
+		"- ID: " + approval.ID + "\n" +
+		"- 依頼者: " + approval.Requester + "\n" +
+		"- 内容: " + approval.Context + "\n" +
+		"フォローアップが必要です。"
+}

--- a/internal/approval/approval_test.go
+++ b/internal/approval/approval_test.go
@@ -1,0 +1,168 @@
+package approval
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRequest(t *testing.T) {
+	m := NewManager()
+
+	approval := m.Request("pr-123", "PR #123 マージ確認", "Priya")
+
+	if approval.ID != "pr-123" {
+		t.Errorf("expected ID 'pr-123', got %s", approval.ID)
+	}
+	if approval.Context != "PR #123 マージ確認" {
+		t.Errorf("unexpected context: %s", approval.Context)
+	}
+	if approval.Requester != "Priya" {
+		t.Errorf("expected requester 'Priya', got %s", approval.Requester)
+	}
+	if approval.Status != StatusPending {
+		t.Errorf("expected status 'pending', got %s", approval.Status)
+	}
+}
+
+func TestCancel(t *testing.T) {
+	m := NewManager()
+
+	m.Request("pr-123", "PR #123 マージ確認", "Priya")
+
+	// Cancel existing
+	if !m.Cancel("pr-123") {
+		t.Error("expected Cancel to return true")
+	}
+
+	// Verify removed
+	if _, ok := m.Get("pr-123"); ok {
+		t.Error("expected approval to be removed after cancel")
+	}
+
+	// Cancel non-existing
+	if m.Cancel("pr-999") {
+		t.Error("expected Cancel to return false for non-existing")
+	}
+}
+
+func TestApprove(t *testing.T) {
+	m := NewManager()
+
+	m.Request("pr-123", "PR #123 マージ確認", "Priya")
+
+	if !m.Approve("pr-123") {
+		t.Error("expected Approve to return true")
+	}
+
+	if _, ok := m.Get("pr-123"); ok {
+		t.Error("expected approval to be removed after approve")
+	}
+
+	if m.Approve("pr-999") {
+		t.Error("expected Approve to return false for non-existing")
+	}
+}
+
+func TestCheckTimeout(t *testing.T) {
+	m := NewManager()
+	m.SetTimeout(50 * time.Millisecond)
+
+	m.Request("pr-123", "PR #123 マージ確認", "Priya")
+
+	// Not timed out yet
+	if m.CheckTimeout("pr-123") {
+		t.Error("expected not timed out immediately")
+	}
+
+	// Wait for timeout
+	time.Sleep(60 * time.Millisecond)
+
+	if !m.CheckTimeout("pr-123") {
+		t.Error("expected timed out after waiting")
+	}
+
+	// Non-existing
+	if m.CheckTimeout("pr-999") {
+		t.Error("expected false for non-existing")
+	}
+}
+
+func TestCheckAll(t *testing.T) {
+	m := NewManager()
+	m.SetTimeout(50 * time.Millisecond)
+
+	var expiredCalled int
+	m.SetOnExpire(func(a *PendingApproval) {
+		expiredCalled++
+	})
+
+	m.Request("pr-1", "PR #1", "Priya")
+	m.Request("pr-2", "PR #2", "Yuki")
+
+	// Not timed out yet
+	timedOut := m.CheckAll()
+	if len(timedOut) != 0 {
+		t.Errorf("expected 0 timed out, got %d", len(timedOut))
+	}
+
+	// Wait for timeout
+	time.Sleep(60 * time.Millisecond)
+
+	timedOut = m.CheckAll()
+	if len(timedOut) != 2 {
+		t.Errorf("expected 2 timed out, got %d", len(timedOut))
+	}
+	if expiredCalled != 2 {
+		t.Errorf("expected onExpire called 2 times, got %d", expiredCalled)
+	}
+
+	// Verify all removed
+	if len(m.Pending()) != 0 {
+		t.Error("expected all pending removed")
+	}
+}
+
+func TestRemainingTime(t *testing.T) {
+	m := NewManager()
+	m.SetTimeout(100 * time.Millisecond)
+
+	m.Request("pr-123", "PR #123", "Priya")
+
+	remaining := m.RemainingTime("pr-123")
+	if remaining <= 0 || remaining > 100*time.Millisecond {
+		t.Errorf("unexpected remaining time: %v", remaining)
+	}
+
+	// Wait a bit
+	time.Sleep(30 * time.Millisecond)
+
+	remaining2 := m.RemainingTime("pr-123")
+	if remaining2 >= remaining {
+		t.Errorf("expected remaining time to decrease: %v >= %v", remaining2, remaining)
+	}
+
+	// Non-existing
+	if m.RemainingTime("pr-999") != 0 {
+		t.Error("expected 0 for non-existing")
+	}
+}
+
+func TestGenerateTimeoutMessage(t *testing.T) {
+	approval := &PendingApproval{
+		ID:        "pr-123",
+		Context:   "PR #123 マージ確認",
+		Requester: "Priya",
+	}
+
+	msg := GenerateTimeoutMessage(approval, "Mei")
+
+	expected := "@Mei オーナー確認待ちがタイムアウトしました。\n" +
+		"- ID: pr-123\n" +
+		"- 依頼者: Priya\n" +
+		"- 内容: PR #123 マージ確認\n" +
+		"フォローアップが必要です。"
+
+	if msg != expected {
+		t.Errorf("unexpected message:\ngot: %s\nwant: %s", msg, expected)
+	}
+}


### PR DESCRIPTION
## Summary

オーナー確認待ちの3分タイムアウト機能を実装。

- 新パッケージ `internal/approval/` を追加
- 確認待ちステータス管理（Pending/Approved/Cancelled/TimedOut）
- タイムアウト検出とコールバック
- PM通知メッセージ生成

## Changes

1. `internal/approval/approval.go`
   - `Manager` 構造体: 確認待ちリクエスト管理
   - `Request()` - 確認待ち開始
   - `Cancel()` / `Approve()` - オーナー応答時
   - `CheckTimeout()` / `CheckAll()` - タイムアウト検出
   - `RemainingTime()` - 残り時間取得
   - `GenerateTimeoutMessage()` - PM通知メッセージ

2. `internal/approval/approval_test.go`
   - 7テストケース（Request, Cancel, Approve, Timeout, CheckAll, RemainingTime, Message）

## Test

```
go test ./internal/approval/... -v
```

Closes #125