### PR TITLE
feat: 初回起動時に.maxam/配下にデフォルト設定ファイル生成

### DIFF
--- a/cmd/maxam/chat.go
+++ b/cmd/maxam/chat.go
@@ -38,6 +38,18 @@ func runChat() {
 	agentName := strings.ToLower(os.Args[2])
 	workDir := getWorkDir()
 
+	// Ensure project .maxam/ directory is initialized
+	if !config.IsProjectInitialized(workDir) {
+		if err := config.EnsureProjectInitialized(workDir); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to initialize .maxam/: %v\n", err)
+		} else {
+			fmt.Println("Created .maxam/ with default configuration files.")
+			fmt.Println("- .maxam/config.yaml")
+			fmt.Println("- .maxam/CLAUDE.md")
+			fmt.Println()
+		}
+	}
+
 	// Check if agents are configured
 	cfg, err := config.LoadWithProject(workDir)
 	if err != nil {

--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -1437,6 +1437,18 @@ func getWorktreePath(agentName, rootDir, subProjectPath string) string {
 func runTeamChat() {
 	workDir := getWorkDir()
 
+	// Ensure project .maxam/ directory is initialized
+	if !config.IsProjectInitialized(workDir) {
+		if err := config.EnsureProjectInitialized(workDir); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to initialize .maxam/: %v\n", err)
+		} else {
+			fmt.Println("Created .maxam/ with default configuration files.")
+			fmt.Println("- .maxam/config.yaml")
+			fmt.Println("- .maxam/CLAUDE.md")
+			fmt.Println()
+		}
+	}
+
 	// Check if agents are configured
 	cfg, err := config.LoadWithProject(workDir)
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -823,3 +823,127 @@ func TestGetTeamName(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureProjectInitialized(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// 初期化前は.maxamが存在しない
+	configDir := ProjectConfigDir(projectDir)
+	if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+		t.Error(".maxam should not exist before initialization")
+	}
+
+	// 初期化実行
+	if err := EnsureProjectInitialized(projectDir); err != nil {
+		t.Fatalf("EnsureProjectInitialized() error: %v", err)
+	}
+
+	// config.yamlが作成されている
+	configPath := filepath.Join(configDir, "config.yaml")
+	if _, err := os.Stat(configPath); err != nil {
+		t.Errorf("config.yaml not created: %v", err)
+	}
+
+	// CLAUDE.mdが作成されている
+	claudeMDPath := filepath.Join(configDir, "CLAUDE.md")
+	if _, err := os.Stat(claudeMDPath); err != nil {
+		t.Errorf("CLAUDE.md not created: %v", err)
+	}
+
+	// 内容確認（config.yaml）
+	configContent, _ := os.ReadFile(configPath)
+	if !contains(string(configContent), "version:") {
+		t.Error("config.yaml should contain version")
+	}
+
+	// 内容確認（CLAUDE.md）
+	claudeContent, _ := os.ReadFile(claudeMDPath)
+	if !contains(string(claudeContent), "## Team Members") {
+		t.Error("CLAUDE.md should contain Team Members section")
+	}
+}
+
+func TestEnsureProjectInitializedNoOverwrite(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// 既存ファイルを作成
+	configDir := ProjectConfigDir(projectDir)
+	os.MkdirAll(configDir, 0755)
+
+	existingConfig := "# existing config\nversion: \"99\"\n"
+	existingClaudeMD := "# existing CLAUDE.md\n"
+
+	os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(existingConfig), 0644)
+	os.WriteFile(filepath.Join(configDir, "CLAUDE.md"), []byte(existingClaudeMD), 0644)
+
+	// 初期化実行
+	if err := EnsureProjectInitialized(projectDir); err != nil {
+		t.Fatalf("EnsureProjectInitialized() error: %v", err)
+	}
+
+	// 既存ファイルが上書きされていない
+	configContent, _ := os.ReadFile(filepath.Join(configDir, "config.yaml"))
+	if string(configContent) != existingConfig {
+		t.Errorf("config.yaml was overwritten: got %q, want %q", string(configContent), existingConfig)
+	}
+
+	claudeContent, _ := os.ReadFile(filepath.Join(configDir, "CLAUDE.md"))
+	if string(claudeContent) != existingClaudeMD {
+		t.Errorf("CLAUDE.md was overwritten: got %q, want %q", string(claudeContent), existingClaudeMD)
+	}
+}
+
+func TestIsProjectInitialized(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(string)
+		expected  bool
+	}{
+		{
+			name: "初期化されていない",
+			setup: func(dir string) {
+				// 何もしない
+			},
+			expected: false,
+		},
+		{
+			name: "初期化済み",
+			setup: func(dir string) {
+				EnsureProjectInitialized(dir)
+			},
+			expected: true,
+		},
+		{
+			name: ".maxamディレクトリのみ（config.yamlなし）",
+			setup: func(dir string) {
+				os.MkdirAll(ProjectConfigDir(dir), 0755)
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectDir := t.TempDir()
+			tt.setup(projectDir)
+
+			got := IsProjectInitialized(projectDir)
+			if got != tt.expected {
+				t.Errorf("IsProjectInitialized() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -178,3 +178,74 @@ func GetAgentDirWithProject(projectDir, name string) (string, error) {
 	// 2. Fall back to global
 	return GetAgentDir(name)
 }
+
+// DefaultProjectConfigTemplate is the default config.yaml template for projects
+const DefaultProjectConfigTemplate = `# MAXAM Project Configuration
+# See: https://github.com/ytnobody/MAXAM
+
+version: "1"
+
+# Team members (run 'maxam team init' to set up)
+# agents:
+#   - name: mei
+#     full_name: Mei Chen
+#     role: PM + Architect
+`
+
+// DefaultProjectClaudeMDTemplate is the default CLAUDE.md template for projects
+const DefaultProjectClaudeMDTemplate = `# Project Settings
+
+> This file manages project-specific settings and learning. Tracked by git.
+
+## Team Members
+
+| Name | Role |
+|------|------|
+| (Run 'maxam team init' to set up) | |
+
+## Learning
+
+(Team learnings will be recorded here)
+
+---
+
+*This file is continuously updated through team learning*
+`
+
+// EnsureProjectInitialized sets up project/.maxam/ if not present
+// Creates default config.yaml and CLAUDE.md templates
+// Does not overwrite existing files
+func EnsureProjectInitialized(projectDir string) error {
+	configDir := ProjectConfigDir(projectDir)
+
+	// Create .maxam directory if not exists
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("create project config dir: %w", err)
+	}
+
+	// Create config.yaml if not exists
+	configPath := filepath.Join(configDir, "config.yaml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		if err := os.WriteFile(configPath, []byte(DefaultProjectConfigTemplate), 0644); err != nil {
+			return fmt.Errorf("write project config: %w", err)
+		}
+	}
+
+	// Create CLAUDE.md if not exists
+	claudeMDPath := filepath.Join(configDir, "CLAUDE.md")
+	if _, err := os.Stat(claudeMDPath); os.IsNotExist(err) {
+		if err := os.WriteFile(claudeMDPath, []byte(DefaultProjectClaudeMDTemplate), 0644); err != nil {
+			return fmt.Errorf("write project CLAUDE.md: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// IsProjectInitialized returns true if project/.maxam/ exists with config files
+func IsProjectInitialized(projectDir string) bool {
+	configDir := ProjectConfigDir(projectDir)
+	configPath := filepath.Join(configDir, "config.yaml")
+	_, err := os.Stat(configPath)
+	return err == nil
+}


### PR DESCRIPTION
## Summary
- 初回起動時に`.maxam/`ディレクトリが存在しなければ自動生成
- `.maxam/config.yaml`と`.maxam/CLAUDE.md`をテンプレートで作成
- 既存ファイルは上書きしない

## Changes
- `EnsureProjectInitialized()`: プロジェクト初期化関数を追加
- `IsProjectInitialized()`: 初期化済みかのチェック関数を追加
- `runTeamChat()`, `runChat()`: 起動時に初期化を呼び出し

## Test plan
- [x] `go test ./...` 全テスト通過
- [x] `EnsureProjectInitialized`のテスト3ケース追加
  - 初期化実行
  - 既存ファイル上書きなし確認
  - `IsProjectInitialized`の各パターン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #131