### PR TITLE
feat: auto-post issue list when all agents become idle

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -178,6 +178,10 @@ type tuiModel struct {
 
 	// Worker pool for goroutine separation
 	workerPool *worker.Pool
+
+	// Issue list on idle
+	lastIssueListTime time.Time // 最後にIssue一覧を投稿した時刻
+	ghClient          *gh.Client // GitHub client for issue list
 }
 
 type agentResponseMsg struct {
@@ -196,6 +200,8 @@ type analysisTickMsg struct {
 
 const maxChainDepth = 1000          // 最大連鎖数
 const meiInterventionInterval = 10  // Meiが介入する間隔
+const issueListInterval = 5 * time.Minute // Issue一覧投稿の最小間隔
+const issueListLimit = 20           // Issue一覧の最大表示件数
 
 func initialTuiModel(workDir string) tuiModel {
 	ti := textinput.New()
@@ -243,7 +249,9 @@ func initialTuiModel(workDir string) tuiModel {
 
 	// Setup PR watcher for worktree cleanup (silently fail if no GitHub access)
 	var prWatcher *gh.Watcher
-	if ghClient, err := gh.NewClient("ytnobody", "MAXAM"); err == nil {
+	var ghClient *gh.Client
+	if client, err := gh.NewClient("ytnobody", "MAXAM"); err == nil {
+		ghClient = client
 		prWatcher = gh.NewWatcher(ghClient)
 	}
 
@@ -305,6 +313,7 @@ func initialTuiModel(workDir string) tuiModel {
 		yoloMode:            cfg.YOLOMode,
 		errorDetector:       errorwatch.DefaultDetector(),
 		workerPool:          workerPool,
+		ghClient:            ghClient,
 	}
 }
 
@@ -326,6 +335,12 @@ type ccusageUpdateMsg struct {
 
 // ccusageTickMsg triggers periodic ccusage updates
 type ccusageTickMsg struct{}
+
+// issueListMsg is sent when issue list is fetched
+type issueListMsg struct {
+	issues []string
+	err    error
+}
 
 func (m tuiModel) Init() tea.Cmd {
 	// Start worker pool
@@ -665,6 +680,26 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.todayCost = msg.cost
 		return m, nil
 
+	case issueListMsg:
+		if msg.err == nil && len(msg.issues) > 0 {
+			// Issue一覧をシステムメッセージとして投稿
+			var sb strings.Builder
+			sb.WriteString("📋 オープンなIssue一覧:\n")
+			for _, issue := range msg.issues {
+				sb.WriteString(fmt.Sprintf("  %s\n", issue))
+			}
+			if len(msg.issues) >= issueListLimit {
+				sb.WriteString(fmt.Sprintf("  ...（%d件まで表示）\n", issueListLimit))
+			}
+			content := sb.String()
+			m.messages = append(m.messages, tuiMessage{role: "system", content: content})
+			if m.history != nil {
+				m.history.Add("system", content)
+			}
+			m.updateViewport()
+		}
+		return m, nil
+
 	case agentResponseMsg:
 		// エージェントの処理状態をクリア
 		delete(m.processingAgents, msg.agent)
@@ -748,6 +783,13 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if len(cmds) > 0 {
 				return m, tea.Batch(cmds...)
+			}
+		}
+
+		// 全エージェントがアイドルになったらIssue一覧を投稿
+		if len(m.processingAgents) == 0 {
+			if cmd := m.maybePostIssueList(); cmd != nil {
+				return m, cmd
 			}
 		}
 
@@ -1422,6 +1464,49 @@ func (m *tuiModel) buildLightweightAnalysisPrompt(messages []tuiMessage) string 
 	}
 
 	return sb.String()
+}
+
+// maybePostIssueList checks if we should post issue list and returns a command if so
+func (m *tuiModel) maybePostIssueList() tea.Cmd {
+	// GitHub clientがなければスキップ
+	if m.ghClient == nil {
+		return nil
+	}
+
+	// 重複防止: 前回投稿から一定時間経過していなければスキップ
+	if time.Since(m.lastIssueListTime) < issueListInterval {
+		return nil
+	}
+
+	// 時刻を更新（先に更新して重複を防ぐ）
+	m.lastIssueListTime = time.Now()
+
+	return m.fetchIssueList()
+}
+
+// fetchIssueList fetches open issues from GitHub
+func (m *tuiModel) fetchIssueList() tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		issues, err := m.ghClient.ListIssues(ctx, nil)
+		if err != nil {
+			return issueListMsg{err: err}
+		}
+
+		// Issue文字列に変換（上限まで）
+		var result []string
+		for i, issue := range issues {
+			if i >= issueListLimit {
+				break
+			}
+			// #番号 タイトル の形式
+			result = append(result, fmt.Sprintf("#%d %s", issue.GetNumber(), issue.GetTitle()))
+		}
+
+		return issueListMsg{issues: result}
+	}
 }
 
 // isNoIssueResponse は「特になし」相当の返答かどうか判定

--- a/cmd/maxam/tui_analysis_test.go
+++ b/cmd/maxam/tui_analysis_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ytnobody/MAXAM/internal/config"
 )
