### PR TITLE
feat: メンションチェッカーのオン/オフ切り替え機能

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -185,6 +185,9 @@ type tuiModel struct {
 	// Issue list on idle
 	lastIssueListTime time.Time // 最後にIssue一覧を投稿した時刻
 	ghClient          *gh.Client // GitHub client for issue list
+
+	// Mention checker toggle
+	mentionCheckerEnabled bool
 }
 
 type agentResponseMsg struct {
@@ -295,30 +298,31 @@ func initialTuiModel(workDir string) tuiModel {
 	}
 
 	return tuiModel{
-		agents:              agents,
-		members:             members,
-		router:              agentRouter,
-		logMgr:              logger.NewManager(logger.GetDefaultLogDir(), workDir),
-		history:             hist,
-		workDir:             workDir,
-		config:              cfg,
-		textInput:           ti,
-		messages:            messages,
-		inputHist:           make([]string, 0),
-		processingAgents:    make(map[string]bool),
-		histIdx:             -1,
-		currentView:         viewChat,
-		tasklist:            tasklistModel,
-		taskService:         taskService,
-		taskWatcher:         taskWatcher,
-		prWatcher:           prWatcher,
-		ccusageClient:       ccClient,
-		analysisMinMessages: cfg.GetAnalysisMinMessages(),
-		yoloMode:            cfg.YOLOMode,
-		errorDetector:       errorwatch.DefaultDetector(),
-		workerPool:          workerPool,
-		ghClient:            ghClient,
-		mentionWarningCount: make(map[string]int),
+		agents:                agents,
+		members:               members,
+		router:                agentRouter,
+		logMgr:                logger.NewManager(logger.GetDefaultLogDir(), workDir),
+		history:               hist,
+		workDir:               workDir,
+		config:                cfg,
+		textInput:             ti,
+		messages:              messages,
+		inputHist:             make([]string, 0),
+		processingAgents:      make(map[string]bool),
+		histIdx:               -1,
+		currentView:           viewChat,
+		tasklist:              tasklistModel,
+		taskService:           taskService,
+		taskWatcher:           taskWatcher,
+		prWatcher:             prWatcher,
+		ccusageClient:         ccClient,
+		analysisMinMessages:   cfg.GetAnalysisMinMessages(),
+		yoloMode:              cfg.YOLOMode,
+		errorDetector:         errorwatch.DefaultDetector(),
+		workerPool:            workerPool,
+		ghClient:              ghClient,
+		mentionWarningCount:   make(map[string]int),
+		mentionCheckerEnabled: cfg.IsMentionCheckerEnabled(),
 	}
 }
 
@@ -448,6 +452,20 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyCtrlY:
 			// Toggle YOLO mode
 			m.yoloMode = !m.yoloMode
+			return m, nil
+
+		case tea.KeyCtrlN:
+			// Toggle mention checker
+			m.mentionCheckerEnabled = !m.mentionCheckerEnabled
+			// Save to config
+			m.config.SetMentionCheckerEnabled(m.mentionCheckerEnabled)
+			if err := config.SaveToProject(m.workDir, m.config); err != nil {
+				// Silent fail, just toggle in memory
+			}
+			// Clear warning if disabled
+			if !m.mentionCheckerEnabled {
+				m.mentionWarning = ""
+			}
 			return m, nil
 
 		case tea.KeyTab:
@@ -765,28 +783,30 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			content: msg.content,
 		})
 
-		// Check for mention leaks in agent response and add to history
+		// Check for mention leaks in agent response and add to history (if enabled)
 		m.mentionWarning = ""
-		mentionResult := mention.Check(msg.content)
 		var triggerRetry bool
