### PR TITLE
feat: CLAUDE.summary.md の自動生成機能

### DIFF
--- a/cmd/maxam/main.go
+++ b/cmd/maxam/main.go
@@ -9,10 +9,18 @@ import (
 
 	"github.com/ytnobody/MAXAM/internal/agent"
 	"github.com/ytnobody/MAXAM/internal/logger"
+	"github.com/ytnobody/MAXAM/internal/summary"
 	"github.com/ytnobody/MAXAM/internal/workflow"
 )
 
 func main() {
+	// Ensure CLAUDE.summary.md is up to date before any command
+	workDir, _ := os.Getwd()
+	if err := summary.EnsureUpToDate(workDir); err != nil {
+		// Non-fatal: just log and continue
+		fmt.Fprintf(os.Stderr, "Warning: failed to update summary: %v\n", err)
+	}
+
 	if len(os.Args) < 2 {
 		// No arguments: launch team chat TUI
 		runTeamChat()

--- a/internal/summary/generator.go
+++ b/internal/summary/generator.go
@@ -1,0 +1,156 @@
+// Package summary provides automatic generation of CLAUDE.summary.md
+package summary
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// SourceFile is the full CLAUDE.md filename
+	SourceFile = "CLAUDE.md"
+	// SummaryFile is the generated summary filename
+	SummaryFile = "CLAUDE.summary.md"
+)
+
+// SectionsToExtract defines which sections to include in summary
+// These are H2 headers (## Section Name)
+var SectionsToExtract = []string{
+	"プロジェクト概要",
+	"チームメンバー",
+	"コーディング規約",
+	"通信規約",
+	"エスカレーションルール",
+	"Worktree運用",
+}
+
+// MaxLinesPerSection limits lines per section to keep summary concise
+const MaxLinesPerSection = 30
+
+// NeedsRegeneration checks if CLAUDE.summary.md needs to be regenerated
+// Returns true if:
+// - CLAUDE.md exists and CLAUDE.summary.md doesn't exist
+// - CLAUDE.md is newer than CLAUDE.summary.md
+func NeedsRegeneration(workDir string) bool {
+	sourcePath := filepath.Join(workDir, SourceFile)
+	summaryPath := filepath.Join(workDir, SummaryFile)
+
+	sourceInfo, err := os.Stat(sourcePath)
+	if err != nil {
+		// Source doesn't exist, nothing to generate
+		return false
+	}
+
+	summaryInfo, err := os.Stat(summaryPath)
+	if err != nil {
+		// Summary doesn't exist but source does
+		return true
+	}
+
+	// Compare modification times
+	return sourceInfo.ModTime().After(summaryInfo.ModTime())
+}
+
+// EnsureUpToDate regenerates summary if needed
+func EnsureUpToDate(workDir string) error {
+	if !NeedsRegeneration(workDir) {
+		return nil
+	}
+	return Generate(workDir)
+}
+
+// Generate creates CLAUDE.summary.md from CLAUDE.md
+func Generate(workDir string) error {
+	sourcePath := filepath.Join(workDir, SourceFile)
+	summaryPath := filepath.Join(workDir, SummaryFile)
+
+	content, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return fmt.Errorf("read source: %w", err)
+	}
+
+	summary := ExtractSections(string(content), SectionsToExtract)
+
+	// Add header and footer
+	output := "# MAXAM 共通規約（要約版）\n\n" + summary + "\n---\n\n*詳細はCLAUDE.md（フル版）を参照。チーム固有情報は.maxam/CLAUDE.mdを参照*\n"
+
+	if err := os.WriteFile(summaryPath, []byte(output), 0644); err != nil {
+		return fmt.Errorf("write summary: %w", err)
+	}
+
+	return nil
+}
+
+// ExtractSections extracts specified H2 sections from markdown content
+func ExtractSections(content string, sections []string) string {
+	// Build a set for quick lookup
+	sectionSet := make(map[string]bool)
+	for _, s := range sections {
+		sectionSet[s] = true
+	}
+
+	var result strings.Builder
+	scanner := bufio.NewScanner(strings.NewReader(content))
+
+	var currentSection string
+	var inTargetSection bool
+	var lineCount int
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Check for H2 header
+		if strings.HasPrefix(line, "## ") {
+			sectionName := strings.TrimPrefix(line, "## ")
+
+			// Finish previous section
+			if inTargetSection && currentSection != "" {
+				result.WriteString("\n")
+			}
+
+			// Check if this section should be extracted
+			if sectionSet[sectionName] {
+				inTargetSection = true
+				currentSection = sectionName
+				lineCount = 0
+				result.WriteString(line)
+				result.WriteString("\n")
+			} else {
+				inTargetSection = false
+				currentSection = ""
+			}
+			continue
+		}
+
+		// Check for H1 header (skip title line)
+		if strings.HasPrefix(line, "# ") {
+			continue
+		}
+
+		// If in target section, add line
+		if inTargetSection {
+			// Stop at H3 within section after certain content (keep first subsections)
+			if strings.HasPrefix(line, "### ") {
+				// Include subsection header
+				lineCount++
+				if lineCount <= MaxLinesPerSection {
+					result.WriteString("\n")
+					result.WriteString(line)
+					result.WriteString("\n")
+				}
+				continue
+			}
+
+			lineCount++
+			if lineCount <= MaxLinesPerSection {
+				result.WriteString(line)
+				result.WriteString("\n")
+			}
+		}
+	}
+
+	return result.String()
+}

