### PR TITLE
feat: add multi-instance support foundation for agents

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -244,7 +244,7 @@ func (r *Runner) RunWithAllowedTools(ctx context.Context, prompt string, tools [
 // Agents provides pre-configured runners for each team member
 type Agents struct {
 	workDir string
-	runners map[string]*Runner
+	runners map[string]*Runner // key: instance key (e.g., "yuki" or "yuki-1")
 }
 
 // NewAgents creates the agent team with project-local priority
@@ -268,12 +268,14 @@ func NewAgents(workDir string) *Agents {
 	// Create runners for configured agents
 	for _, agentCfg := range cfg.Agents {
 		name := agentCfg.Name
+		instanceKey := agentCfg.GetInstanceKey()
 		fullName := agentCfg.FullName
 		if fullName == "" {
 			fullName = name // Use agent name if FullName not set
 		}
 
 		// Get agent directory with project priority
+		// Use base name for agent directory (shared across instances)
 		agentDir, err := config.GetAgentDirWithProject(workDir, name)
 		if err != nil {
 			continue // Skip if agent not found
@@ -287,7 +289,7 @@ func NewAgents(workDir string) *Agents {
 			if agentCfg.Model != "" {
 				runner.Model = Model(agentCfg.Model)
 			}
-			runners[name] = runner
+			runners[instanceKey] = runner
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,11 +31,25 @@ type Config struct {
 
 // AgentConfig represents an agent configuration
 type AgentConfig struct {
-	Name     string `yaml:"name"`
-	FullName string `yaml:"full_name"`
-	Role     string `yaml:"role"`
-	Model    string `yaml:"model,omitempty"` // opus, sonnet, haiku
-	Color    string `yaml:"color,omitempty"` // hex color code (e.g., "#FF9933")
+	Name       string `yaml:"name"`
+	FullName   string `yaml:"full_name"`
+	Role       string `yaml:"role"`
+	Model      string `yaml:"model,omitempty"`       // opus, sonnet, haiku
+	Color      string `yaml:"color,omitempty"`       // hex color code (e.g., "#FF9933")
+	InstanceID string `yaml:"instance_id,omitempty"` // for multi-instance support (e.g., "1", "2")
+}
+
+// TODO: Move to config.yaml when multi-instance feature is stabilized
+// DefaultMaxInstances is the default maximum number of instances per agent
+const DefaultMaxInstances = 3
+
+// GetInstanceKey returns the unique key for this agent instance
+// Format: "name" (no instance) or "name-instanceID" (with instance)
+func (a *AgentConfig) GetInstanceKey() string {
+	if a.InstanceID == "" {
+		return a.Name
+	}
+	return a.Name + "-" + a.InstanceID
 }
 
 // DefaultAnalysisMinMessages is the default minimum message count for analysis
@@ -294,6 +308,50 @@ func (c *Config) GetAgentColor(name string) string {
 		}
 	}
 	return ""
+}
+
+// GetAgentByInstanceKey returns the agent with the specified instance key
+// Supports both "name" and "name-instanceID" formats
+func (c *Config) GetAgentByInstanceKey(key string) *AgentConfig {
+	for i := range c.Agents {
+		if c.Agents[i].GetInstanceKey() == key {
+			return &c.Agents[i]
+		}
+	}
+	return nil
+}
+
+// GetAgentInstances returns all instances of the specified agent name
+func (c *Config) GetAgentInstances(name string) []AgentConfig {
+	var result []AgentConfig
+	for _, agent := range c.Agents {
+		if agent.Name == name {
+			result = append(result, agent)
+		}
+	}
+	return result
+}
+
+// GetAllInstanceKeys returns all unique instance keys for agents
+func (c *Config) GetAllInstanceKeys() []string {
+	var keys []string
+	for _, agent := range c.Agents {
+		keys = append(keys, agent.GetInstanceKey())
+	}
+	return keys
+}
+
+// GetUniqueAgentNames returns unique agent names (without instance IDs)
+func (c *Config) GetUniqueAgentNames() []string {
+	seen := make(map[string]bool)
+	var names []string
+	for _, agent := range c.Agents {
+		if !seen[agent.Name] {
+			seen[agent.Name] = true
+			names = append(names, agent.Name)
+		}
+	}
+	return names
 }
 
 // GetAgentByRole returns the first agent with the specified role

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -947,3 +947,204 @@ func containsHelper(s, substr string) bool {
 	}
 	return false
 }
+
+func TestAgentConfigGetInstanceKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   AgentConfig
+		expected string
+	}{
+		{
+			name:     "インスタンスIDなし",
+			config:   AgentConfig{Name: "yuki"},
+			expected: "yuki",
+		},
+		{
+			name:     "インスタンスIDあり",
+			config:   AgentConfig{Name: "yuki", InstanceID: "1"},
+			expected: "yuki-1",
+		},
+		{
+			name:     "インスタンスID=2",
+			config:   AgentConfig{Name: "yuki", InstanceID: "2"},
+			expected: "yuki-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.GetInstanceKey()
+			if got != tt.expected {
+				t.Errorf("GetInstanceKey() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetAgentByInstanceKey(t *testing.T) {
+	cfg := &Config{
+		Agents: []AgentConfig{
+			{Name: "yuki", FullName: "Yuki Tanaka"},
+			{Name: "yuki", FullName: "Yuki Tanaka", InstanceID: "1"},
+			{Name: "yuki", FullName: "Yuki Tanaka", InstanceID: "2"},
+			{Name: "mei", FullName: "Mei Chen"},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		key        string
+		shouldFind bool
+		wantName   string
+		wantID     string
+	}{
+		{
+			name:       "インスタンスIDなしで検索",
+			key:        "yuki",
+			shouldFind: true,
+			wantName:   "yuki",
+			wantID:     "",
+		},
+		{
+			name:       "インスタンスID=1で検索",
+			key:        "yuki-1",
+			shouldFind: true,
+			wantName:   "yuki",
+			wantID:     "1",
+		},
+		{
+			name:       "インスタンスID=2で検索",
+			key:        "yuki-2",
+			shouldFind: true,
+			wantName:   "yuki",
+			wantID:     "2",
+		},
+		{
+			name:       "存在しないキー",
+			key:        "yuki-3",
+			shouldFind: false,
+		},
+		{
+			name:       "別のエージェント",
+			key:        "mei",
+			shouldFind: true,
+			wantName:   "mei",
+			wantID:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cfg.GetAgentByInstanceKey(tt.key)
+			if tt.shouldFind {
+				if got == nil {
+					t.Errorf("GetAgentByInstanceKey(%q) returned nil", tt.key)
+					return
+				}
+				if got.Name != tt.wantName {
+					t.Errorf("Name = %q, want %q", got.Name, tt.wantName)
+				}
+				if got.InstanceID != tt.wantID {
+					t.Errorf("InstanceID = %q, want %q", got.InstanceID, tt.wantID)
+				}
+			} else {
+				if got != nil {
+					t.Errorf("GetAgentByInstanceKey(%q) = %v, want nil", tt.key, got)
+				}
+			}
+		})
+	}
+}
+
+func TestGetAgentInstances(t *testing.T) {
+	cfg := &Config{
+		Agents: []AgentConfig{
+			{Name: "yuki", FullName: "Yuki Tanaka"},
+			{Name: "yuki", FullName: "Yuki Tanaka", InstanceID: "1"},
+			{Name: "yuki", FullName: "Yuki Tanaka", InstanceID: "2"},
+			{Name: "mei", FullName: "Mei Chen"},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		agentName     string
+		expectedCount int
+	}{
+		{
+			name:          "yukiは3インスタンス",
+			agentName:     "yuki",
+			expectedCount: 3,
+		},
+		{
+			name:          "meiは1インスタンス",
+			agentName:     "mei",
+			expectedCount: 1,
+		},
+		{
+			name:          "存在しないエージェントは0",
+			agentName:     "unknown",
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cfg.GetAgentInstances(tt.agentName)
+			if len(got) != tt.expectedCount {
+				t.Errorf("GetAgentInstances(%q) returned %d, want %d", tt.agentName, len(got), tt.expectedCount)
+			}
+		})
+	}
+}
+
+func TestGetAllInstanceKeys(t *testing.T) {
+	cfg := &Config{
+		Agents: []AgentConfig{
+			{Name: "yuki"},
+			{Name: "yuki", InstanceID: "1"},
+			{Name: "mei"},
+		},
+	}
+
+	keys := cfg.GetAllInstanceKeys()
+	if len(keys) != 3 {
+		t.Errorf("GetAllInstanceKeys() returned %d keys, want 3", len(keys))
+	}
+
+	expected := map[string]bool{"yuki": true, "yuki-1": true, "mei": true}
+	for _, key := range keys {
+		if !expected[key] {
+			t.Errorf("Unexpected key: %q", key)
+		}
+	}
+}
+
+func TestGetUniqueAgentNames(t *testing.T) {
+	cfg := &Config{
+		Agents: []AgentConfig{
+			{Name: "yuki"},
+			{Name: "yuki", InstanceID: "1"},
+			{Name: "yuki", InstanceID: "2"},
+			{Name: "mei"},
+		},
+	}
+
+	names := cfg.GetUniqueAgentNames()
+	if len(names) != 2 {
+		t.Errorf("GetUniqueAgentNames() returned %d names, want 2", len(names))
+	}
+
+	expected := map[string]bool{"yuki": true, "mei": true}
+	for _, name := range names {
+		if !expected[name] {
+			t.Errorf("Unexpected name: %q", name)
+		}
+	}
+}
+
+func TestDefaultMaxInstances(t *testing.T) {
+	if DefaultMaxInstances != 3 {
+		t.Errorf("DefaultMaxInstances = %d, want 3", DefaultMaxInstances)
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -6,16 +6,47 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/ytnobody/MAXAM/internal/config"
 )
 
 const basePath = "/tmp/maxam"
 
-var agentNames = []string{"mei", "yuki", "rin", "shiori", "priya", "amara"}
+// getAgentNames returns agent names from config, or detects from filesystem
+func getAgentNames(workDir string) []string {
+	// Try to get from config first
+	if workDir != "" {
+		cfg, err := config.LoadWithProject(workDir)
+		if err == nil && cfg.HasAgents() {
+			return cfg.GetUniqueAgentNames()
+		}
+	}
+
+	// Fallback: detect from filesystem
+	return detectAgentsFromFilesystem()
+}
+
+// detectAgentsFromFilesystem scans /tmp/maxam for existing agent directories
+func detectAgentsFromFilesystem() []string {
+	var agents []string
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		return agents
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			agents = append(agents, entry.Name())
+		}
+	}
+	return agents
+}
 
 // CleanupForBranch removes all worktrees associated with the given branch
 // Silently ignores errors (best-effort cleanup)
 func CleanupForBranch(repoPath, branchName string) {
-	for _, agent := range agentNames {
+	agents := getAgentNames(repoPath)
+	for _, agent := range agents {
 		worktrees := findWorktreesForAgent(agent, branchName)
 		for _, wt := range worktrees {
 			removeWorktree(repoPath, wt)
@@ -91,9 +122,15 @@ func removeWorktree(repoPath, wtPath string) {
 
 // ListAll returns all worktrees under /tmp/maxam
 func ListAll() map[string][]string {
+	return ListAllForProject("")
+}
+
+// ListAllForProject returns all worktrees under /tmp/maxam for a specific project
+func ListAllForProject(workDir string) map[string][]string {
 	result := make(map[string][]string)
 
-	for _, agent := range agentNames {
+	agents := getAgentNames(workDir)
+	for _, agent := range agents {
 		agentDir := filepath.Join(basePath, agent)
 		entries, err := os.ReadDir(agentDir)
 		if err != nil {


### PR DESCRIPTION
## Summary
- 同一エージェントの複数インスタンス起動の基盤を実装
- AgentConfigに`InstanceID`フィールドを追加（例：`yuki-1`, `yuki-2`）
- worktreeのハードコードされたエージェントリストを削除し、設定から動的に取得するように変更
- DefaultMaxInstances定数を追加（TODO: 後で設定ファイルに移動）

## Test plan
- [x] `go test ./...` 全テスト通過
- [x] 新規テスト8ケース追加
  - GetInstanceKey (3ケース)
  - GetAgentByInstanceKey (5ケース) 
  - GetAgentInstances (3ケース)
  - GetAllInstanceKeys (1ケース)
  - GetUniqueAgentNames (1ケース)
  - DefaultMaxInstances (1ケース)

## 変更ファイル
- `internal/config/config.go` - InstanceIDフィールド追加、ヘルパーメソッド追加
- `internal/config/config_test.go` - テスト追加
- `internal/agent/runner.go` - インスタンスキーでRunner管理
- `internal/worktree/worktree.go` - 動的エージェント検出

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)