-		if mentionResult.NeedsWarning {
-			m.mentionWarning = mention.FormatWarning()
-			// Add warning to messages and history for agent responses
-			warningMsg := mention.FormatSystemWarning(m.getFullName(msg.agent))
-			m.messages = append(m.messages, tuiMessage{role: "system", content: warningMsg})
-			if m.history != nil {
-				m.history.Add("system", warningMsg)
-			}
+		if m.mentionCheckerEnabled {
+			mentionResult := mention.Check(msg.content)
+			if mentionResult.NeedsWarning {
+				m.mentionWarning = mention.FormatWarning()
+				// Add warning to messages and history for agent responses
+				warningMsg := mention.FormatSystemWarning(m.getFullName(msg.agent))
+				m.messages = append(m.messages, tuiMessage{role: "system", content: warningMsg})
+				if m.history != nil {
+					m.history.Add("system", warningMsg)
+				}
 
-			// Increment consecutive warning count for this agent
-			m.mentionWarningCount[msg.agent]++
-			// Trigger retry if this is the first or second warning (allow 2 attempts)
-			if m.mentionWarningCount[msg.agent] <= 2 {
-				triggerRetry = true
+				// Increment consecutive warning count for this agent
+				m.mentionWarningCount[msg.agent]++
+				// Trigger retry if this is the first or second warning (allow 2 attempts)
+				if m.mentionWarningCount[msg.agent] <= 2 {
+					triggerRetry = true
+				}
+			} else {
+				// Reset warning count on successful mention
+				m.mentionWarningCount[msg.agent] = 0
 			}
-		} else {
-			// Reset warning count on successful mention
-			m.mentionWarningCount[msg.agent] = 0
 		}
 
 		// projectContextを初回送信済みとしてマーク
@@ -844,8 +864,8 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.textInput, tiCmd = m.textInput.Update(msg)
 	cmds = append(cmds, tiCmd)
 
-	// Check for mention leaks in real-time as user types
-	if m.currentView == viewChat {
+	// Check for mention leaks in real-time as user types (if enabled)
+	if m.currentView == viewChat && m.mentionCheckerEnabled {
 		input := m.textInput.Value()
 		result := mention.Check(input)
 		if result.NeedsWarning {
@@ -1147,16 +1167,19 @@ func (m tuiModel) View() string {
 
 	// Header - ビューに応じてタイトルを切り替え（行全体に背景色）
 	var headerContent string
-	var yoloIndicator string
+	var modeIndicators string
 	if m.yoloMode {
-		yoloIndicator = " " + yoloStyle.Render("YOLO")
+		modeIndicators += " " + yoloStyle.Render("YOLO")
+	}
+	if !m.mentionCheckerEnabled {
+		modeIndicators += " " + helpStyle.Render("[M:OFF]")
 	}
 	if m.currentView == viewTaskboard {
-		headerContent = titleStyle.Render("MAXAM "+Version) + yoloIndicator + "  " +
+		headerContent = titleStyle.Render("MAXAM "+Version) + modeIndicators + "  " +
 			helpStyle.Render("Task Board | Tab:チャット | ↑↓:選択 Enter:ステータス変更 d:削除")
 	} else {
-		headerContent = titleStyle.Render("MAXAM "+Version) + yoloIndicator + "  " +
-			helpStyle.Render("Team Chat | Tab:タスクボード | Ctrl+Y:YOLO | Ctrl+L:再描画")
+		headerContent = titleStyle.Render("MAXAM "+Version) + modeIndicators + "  " +
+			helpStyle.Render("Team Chat | Tab:タスクボード | Ctrl+Y:YOLO | Ctrl+N:メンション | Ctrl+L:再描画")
 	}
 	// 行全体に背景色を適用（幅いっぱいにパディング）
 	header := headerStyle.Width(m.width).Render(headerContent)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,14 +19,15 @@ const (
 
 // Config represents the MAXAM configuration
 type Config struct {
-	Version             string        `yaml:"version"`
-	TeamName            string        `yaml:"team_name,omitempty"`
-	DefaultAgent        string        `yaml:"default_agent,omitempty"`
-	Agents              []AgentConfig `yaml:"agents"`
-	AnalysisMinMessages int           `yaml:"analysis_min_messages,omitempty"`
-	ContextMode         ContextMode   `yaml:"context_mode,omitempty"`
-	YOLOMode            bool          `yaml:"yolo_mode,omitempty"`
-	WorkersPerAgent     int           `yaml:"workers_per_agent,omitempty"`
+	Version               string        `yaml:"version"`
+	TeamName              string        `yaml:"team_name,omitempty"`
+	DefaultAgent          string        `yaml:"default_agent,omitempty"`
+	Agents                []AgentConfig `yaml:"agents"`
+	AnalysisMinMessages   int           `yaml:"analysis_min_messages,omitempty"`
+	ContextMode           ContextMode   `yaml:"context_mode,omitempty"`
+	YOLOMode              bool          `yaml:"yolo_mode,omitempty"`
+	WorkersPerAgent       int           `yaml:"workers_per_agent,omitempty"`
+	MentionCheckerEnabled *bool         `yaml:"mention_checker_enabled,omitempty"`
 }
 
 // AgentConfig represents an agent configuration
@@ -232,6 +233,11 @@ func mergeConfigs(base, override *Config) *Config {
 		result.WorkersPerAgent = override.WorkersPerAgent
 	}
 
+	// Override mention checker enabled if explicitly set
+	if override.MentionCheckerEnabled != nil {
+		result.MentionCheckerEnabled = override.MentionCheckerEnabled
+	}
+
 	return &result
 }
 
@@ -382,4 +388,17 @@ func (c *Config) GetTeamName() string {
 		return "Team"
 	}
 	return c.TeamName
+}
+
+// IsMentionCheckerEnabled returns whether mention checker is enabled (default: true)
+func (c *Config) IsMentionCheckerEnabled() bool {
+	if c.MentionCheckerEnabled == nil {
+		return true // default enabled
+	}
+	return *c.MentionCheckerEnabled
+}
+
+// SetMentionCheckerEnabled sets the mention checker enabled state
+func (c *Config) SetMentionCheckerEnabled(enabled bool) {
+	c.MentionCheckerEnabled = &enabled
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1148,3 +1148,107 @@ func TestDefaultMaxInstances(t *testing.T) {
 		t.Errorf("DefaultMaxInstances = %d, want 3", DefaultMaxInstances)
 	}
 }
+
+func TestIsMentionCheckerEnabled(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name     string
+		cfg      *Config
+		expected bool
+	}{
+		{
+			name:     "デフォルト（nil）はtrue",
+			cfg:      &Config{},
+			expected: true,
+		},
+		{
+			name:     "明示的にtrue",
+			cfg:      &Config{MentionCheckerEnabled: &trueVal},
+			expected: true,
+		},
+		{
+			name:     "明示的にfalse",
+			cfg:      &Config{MentionCheckerEnabled: &falseVal},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.IsMentionCheckerEnabled()
+			if got != tt.expected {
+				t.Errorf("IsMentionCheckerEnabled() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSetMentionCheckerEnabled(t *testing.T) {
+	cfg := &Config{}
+
+	// 初期状態（nil）
+	if cfg.MentionCheckerEnabled != nil {
+		t.Error("MentionCheckerEnabled should be nil initially")
+	}
+
+	// trueに設定
+	cfg.SetMentionCheckerEnabled(true)
+	if cfg.MentionCheckerEnabled == nil || !*cfg.MentionCheckerEnabled {
+		t.Error("SetMentionCheckerEnabled(true) failed")
+	}
+
+	// falseに設定
+	cfg.SetMentionCheckerEnabled(false)
+	if cfg.MentionCheckerEnabled == nil || *cfg.MentionCheckerEnabled {
+		t.Error("SetMentionCheckerEnabled(false) failed")
+	}
+}
+
+func TestMergeConfigsMentionChecker(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name     string
+		base     *Config
+		override *Config
+		expected bool
+	}{
+		{
+			name:     "base=nil, override=nil → default true",
+			base:     &Config{},
+			override: &Config{},
+			expected: true,
+		},
+		{
+			name:     "base=true, override=nil → true",
+			base:     &Config{MentionCheckerEnabled: &trueVal},
+			override: &Config{},
+			expected: true,
+		},
+		{
+			name:     "base=nil, override=false → false",
+			base:     &Config{},
+			override: &Config{MentionCheckerEnabled: &falseVal},
+			expected: false,
+		},
+		{
+			name:     "base=true, override=false → false",
+			base:     &Config{MentionCheckerEnabled: &trueVal},
+			override: &Config{MentionCheckerEnabled: &falseVal},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			merged := mergeConfigs(tt.base, tt.override)
+			got := merged.IsMentionCheckerEnabled()
+			if got != tt.expected {
+				t.Errorf("IsMentionCheckerEnabled() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- TUIでメンションチェッカーのオン/オフをトグルできる機能を追加
- Ctrl+Nでトグル操作
- 設定はconfig.yamlに永続化、デフォルトはオン
- ヘッダーに現在の状態を表示（[M:OFF]：オフ時のみ）

## Test plan
- [ ] `go test ./...` が通ること
- [ ] TUIでCtrl+Nを押してトグルが切り替わることを確認
- [ ] オフ時にメンション警告が出ないことを確認
- [ ] 再起動後も設定が維持されることを確認

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)