### PR TITLE
feat: implement goroutine separation for agents

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 
 	"github.com/ytnobody/MAXAM/internal/agent"
+	"github.com/ytnobody/MAXAM/internal/agent/worker"
 	"github.com/ytnobody/MAXAM/internal/ccusage"
 	"github.com/ytnobody/MAXAM/internal/config"
 	"github.com/ytnobody/MAXAM/internal/errorwatch"
@@ -174,6 +175,9 @@ type tuiModel struct {
 
 	// Error detection and automatic follow-up
 	errorDetector *errorwatch.Detector
+
+	// Worker pool for goroutine separation
+	workerPool *worker.Pool
 }
 
 type agentResponseMsg struct {
@@ -268,8 +272,18 @@ func initialTuiModel(workDir string) tuiModel {
 
 	members := member.NewMembers(workDir)
 
+	// Setup agents and worker pool
+	agents := agent.NewAgents(workDir)
+	workerPool := worker.NewPool()
+	for _, name := range agents.All() {
+		if runner, ok := agents.Get(name); ok {
+			w := worker.NewWorker(name, runner)
+			workerPool.Add(w)
+		}
+	}
+
 	return tuiModel{
-		agents:              agent.NewAgents(workDir),
+		agents:              agents,
 		members:             members,
 		router:              agentRouter,
 		logMgr:              logger.NewManager(logger.GetDefaultLogDir(), workDir),
@@ -290,6 +304,7 @@ func initialTuiModel(workDir string) tuiModel {
 		analysisMinMessages: cfg.GetAnalysisMinMessages(),
 		yoloMode:            cfg.YOLOMode,
 		errorDetector:       errorwatch.DefaultDetector(),
+		workerPool:          workerPool,
 	}
 }
 
@@ -313,6 +328,11 @@ type ccusageUpdateMsg struct {
 type ccusageTickMsg struct{}
 
 func (m tuiModel) Init() tea.Cmd {
+	// Start worker pool
+	if m.workerPool != nil {
+		m.workerPool.StartAll()
+	}
+
 	cmds := []tea.Cmd{textinput.Blink, tea.EnterAltScreen, m.tickAnalysis()}
 	if m.taskWatcher != nil {
 		cmds = append(cmds, m.watchTaskFile())
@@ -395,6 +415,9 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.taskWatcher != nil {
 				m.taskWatcher.Close()
 			}
+			if m.workerPool != nil {
+				m.workerPool.StopAll()
+			}
 			return m, tea.Quit
 
 		case tea.KeyCtrlL:
@@ -437,6 +460,9 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.logMgr.Close()
 				if m.taskWatcher != nil {
 					m.taskWatcher.Close()
+				}
+				if m.workerPool != nil {
+					m.workerPool.StopAll()
 				}
 				return m, tea.Quit
 			}
@@ -769,6 +795,34 @@ func (m *tuiModel) runAgentAsync(input string, targetAgent string, depth int) te
 			prompt = m.buildPrompt(agentName, input)
 		}
 
+		// Try to use worker pool first
+		if m.workerPool != nil {
+			if w, ok := m.workerPool.Get(agentName); ok {
+				responseChan := make(chan worker.ChatResponse, 1)
+				w.SendChat(prompt, responseChan)
+
+				// Wait for response
+				resp := <-responseChan
+				result := strings.TrimSpace(resp.Content)
+
+				// 返答内の他エージェントへのメンションを検出（複数対応）
+				var nextAgents []string
+				if depth < maxChainDepth && resp.Err == nil {
+					nextAgents = m.detectAgentMentions(result, agentName)
+				}
+
+				return agentResponseMsg{
+					agent:      agentName,
+					content:    result,
+					elapsed:    resp.Elapsed,
+					err:        resp.Err,
+					nextAgents: nextAgents,
+					chainDepth: depth,
+				}
+			}
+		}
+
+		// Fallback to direct runner execution
 		runner, _ := m.agents.Get(agentName)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/internal/agent/worker/state.go
+++ b/internal/agent/worker/state.go
@@ -1,0 +1,110 @@
+package worker
+
+import (
+	"sync"
+	"time"
+)
+
+// State represents the current state of an agent
+type State int
+
+const (
+	// StateAvailable means the agent can accept new tasks
+	StateAvailable State = iota
+	// StateWorking means the agent is currently executing a task
+	StateWorking
+)
+
+func (s State) String() string {
+	switch s {
+	case StateAvailable:
+		return "available"
+	case StateWorking:
+		return "working"
+	default:
+		return "unknown"
+	}
+}
+
+// AgentState holds the current state of an agent
+type AgentState struct {
+	mu          sync.RWMutex
+	state       State
+	currentTask string    // Description of current task
+	startedAt   time.Time // When current task started
+}
+
+// NewAgentState creates a new agent state
+func NewAgentState() *AgentState {
+	return &AgentState{
+		state: StateAvailable,
+	}
+}
+
+// Get returns the current state
+func (s *AgentState) Get() State {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.state
+}
+
+// IsWorking returns true if the agent is currently working
+func (s *AgentState) IsWorking() bool {
+	return s.Get() == StateWorking
+}
+
+// IsAvailable returns true if the agent is available
+func (s *AgentState) IsAvailable() bool {
+	return s.Get() == StateAvailable
+}
+
+// GetCurrentTask returns the current task description
+func (s *AgentState) GetCurrentTask() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.currentTask
+}
+
+// GetTaskDuration returns how long the current task has been running
+func (s *AgentState) GetTaskDuration() time.Duration {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.state != StateWorking {
+		return 0
+	}
+	return time.Since(s.startedAt)
+}
+
+// StartTask transitions to working state
+func (s *AgentState) StartTask(description string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.state = StateWorking
+	s.currentTask = description
+	s.startedAt = time.Now()
+}
+
+// CompleteTask transitions to available state
+func (s *AgentState) CompleteTask() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.state = StateAvailable
+	s.currentTask = ""
+	s.startedAt = time.Time{}
+}
+
+// GetStatus returns a human-readable status message
+func (s *AgentState) GetStatus() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.state == StateAvailable {
+		return "待機中"
+	}
+
+	duration := time.Since(s.startedAt).Round(time.Second)
+	if s.currentTask != "" {
+		return s.currentTask + " (" + duration.String() + ")"
+	}
+	return "作業中 (" + duration.String() + ")"
+}

