### PR TITLE
feat: メンション漏れ検知機能

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -103,6 +103,11 @@ var (
 			Background(lipgloss.Color("#FFFF00")).
 			Bold(true).
 			Padding(0, 1)
+
+	// System message style for mention warnings
+	systemStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FFD700")).
+			Bold(true)
 )
 
 type tuiMessage struct {
@@ -453,6 +458,17 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.history != nil {
 				m.history.Add("user", input)
 			}
+
+			// Check for mention leak and add system warning if needed
+			result := mention.Check(input)
+			if result.NeedsWarning {
+				warningMsg := mention.FormatSystemWarning("オーナー")
+				m.messages = append(m.messages, tuiMessage{role: "system", content: warningMsg})
+				if m.history != nil {
+					m.history.Add("system", warningMsg)
+				}
+			}
+
 			m.updateViewport()
 
 			// 複数メンション対応: 検出されたエージェント全員に並列でリクエスト
@@ -821,6 +837,8 @@ func (m *tuiModel) updateViewport() {
 		if msg.role == "user" {
 			sb.WriteString(userStyle.Render("You: "))
 			sb.WriteString(msg.content)
+		} else if msg.role == "system" {
+			sb.WriteString(systemStyle.Render(msg.content))
 		} else {
 			style := m.getAgentStyle(msg.role)
 			sb.WriteString(style.Render(m.getFullName(msg.role) + ": "))

--- a/internal/mention/checker.go
+++ b/internal/mention/checker.go
@@ -45,8 +45,8 @@ func NewChecker(agentNames []string) *Checker {
 			}
 		}
 	}
-	// Always include @オーナー as a valid mention
-	parts = append(parts, "オーナー")
+	// Always include @オーナー and @owner as valid mentions
+	parts = append(parts, "オーナー", "owner", "Owner")
 
 	pattern := `@(` + strings.Join(parts, "|") + `)`
 	return &Checker{
@@ -104,4 +104,9 @@ func Check(message string) Result {
 // FormatWarning returns a warning message for display
 func FormatWarning() string {
 	return "メンション先を明示してください（@名前）"
+}
+
+// FormatSystemWarning returns a system warning message for chat display
+func FormatSystemWarning(sender string) string {
+	return "[System] @" + sender + " メンションが漏れている可能性があります。宛先を確認してください"
 }

--- a/internal/mention/checker_test.go
+++ b/internal/mention/checker_test.go
@@ -217,3 +217,68 @@ func TestSetDefaultChecker(t *testing.T) {
 		t.Error("Custom checker should not match @yuki")
 	}
 }
+
+func TestOwnerMention(t *testing.T) {
+	// Test that @owner (English) is recognized as valid mention
+	tests := []struct {
+		name        string
+		agentNames  []string
+		message     string
+		wantMention bool
+	}{
+		{
+			name:        "@owner lowercase",
+			agentNames:  []string{"alice"},
+			message:     "@owner 確認お願い",
+			wantMention: true,
+		},
+		{
+			name:        "@Owner title case",
+			agentNames:  []string{"alice"},
+			message:     "@Owner 確認お願い",
+			wantMention: true,
+		},
+		{
+			name:        "@オーナー Japanese",
+			agentNames:  []string{"alice"},
+			message:     "@オーナー 確認お願い",
+			wantMention: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := NewChecker(tt.agentNames)
+			result := checker.Check(tt.message)
+			if result.HasMention != tt.wantMention {
+				t.Errorf("Check(%q).HasMention = %v, want %v",
+					tt.message, result.HasMention, tt.wantMention)
+			}
+		})
+	}
+}
+
+func TestFormatSystemWarning(t *testing.T) {
+	tests := []struct {
+		sender   string
+		expected string
+	}{
+		{
+			sender:   "オーナー",
+			expected: "[System] @オーナー メンションが漏れている可能性があります。宛先を確認してください",
+		},
+		{
+			sender:   "Yuki",
+			expected: "[System] @Yuki メンションが漏れている可能性があります。宛先を確認してください",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sender, func(t *testing.T) {
+			result := FormatSystemWarning(tt.sender)
+			if result != tt.expected {
+				t.Errorf("FormatSystemWarning(%q) = %q, want %q", tt.sender, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- メンションなしで送信した場合、チャット上にシステムメッセージを表示
- `@owner` / `@Owner` を有効なメンションとして追加（`@オーナー` と同等）

## Changes
- `internal/mention/checker.go`: `@owner`/`@Owner` サポート追加、`FormatSystemWarning()` 追加
- `cmd/maxam/tui.go`: 送信時のメンションチェック、システムメッセージ表示
- テスト6ケース追加

## Test plan
- [x] `go test ./internal/mention/...` 全テスト通過
- [x] `go build ./cmd/maxam` ビルド成功
- [x] メンションなしでメッセージ送信 → `[System] @オーナー メンションが漏れている可能性があります。宛先を確認してください` が表示される
- [x] `@owner` / `@オーナー` でメンションすると警告なし

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)