@@ -444,6 +445,87 @@ func TestAgentMentionWarningAddedToHistory(t *testing.T) {
 			// 詳細なテストは internal/mention/checker_test.go で実施
 			_ = tt.expectWarning // プレースホルダー
 		})
+	}
+}
+
+func TestMaybePostIssueList(t *testing.T) {
+	tests := []struct {
+		name              string
+		hasGHClient       bool
+		lastPostTime      time.Duration // 前回投稿からの経過時間
+		expectPostCommand bool
+	}{
+		{
+			name:              "GitHubクライアントなし - スキップ",
+			hasGHClient:       false,
+			lastPostTime:      10 * time.Minute,
+			expectPostCommand: false,
+		},
+		{
+			name:              "前回投稿から5分未満 - スキップ",
+			hasGHClient:       true,
+			lastPostTime:      2 * time.Minute,
+			expectPostCommand: false,
+		},
+		{
+			name:              "前回投稿から5分以上 - 投稿する",
+			hasGHClient:       true,
+			lastPostTime:      6 * time.Minute,
+			expectPostCommand: true,
+		},
+		{
+			name:              "初回（ゼロ値） - 投稿する",
+			hasGHClient:       true,
+			lastPostTime:      0, // time.Time{}からの経過 = 非常に長い
+			expectPostCommand: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &tuiModel{}
+
+			// ghClientの有無をシミュレート
+			// 実際のghClientは使わず、nilかどうかでチェック
+			if !tt.hasGHClient {
+				m.ghClient = nil
+			} else {
+				// ダミー値を設定する代わりに、ロジックの一部だけテスト
+				// ghClientがあると仮定したロジックのみ検証
+			}
+
+			// 前回投稿時刻を設定
+			if tt.lastPostTime > 0 {
+				m.lastIssueListTime = time.Now().Add(-tt.lastPostTime)
+			}
+			// lastPostTime == 0 の場合は time.Time{} (ゼロ値)のまま
+
+			// ghClientがない場合のテスト
+			if !tt.hasGHClient {
+				cmd := m.maybePostIssueList()
+				if cmd != nil {
+					t.Error("ghClientがない場合はnilを返すべき")
+				}
+				return
+			}
+
+			// ghClientがある場合の時間チェックロジックのテスト
+			shouldPost := time.Since(m.lastIssueListTime) >= issueListInterval
+			if shouldPost != tt.expectPostCommand {
+				t.Errorf("time check: got %v, want %v (elapsed: %v)",
+					shouldPost, tt.expectPostCommand, time.Since(m.lastIssueListTime))
+			}
+		})
+	}
+}
+
+func TestIssueListConstants(t *testing.T) {
+	// 定数が適切な値であることを確認
+	if issueListInterval != 5*time.Minute {
+		t.Errorf("issueListInterval = %v, want 5m", issueListInterval)
+	}
+	if issueListLimit != 20 {
+		t.Errorf("issueListLimit = %d, want 20", issueListLimit)
 	}
 }
 


### PR DESCRIPTION
## Summary
- 全エージェントがアイドル状態（「○○ 処理中...」表示が0人）になったときにオープンなIssue一覧を自動投稿
- 重複防止: 前回投稿から5分以内は再投稿しない
- 件数上限: 最大20件まで表示
- systemメッセージとして履歴に残る

## Test plan
- [ ] `go test ./cmd/maxam/...` で新規テスト含め全て通過
- [ ] TUIで複数エージェントを呼び出し、全員の応答完了後にIssue一覧が表示されることを確認
- [ ] 5分以内に再度アイドル状態になっても重複投稿されないことを確認

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)