--- a/internal/agent/worker/worker.go
+++ b/internal/agent/worker/worker.go
@@ -1,0 +1,272 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ytnobody/MAXAM/internal/agent"
+)
+
+// ChatRequest represents a chat/conversation request
+type ChatRequest struct {
+	Input    string
+	Response chan<- ChatResponse
+}
+
+// ChatResponse is the response to a chat request
+type ChatResponse struct {
+	Content string
+	Elapsed time.Duration
+	Err     error
+}
+
+// TaskRequest represents a work task request
+type TaskRequest struct {
+	Description string
+	Prompt      string
+	Response    chan<- TaskResponse
+}
+
+// TaskResponse is the response to a task request
+type TaskResponse struct {
+	Content string
+	Elapsed time.Duration
+	Err     error
+}
+
+// Worker manages an agent's chat and task goroutines
+type Worker struct {
+	name   string
+	runner *agent.Runner
+	state  *AgentState
+
+	chatChan chan ChatRequest
+	taskChan chan TaskRequest
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	// Callback for building prompts with context
+	buildPrompt func(agentName, input string) string
+}
+
+// NewWorker creates a new worker for an agent
+func NewWorker(name string, runner *agent.Runner) *Worker {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Worker{
+		name:     name,
+		runner:   runner,
+		state:    NewAgentState(),
+		chatChan: make(chan ChatRequest, 10),
+		taskChan: make(chan TaskRequest, 10),
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+}
+
+// SetPromptBuilder sets the callback for building prompts
+func (w *Worker) SetPromptBuilder(fn func(agentName, input string) string) {
+	w.buildPrompt = fn
+}
+
+// Start begins the chat and task goroutines
+func (w *Worker) Start() {
+	w.wg.Add(2)
+	go w.chatLoop()
+	go w.taskLoop()
+}
+
+// Stop gracefully shuts down the worker
+func (w *Worker) Stop() {
+	w.cancel()
+	close(w.chatChan)
+	close(w.taskChan)
+	w.wg.Wait()
+}
+
+// State returns the agent's current state
+func (w *Worker) State() *AgentState {
+	return w.state
+}
+
+// Name returns the worker's name
+func (w *Worker) Name() string {
+	return w.name
+}
+
+// SendChat sends a chat request and returns immediately
+// The response will be sent to the provided channel
+func (w *Worker) SendChat(input string, response chan<- ChatResponse) {
+	select {
+	case w.chatChan <- ChatRequest{Input: input, Response: response}:
+	case <-w.ctx.Done():
+		response <- ChatResponse{Err: w.ctx.Err()}
+	}
+}
+
+// SendTask sends a task request and returns immediately
+func (w *Worker) SendTask(description, prompt string, response chan<- TaskResponse) {
+	select {
+	case w.taskChan <- TaskRequest{Description: description, Prompt: prompt, Response: response}:
+	case <-w.ctx.Done():
+		response <- TaskResponse{Err: w.ctx.Err()}
+	}
+}
+
+// chatLoop handles chat requests - responds immediately even when working
+func (w *Worker) chatLoop() {
+	defer w.wg.Done()
+
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case req, ok := <-w.chatChan:
+			if !ok {
+				return
+			}
+			w.handleChat(req)
+		}
+	}
+}
+
+// handleChat processes a single chat request
+func (w *Worker) handleChat(req ChatRequest) {
+	// If working, return status message without calling LLM
+	if w.state.IsWorking() {
+		status := w.state.GetStatus()
+		req.Response <- ChatResponse{
+			Content: fmt.Sprintf("今%sの作業中。完了したら対応する。", status),
+			Elapsed: 0,
+			Err:     nil,
+		}
+		return
+	}
+
+	// Available - process normally
+	prompt := req.Input
+	if w.buildPrompt != nil {
+		prompt = w.buildPrompt(w.name, req.Input)
+	}
+
+	ctx, cancel := context.WithTimeout(w.ctx, 5*time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	result, err := w.runner.Run(ctx, prompt)
+	elapsed := time.Since(start)
+
+	req.Response <- ChatResponse{
+		Content: result,
+		Elapsed: elapsed,
+		Err:     err,
+	}
+}
+
+// taskLoop handles task requests
+func (w *Worker) taskLoop() {
+	defer w.wg.Done()
+
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case req, ok := <-w.taskChan:
+			if !ok {
+				return
+			}
+			w.handleTask(req)
+		}
+	}
+}
+
+// handleTask processes a single task request
+func (w *Worker) handleTask(req TaskRequest) {
+	// Mark as working
+	w.state.StartTask(req.Description)
+	defer w.state.CompleteTask()
+
+	ctx, cancel := context.WithTimeout(w.ctx, 10*time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	result, err := w.runner.Run(ctx, req.Prompt)
+	elapsed := time.Since(start)
+
+	req.Response <- TaskResponse{
+		Content: result,
+		Elapsed: elapsed,
+		Err:     err,
+	}
+}
+
+// Pool manages multiple workers
+type Pool struct {
+	workers map[string]*Worker
+	mu      sync.RWMutex
+}
+
+// NewPool creates a new worker pool
+func NewPool() *Pool {
+	return &Pool{
+		workers: make(map[string]*Worker),
+	}
+}
+
+// Add adds a worker to the pool
+func (p *Pool) Add(w *Worker) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.workers[w.name] = w
+}
+
+// Get returns a worker by name
+func (p *Pool) Get(name string) (*Worker, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	w, ok := p.workers[name]
+	return w, ok
+}
+
+// StartAll starts all workers
+func (p *Pool) StartAll() {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for _, w := range p.workers {
+		w.Start()
+	}
+}
+
+// StopAll stops all workers
+func (p *Pool) StopAll() {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for _, w := range p.workers {
+		w.Stop()
+	}
+}
+
+// GetStatus returns the status of all workers
+func (p *Pool) GetStatus() map[string]string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	status := make(map[string]string)
+	for name, w := range p.workers {
+		status[name] = w.state.GetStatus()
+	}
+	return status
+}
+
+// All returns all worker names
+func (p *Pool) All() []string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	names := make([]string, 0, len(p.workers))
+	for name := range p.workers {
+		names = append(names, name)
+	}
+	return names
+}