--- a/internal/summary/generator_test.go
+++ b/internal/summary/generator_test.go
@@ -1,0 +1,272 @@
+package summary
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNeedsRegeneration(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(dir string) error
+		expected bool
+	}{
+		{
+			name: "no source file",
+			setup: func(dir string) error {
+				// Don't create anything
+				return nil
+			},
+			expected: false,
+		},
+		{
+			name: "source exists, no summary",
+			setup: func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, SourceFile), []byte("# Test"), 0644)
+			},
+			expected: true,
+		},
+		{
+			name: "source newer than summary",
+			setup: func(dir string) error {
+				summaryPath := filepath.Join(dir, SummaryFile)
+				if err := os.WriteFile(summaryPath, []byte("# Summary"), 0644); err != nil {
+					return err
+				}
+				// Set summary to older time
+				oldTime := time.Now().Add(-1 * time.Hour)
+				if err := os.Chtimes(summaryPath, oldTime, oldTime); err != nil {
+					return err
+				}
+				// Create source (will be newer)
+				return os.WriteFile(filepath.Join(dir, SourceFile), []byte("# Test"), 0644)
+			},
+			expected: true,
+		},
+		{
+			name: "summary newer than source",
+			setup: func(dir string) error {
+				sourcePath := filepath.Join(dir, SourceFile)
+				if err := os.WriteFile(sourcePath, []byte("# Test"), 0644); err != nil {
+					return err
+				}
+				// Set source to older time
+				oldTime := time.Now().Add(-1 * time.Hour)
+				if err := os.Chtimes(sourcePath, oldTime, oldTime); err != nil {
+					return err
+				}
+				// Create summary (will be newer)
+				return os.WriteFile(filepath.Join(dir, SummaryFile), []byte("# Summary"), 0644)
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := tt.setup(dir); err != nil {
+				t.Fatalf("setup failed: %v", err)
+			}
+
+			got := NeedsRegeneration(dir)
+			if got != tt.expected {
+				t.Errorf("NeedsRegeneration() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractSections(t *testing.T) {
+	content := `# MAXAM 共通規約
+
+## プロジェクト概要
+
+MAXAMは複数のAIエージェントが協調して開発業務を遂行するシステム。
+
+## チームメンバー
+
+チームメンバー情報は管理されます。
+
+## 設定管理の指針
+
+これはスキップされるセクション。
+
+## コーディング規約
+
+### 全般
+- シンプルに保つ
+- テストを書く
+
+### Go
+- gofmtでフォーマット
+
+## 別のセクション
+
+これもスキップ。
+
+## エスカレーションルール
+
+1. ルール1
+2. ルール2
+`
+
+	sections := []string{
+		"プロジェクト概要",
+		"チームメンバー",
+		"コーディング規約",
+		"エスカレーションルール",
+	}
+
+	result := ExtractSections(content, sections)
+
+	// Check that target sections are included
+	if !contains(result, "## プロジェクト概要") {
+		t.Error("missing プロジェクト概要 section")
+	}
+	if !contains(result, "## チームメンバー") {
+		t.Error("missing チームメンバー section")
+	}
+	if !contains(result, "## コーディング規約") {
+		t.Error("missing コーディング規約 section")
+	}
+	if !contains(result, "## エスカレーションルール") {
+		t.Error("missing エスカレーションルール section")
+	}
+
+	// Check that non-target sections are excluded
+	if contains(result, "## 設定管理の指針") {
+		t.Error("should not include 設定管理の指針 section")
+	}
+	if contains(result, "## 別のセクション") {
+		t.Error("should not include 別のセクション section")
+	}
+
+	// Check subsections are included
+	if !contains(result, "### 全般") {
+		t.Error("missing subsection 全般")
+	}
+}
+
+func TestGenerate(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create source file
+	sourceContent := `# MAXAM 共通規約
+
+## プロジェクト概要
+
+MAXAMはテストシステム。
+
+## チームメンバー
+
+テストチーム。
+
+## コーディング規約
+
+### 全般
+- シンプル
+
+## 通信規約
+
+チャットで連絡。
+
+## エスカレーションルール
+
+PMへ。
+
+## Worktree運用
+
+/tmp/maxam/
+`
+
+	sourcePath := filepath.Join(dir, SourceFile)
+	if err := os.WriteFile(sourcePath, []byte(sourceContent), 0644); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+
+	// Generate summary
+	if err := Generate(dir); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	// Check summary was created
+	summaryPath := filepath.Join(dir, SummaryFile)
+	data, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("failed to read summary: %v", err)
+	}
+
+	summary := string(data)
+
+	// Check header
+	if !contains(summary, "# MAXAM 共通規約（要約版）") {
+		t.Error("missing summary header")
+	}
+
+	// Check footer
+	if !contains(summary, "詳細はCLAUDE.md（フル版）を参照") {
+		t.Error("missing summary footer")
+	}
+
+	// Check sections are present
+	if !contains(summary, "## プロジェクト概要") {
+		t.Error("missing プロジェクト概要")
+	}
+	if !contains(summary, "MAXAMはテストシステム") {
+		t.Error("missing content from プロジェクト概要")
+	}
+}
+
+func TestEnsureUpToDate(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create source file
+	sourcePath := filepath.Join(dir, SourceFile)
+	if err := os.WriteFile(sourcePath, []byte("# Test\n\n## プロジェクト概要\n\nテスト"), 0644); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+
+	// First call should generate
+	if err := EnsureUpToDate(dir); err != nil {
+		t.Fatalf("EnsureUpToDate() error = %v", err)
+	}
+
+	// Check summary exists
+	summaryPath := filepath.Join(dir, SummaryFile)
+	if _, err := os.Stat(summaryPath); err != nil {
+		t.Error("summary file should exist after EnsureUpToDate")
+	}
+
+	// Get summary mtime
+	info1, _ := os.Stat(summaryPath)
+	mtime1 := info1.ModTime()
+
+	// Wait a bit and call again - should not regenerate
+	time.Sleep(10 * time.Millisecond)
+	if err := EnsureUpToDate(dir); err != nil {
+		t.Fatalf("second EnsureUpToDate() error = %v", err)
+	}
+
+	info2, _ := os.Stat(summaryPath)
+	mtime2 := info2.ModTime()
+
+	if !mtime1.Equal(mtime2) {
+		t.Error("summary should not be regenerated when up to date")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- internal/summary パッケージを追加
- CLAUDE.mdからテンプレートベースでセクションを抽出し、CLAUDE.summary.mdを生成
- 起動時にmtime比較して必要なときだけ再生成
- Claude API呼び出しなし、ローカル完結

## 実装詳細
- 対象セクション: プロジェクト概要、チームメンバー、コーディング規約、通信規約、エスカレーションルール、Worktree運用
- セクションあたり最大30行で切り詰め
- H2ヘッダーをパースして抽出

## テスト
- 4テストケース追加
  - TestNeedsRegeneration: mtime比較ロジック（4パターン）
  - TestExtractSections: セクション抽出
  - TestGenerate: ファイル生成
  - TestEnsureUpToDate: 更新チェック＆生成

Closes #116

Generated with Claude Code