### PR TITLE
daemon モードでメンションチェッカーをデフォルトオフにする

### DIFF
--- a/cmd/maxam/chat.go
+++ b/cmd/maxam/chat.go
@@ -17,13 +17,21 @@ import (
 	"github.com/ytnobody/MAXAM/internal/mention"
 )
 
+// chatFlags holds parsed command line flags for chat command
+type chatFlags struct {
+	agentName    string
+	daemon       bool
+	mentionCheck bool
+}
+
 // ChatSession manages an interactive conversation with an agent
 type ChatSession struct {
-	agents  *agent.Agents
-	members *member.Members
-	logMgr  *logger.Manager
-	workDir string
-	history []chatMessage
+	agents       *agent.Agents
+	members      *member.Members
+	logMgr       *logger.Manager
+	workDir      string
+	history      []chatMessage
+	mentionCheck bool
 }
 
 type chatMessage struct {
@@ -31,17 +39,52 @@ type chatMessage struct {
 	content string
 }
 
+// parseChatFlags parses command line arguments for chat command
+func parseChatFlags(args []string) chatFlags {
+	flags := chatFlags{
+		mentionCheck: true, // default: on
+	}
+
+	if len(args) < 3 {
+		return flags
+	}
+
+	flags.agentName = strings.ToLower(args[2])
+
+	// Parse remaining flags
+	for i := 3; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--daemon":
+			flags.daemon = true
+			// daemon mode: default mention check to false
+			flags.mentionCheck = false
+		case arg == "--mention-check":
+			flags.mentionCheck = true
+		case arg == "--mention-check=true":
+			flags.mentionCheck = true
+		case arg == "--mention-check=false":
+			flags.mentionCheck = false
+		case arg == "--no-mention-check":
+			flags.mentionCheck = false
+		}
+	}
+
+	return flags
+}
+
 func runChat() {
 	if len(os.Args) < 3 {
-		fmt.Fprintln(os.Stderr, "Usage: maxam chat <agent> [--daemon]")
+		fmt.Fprintln(os.Stderr, "Usage: maxam chat <agent> [flags]")
 		fmt.Fprintln(os.Stderr, "Agents: (run 'maxam team list' to see configured agents)")
 		fmt.Fprintln(os.Stderr, "Flags:")
-		fmt.Fprintln(os.Stderr, "  --daemon  Run in daemon mode (wait for input continuously)")
+		fmt.Fprintln(os.Stderr, "  --daemon          Run in daemon mode (wait for input continuously)")
+		fmt.Fprintln(os.Stderr, "  --mention-check   Enable mention checker (default: on, off in daemon mode)")
+		fmt.Fprintln(os.Stderr, "  --no-mention-check  Disable mention checker")
 		os.Exit(1)
 	}
 
-	agentName := strings.ToLower(os.Args[2])
-	daemon := len(os.Args) > 3 && os.Args[3] == "--daemon"
+	flags := parseChatFlags(os.Args)
 	workDir := getWorkDir()
 
 	// Ensure project .maxam/ directory is initialized
@@ -68,22 +111,23 @@ func runChat() {
 	}
 
 	session := &ChatSession{
-		agents:  agent.NewAgents(workDir),
-		members: member.NewMembers(workDir),
-		logMgr:  logger.NewManager(logger.GetDefaultLogDir(), workDir),
-		workDir: workDir,
-		history: make([]chatMessage, 0),
+		agents:       agent.NewAgents(workDir),
+		members:      member.NewMembers(workDir),
+		logMgr:       logger.NewManager(logger.GetDefaultLogDir(), workDir),
+		workDir:      workDir,
+		history:      make([]chatMessage, 0),
+		mentionCheck: flags.mentionCheck,
 	}
 	defer session.logMgr.Close()
 
-	if agentName == "team" {
-		if daemon {
+	if flags.agentName == "team" {
+		if flags.daemon {
 			session.runTeamChatDaemon()
 		} else {
 			session.runTeamChat()
 		}
 	} else {
-		session.runAgentChat(agentName)
+		session.runAgentChat(flags.agentName)
 	}
 }
 
@@ -148,8 +192,10 @@ func (s *ChatSession) runAgentChat(agentName string) {
 		fmt.Println(result)
 
 		// Check for mention leaks in agent response
-		if checkResult := mention.Check(result); checkResult.NeedsWarning {
-			fmt.Printf("⚠️  %s\n", mention.FormatWarning())
+		if s.mentionCheck {
+			if checkResult := mention.Check(result); checkResult.NeedsWarning {
+				fmt.Printf("⚠️  %s\n", mention.FormatWarning())
+			}
 		}
 
 		s.history = append(s.history, chatMessage{role: agentName, content: result})
@@ -227,8 +273,10 @@ func (s *ChatSession) runTeamChat() {
 			fmt.Println(result)
 
 			// Check for mention leaks in agent response
-			if checkResult := mention.Check(result); checkResult.NeedsWarning {
-				fmt.Printf("⚠️  %s\n", mention.FormatWarning())
+			if s.mentionCheck {
+				if checkResult := mention.Check(result); checkResult.NeedsWarning {
+					fmt.Printf("⚠️  %s\n", mention.FormatWarning())
+				}
 			}
 
 			s.history = append(s.history, chatMessage{role: agentName, content: result})
@@ -308,8 +356,10 @@ func (s *ChatSession) processTeamMessage(input string) {
 		fmt.Println(result)
 
 		// Check for mention leaks in agent response
-		if checkResult := mention.Check(result); checkResult.NeedsWarning {
-			fmt.Printf("⚠️  %s\n", mention.FormatWarning())
+		if s.mentionCheck {
+			if checkResult := mention.Check(result); checkResult.NeedsWarning {
+				fmt.Printf("⚠️  %s\n", mention.FormatWarning())
+			}
 		}
 
 		s.history = append(s.history, chatMessage{role: agentName, content: result})

--- a/cmd/maxam/chat_test.go
+++ b/cmd/maxam/chat_test.go
@@ -1,0 +1,86 @@
+package main
+
+import "testing"
+
+func TestParseChatFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantAgent    string
+		wantDaemon   bool
+		wantMention  bool
+	}{
+		{
+			name:         "agent only",
+			args:         []string{"maxam", "chat", "yuki"},
+			wantAgent:    "yuki",
+			wantDaemon:   false,
+			wantMention:  true,
+		},
+		{
+			name:         "agent with daemon",
+			args:         []string{"maxam", "chat", "team", "--daemon"},
+			wantAgent:    "team",
+			wantDaemon:   true,
+			wantMention:  false, // daemon mode: default off
+		},
+		{
+			name:         "daemon with mention-check explicitly enabled",
+			args:         []string{"maxam", "chat", "team", "--daemon", "--mention-check"},
+			wantAgent:    "team",
+			wantDaemon:   true,
+			wantMention:  true,
+		},
+		{
+			name:         "daemon with mention-check=true",
+			args:         []string{"maxam", "chat", "team", "--daemon", "--mention-check=true"},
+			wantAgent:    "team",
+			wantDaemon:   true,
+			wantMention:  true,
+		},
+		{
+			name:         "daemon with mention-check=false",
+			args:         []string{"maxam", "chat", "team", "--daemon", "--mention-check=false"},
+			wantAgent:    "team",
+			wantDaemon:   true,
+			wantMention:  false,
+		},
+		{
+			name:         "non-daemon with no-mention-check",
+			args:         []string{"maxam", "chat", "yuki", "--no-mention-check"},
+			wantAgent:    "yuki",
+			wantDaemon:   false,
+			wantMention:  false,
+		},
+		{
+			name:         "uppercase agent name normalized",
+			args:         []string{"maxam", "chat", "YUKI"},
+			wantAgent:    "yuki",
+			wantDaemon:   false,
+			wantMention:  true,
+		},
+		{
+			name:         "empty args",
+			args:         []string{"maxam", "chat"},
+			wantAgent:    "",
+			wantDaemon:   false,
+			wantMention:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := parseChatFlags(tt.args)
+
+			if flags.agentName != tt.wantAgent {
+				t.Errorf("agentName = %q, want %q", flags.agentName, tt.wantAgent)
+			}
+			if flags.daemon != tt.wantDaemon {
+				t.Errorf("daemon = %v, want %v", flags.daemon, tt.wantDaemon)
+			}
+			if flags.mentionCheck != tt.wantMention {
+				t.Errorf("mentionCheck = %v, want %v", flags.mentionCheck, tt.wantMention)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `--daemon` フラグ指定時は `--mention-check` をデフォルト `false` に変更
- 明示的に `--mention-check` または `--mention-check=true` を指定すれば有効化可能
- `--no-mention-check` または `--mention-check=false` で無効化も可能

## Changes

- `chatFlags` 構造体を追加してフラグ管理を整理
- `parseChatFlags` 関数でコマンドライン引数をパース
- `ChatSession` に `mentionCheck` フィールドを追加
- メンションチェック部分を条件分岐に変更

## Test

```bash
go test ./cmd/maxam/ -run TestParseChatFlags -v
```

8パターンのテストケースでカバー:
- 通常モード（メンションチェックON）
- daemonモード（メンションチェックOFF）
- daemonモードで明示的にON
- 通常モードで明示的にOFF

Closes #162

🤖 Generated with [Claude Code](https://claude.ai/code)