--- a/internal/agent/worker/worker_test.go
+++ b/internal/agent/worker/worker_test.go
@@ -1,0 +1,163 @@
+package worker
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAgentState(t *testing.T) {
+	t.Run("initial state is available", func(t *testing.T) {
+		state := NewAgentState()
+		if !state.IsAvailable() {
+			t.Error("expected initial state to be available")
+		}
+		if state.IsWorking() {
+			t.Error("expected initial state to not be working")
+		}
+	})
+
+	t.Run("start task transitions to working", func(t *testing.T) {
+		state := NewAgentState()
+		state.StartTask("implementing feature")
+
+		if !state.IsWorking() {
+			t.Error("expected state to be working after StartTask")
+		}
+		if state.IsAvailable() {
+			t.Error("expected state to not be available after StartTask")
+		}
+		if state.GetCurrentTask() != "implementing feature" {
+			t.Errorf("expected task to be 'implementing feature', got '%s'", state.GetCurrentTask())
+		}
+	})
+
+	t.Run("complete task transitions to available", func(t *testing.T) {
+		state := NewAgentState()
+		state.StartTask("implementing feature")
+		state.CompleteTask()
+
+		if !state.IsAvailable() {
+			t.Error("expected state to be available after CompleteTask")
+		}
+		if state.GetCurrentTask() != "" {
+			t.Errorf("expected task to be empty after CompleteTask, got '%s'", state.GetCurrentTask())
+		}
+	})
+
+	t.Run("get status while working", func(t *testing.T) {
+		state := NewAgentState()
+		state.StartTask("PRレビュー")
+		time.Sleep(10 * time.Millisecond)
+
+		status := state.GetStatus()
+		if status == "" {
+			t.Error("expected non-empty status")
+		}
+		// Should contain task description
+		if len(status) < 5 {
+			t.Errorf("expected status to contain task description, got '%s'", status)
+		}
+	})
+
+	t.Run("get status while available", func(t *testing.T) {
+		state := NewAgentState()
+		status := state.GetStatus()
+		if status != "待機中" {
+			t.Errorf("expected status '待機中', got '%s'", status)
+		}
+	})
+}
+
+func TestWorkerChatWhileWorking(t *testing.T) {
+	t.Run("returns busy message when working", func(t *testing.T) {
+		// Create a worker with nil runner (won't be used for busy response)
+		w := NewWorker("yuki", nil)
+		w.Start()
+		defer w.Stop()
+
+		// Set state to working
+		w.state.StartTask("PR #123 レビュー中")
+
+		// Send chat request
+		responseChan := make(chan ChatResponse, 1)
+		w.SendChat("@yuki 手伝って", responseChan)
+
+		// Should get immediate busy response
+		select {
+		case resp := <-responseChan:
+			if resp.Err != nil {
+				t.Errorf("unexpected error: %v", resp.Err)
+			}
+			if resp.Content == "" {
+				t.Error("expected non-empty response")
+			}
+			// Should contain task description
+			if len(resp.Content) < 10 {
+				t.Errorf("expected response to contain task info, got '%s'", resp.Content)
+			}
+		case <-time.After(1 * time.Second):
+			t.Error("timeout waiting for response")
+		}
+	})
+}
+
+func TestPool(t *testing.T) {
+	t.Run("add and get worker", func(t *testing.T) {
+		pool := NewPool()
+
+		// Create a mock worker (nil runner is fine for this test)
+		w := NewWorker("test", nil)
+		pool.Add(w)
+
+		got, ok := pool.Get("test")
+		if !ok {
+			t.Error("expected to find worker 'test'")
+		}
+		if got.Name() != "test" {
+			t.Errorf("expected worker name 'test', got '%s'", got.Name())
+		}
+	})
+
+	t.Run("get non-existent worker", func(t *testing.T) {
+		pool := NewPool()
+
+		_, ok := pool.Get("nonexistent")
+		if ok {
+			t.Error("expected not to find worker 'nonexistent'")
+		}
+	})
+
+	t.Run("all returns all worker names", func(t *testing.T) {
+		pool := NewPool()
+		pool.Add(NewWorker("mei", nil))
+		pool.Add(NewWorker("yuki", nil))
+
+		names := pool.All()
+		if len(names) != 2 {
+			t.Errorf("expected 2 workers, got %d", len(names))
+		}
+	})
+
+	t.Run("get status", func(t *testing.T) {
+		pool := NewPool()
+		w1 := NewWorker("mei", nil)
+		w2 := NewWorker("yuki", nil)
+		pool.Add(w1)
+		pool.Add(w2)
+
+		// Set one to working
+		w1.state.StartTask("レビュー")
+
+		status := pool.GetStatus()
+		if len(status) != 2 {
+			t.Errorf("expected 2 status entries, got %d", len(status))
+		}
+		if status["yuki"] != "待機中" {
+			t.Errorf("expected yuki status '待機中', got '%s'", status["yuki"])
+		}
+		// mei should be working
+		if status["mei"] == "待機中" {
+			t.Errorf("expected mei status to not be '待機中', got '%s'", status["mei"])
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- エージェントごとにchatLoop/taskLoopの2つのgoroutineを管理するWorker構造体を追加
- 作業中でも会話に応答できる（「今○○作業中。完了したら対応する。」）
- WorkerPool経由で全エージェントを一括管理
- PRマージ後のerrorwatch機能とも統合済み

## Changes
- `internal/agent/worker/worker.go` - Worker/Pool構造体
- `internal/agent/worker/state.go` - AgentState（Working/Available）
- `internal/agent/worker/worker_test.go` - テスト4ケース
- `cmd/maxam/tui.go` - WorkerPool統合、errorwatchとの共存

## Test
`go test ./...` → PASS

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)