### PR TITLE
feat: add mode switching foundation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,11 +17,39 @@ const (
 	ContextModeSummary ContextMode = "summary"
 )
 
+// Mode represents the MAXAM operating mode
+type Mode string
+
+const (
+	// ModeInteractive is for free-form conversation with the team
+	ModeInteractive Mode = "interactive"
+	// ModePlan is for automated project analysis and planning
+	ModePlan Mode = "plan"
+	// ModeAuto is for automated implementation (only accessible from plan mode)
+	ModeAuto Mode = "auto"
+)
+
+// ValidModes returns all valid mode values
+func ValidModes() []Mode {
+	return []Mode{ModeInteractive, ModePlan, ModeAuto}
+}
+
+// IsValidMode checks if the given mode is valid
+func IsValidMode(m Mode) bool {
+	for _, valid := range ValidModes() {
+		if m == valid {
+			return true
+		}
+	}
+	return false
+}
+
 // Config represents the MAXAM configuration
 type Config struct {
 	Version               string        `yaml:"version"`
 	TeamName              string        `yaml:"team_name,omitempty"`
 	DefaultAgent          string        `yaml:"default_agent,omitempty"`
+	DefaultMode           Mode          `yaml:"default_mode,omitempty"`
 	Agents                []AgentConfig `yaml:"agents"`
 	AnalysisMinMessages   int           `yaml:"analysis_min_messages,omitempty"`
 	ContextMode           ContextMode   `yaml:"context_mode,omitempty"`
@@ -208,6 +236,11 @@ func mergeConfigs(base, override *Config) *Config {
 		result.DefaultAgent = override.DefaultAgent
 	}
 
+	// Override default mode if set
+	if override.DefaultMode != "" {
+		result.DefaultMode = override.DefaultMode
+	}
+
 	// Override agents if specified (complete replacement)
 	if len(override.Agents) > 0 {
 		result.Agents = override.Agents
@@ -388,6 +421,14 @@ func (c *Config) GetTeamName() string {
 		return "Team"
 	}
 	return c.TeamName
+}
+
+// GetDefaultMode returns the default operating mode with fallback
+func (c *Config) GetDefaultMode() Mode {
+	if c.DefaultMode == "" {
+		return ModeInteractive
+	}
+	return c.DefaultMode
 }
 
 // IsMentionCheckerEnabled returns whether mention checker is enabled (default: true)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1206,6 +1206,140 @@ func TestSetMentionCheckerEnabled(t *testing.T) {
 	}
 }
 
+func TestValidModes(t *testing.T) {
+	modes := ValidModes()
+	if len(modes) != 3 {
+		t.Errorf("ValidModes() returned %d modes, want 3", len(modes))
+	}
+
+	expected := map[Mode]bool{ModeInteractive: true, ModePlan: true, ModeAuto: true}
+	for _, m := range modes {
+		if !expected[m] {
+			t.Errorf("Unexpected mode: %q", m)
+		}
+	}
+}
+
+func TestIsValidMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     Mode
+		expected bool
+	}{
+		{
+			name:     "interactive is valid",
+			mode:     ModeInteractive,
+			expected: true,
+		},
+		{
+			name:     "plan is valid",
+			mode:     ModePlan,
+			expected: true,
+		},
+		{
+			name:     "auto is valid",
+			mode:     ModeAuto,
+			expected: true,
+		},
+		{
+			name:     "empty is invalid",
+			mode:     "",
+			expected: false,
+		},
+		{
+			name:     "unknown is invalid",
+			mode:     "unknown",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsValidMode(tt.mode)
+			if got != tt.expected {
+				t.Errorf("IsValidMode(%q) = %v, want %v", tt.mode, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetDefaultMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *Config
+		expected Mode
+	}{
+		{
+			name:     "empty defaults to interactive",
+			cfg:      &Config{},
+			expected: ModeInteractive,
+		},
+		{
+			name:     "explicit interactive",
+			cfg:      &Config{DefaultMode: ModeInteractive},
+			expected: ModeInteractive,
+		},
+		{
+			name:     "explicit plan",
+			cfg:      &Config{DefaultMode: ModePlan},
+			expected: ModePlan,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.GetDefaultMode()
+			if got != tt.expected {
+				t.Errorf("GetDefaultMode() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMergeConfigsDefaultMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     *Config
+		override *Config
+		expected Mode
+	}{
+		{
+			name:     "base=empty, override=empty → interactive",
+			base:     &Config{},
+			override: &Config{},
+			expected: ModeInteractive,
+		},
+		{
+			name:     "base=plan, override=empty → plan",
+			base:     &Config{DefaultMode: ModePlan},
+			override: &Config{},
+			expected: ModePlan,
+		},
+		{
+			name:     "base=empty, override=plan → plan",
+			base:     &Config{},
+			override: &Config{DefaultMode: ModePlan},
+			expected: ModePlan,
+		},
+		{
+			name:     "base=interactive, override=plan → plan",
+			base:     &Config{DefaultMode: ModeInteractive},
+			override: &Config{DefaultMode: ModePlan},
+			expected: ModePlan,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			merged := mergeConfigs(tt.base, tt.override)
+			got := merged.GetDefaultMode()
+			if got != tt.expected {
+				t.Errorf("GetDefaultMode() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestMergeConfigsMentionChecker(t *testing.T) {
 	trueVal := true
 	falseVal := false

--- a/internal/mode/command.go
+++ b/internal/mode/command.go
@@ -1,0 +1,57 @@
+package mode
+
+import (
+	"strings"
+)
+
+// Command represents a mode-related command
+type Command string
+
+const (
+	// CommandPlan enters plan mode
+	CommandPlan Command = "/plan"
+	// CommandStop stops current mode and returns to interactive
+	CommandStop Command = "/stop"
+	// CommandStatus shows current mode status
+	CommandStatus Command = "/status"
+)
+
+// ParseResult contains the result of parsing user input for commands
+type ParseResult struct {
+	IsCommand bool
+	Command   Command
+	Args      string // remaining text after command
+}
+
+// Parse parses user input and extracts any mode command
+func Parse(input string) ParseResult {
+	trimmed := strings.TrimSpace(input)
+
+	// Check for known commands
+	commands := []Command{CommandPlan, CommandStop, CommandStatus}
+	for _, cmd := range commands {
+		cmdStr := string(cmd)
+		if trimmed == cmdStr {
+			return ParseResult{
+				IsCommand: true,
+				Command:   cmd,
+				Args:      "",
+			}
+		}
+		if strings.HasPrefix(trimmed, cmdStr+" ") {
+			return ParseResult{
+				IsCommand: true,
+				Command:   cmd,
+				Args:      strings.TrimSpace(trimmed[len(cmdStr):]),
+			}
+		}
+	}
+
+	return ParseResult{IsCommand: false}
+}
+
+// IsCommand checks if the input starts with a command prefix
+func IsCommand(input string) bool {
+	trimmed := strings.TrimSpace(input)
+	return strings.HasPrefix(trimmed, "/")
+}

--- a/internal/mode/command_test.go
+++ b/internal/mode/command_test.go
@@ -1,0 +1,131 @@
+package mode
+
+import (
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantCommand bool
+		wantCmd     Command
+		wantArgs    string
+	}{
+		{
+			name:        "/plan command",
+			input:       "/plan",
+			wantCommand: true,
+			wantCmd:     CommandPlan,
+			wantArgs:    "",
+		},
+		{
+			name:        "/plan with args",
+			input:       "/plan some project analysis",
+			wantCommand: true,
+			wantCmd:     CommandPlan,
+			wantArgs:    "some project analysis",
+		},
+		{
+			name:        "/stop command",
+			input:       "/stop",
+			wantCommand: true,
+			wantCmd:     CommandStop,
+			wantArgs:    "",
+		},
+		{
+			name:        "/status command",
+			input:       "/status",
+			wantCommand: true,
+			wantCmd:     CommandStatus,
+			wantArgs:    "",
+		},
+		{
+			name:        "regular message",
+			input:       "hello team",
+			wantCommand: false,
+		},
+		{
+			name:        "unknown command",
+			input:       "/unknown",
+			wantCommand: false,
+		},
+		{
+			name:        "empty input",
+			input:       "",
+			wantCommand: false,
+		},
+		{
+			name:        "/plan with whitespace",
+			input:       "  /plan  ",
+			wantCommand: true,
+			wantCmd:     CommandPlan,
+			wantArgs:    "",
+		},
+		{
+			name:        "text containing /plan but not starting with it",
+			input:       "let's /plan this",
+			wantCommand: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Parse(tt.input)
+			if result.IsCommand != tt.wantCommand {
+				t.Errorf("IsCommand = %v, want %v", result.IsCommand, tt.wantCommand)
+			}
+			if tt.wantCommand {
+				if result.Command != tt.wantCmd {
+					t.Errorf("Command = %q, want %q", result.Command, tt.wantCmd)
+				}
+				if result.Args != tt.wantArgs {
+					t.Errorf("Args = %q, want %q", result.Args, tt.wantArgs)
+				}
+			}
+		})
+	}
+}
+
+func TestIsCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "starts with slash",
+			input:    "/plan",
+			expected: true,
+		},
+		{
+			name:     "slash with space prefix",
+			input:    "  /plan",
+			expected: true,
+		},
+		{
+			name:     "regular text",
+			input:    "hello",
+			expected: false,
+		},
+		{
+			name:     "slash in middle",
+			input:    "hello/world",
+			expected: false,
+		},
+		{
+			name:     "empty",
+			input:    "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsCommand(tt.input)
+			if got != tt.expected {
+				t.Errorf("IsCommand(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/mode/mode.go
+++ b/internal/mode/mode.go
@@ -1,0 +1,148 @@
+// Package mode manages MAXAM operating modes
+package mode
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/ytnobody/MAXAM/internal/config"
+)
+
+// Manager manages the current operating mode
+type Manager struct {
+	mu          sync.RWMutex
+	currentMode config.Mode
+	// planContext stores context from plan mode for auto mode transition
+	planContext *PlanContext
+}
+
+// PlanContext stores the context from plan mode
+type PlanContext struct {
+	DiscussionURL string   // URL of approved discussion
+	IssueNumbers  []int    // Issue numbers created from the plan
+	Approved      bool     // Whether the plan was approved
+}
+
+// NewManager creates a new mode manager with the given default mode
+func NewManager(defaultMode config.Mode) *Manager {
+	if defaultMode == "" {
+		defaultMode = config.ModeInteractive
+	}
+	return &Manager{
+		currentMode: defaultMode,
+	}
+}
+
+// Current returns the current operating mode
+func (m *Manager) Current() config.Mode {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.currentMode
+}
+
+// IsInteractive returns true if in interactive mode
+func (m *Manager) IsInteractive() bool {
+	return m.Current() == config.ModeInteractive
+}
+
+// IsPlan returns true if in plan mode
+func (m *Manager) IsPlan() bool {
+	return m.Current() == config.ModePlan
+}
+
+// IsAuto returns true if in auto mode
+func (m *Manager) IsAuto() bool {
+	return m.Current() == config.ModeAuto
+}
+
+// EnterPlanMode transitions to plan mode from interactive mode
+func (m *Manager) EnterPlanMode() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.currentMode != config.ModeInteractive {
+		return fmt.Errorf("can only enter plan mode from interactive mode (current: %s)", m.currentMode)
+	}
+
+	m.currentMode = config.ModePlan
+	m.planContext = &PlanContext{}
+	return nil
+}
+
+// EnterAutoMode transitions to auto mode from plan mode
+// Requires plan approval
+func (m *Manager) EnterAutoMode(ctx *PlanContext) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.currentMode != config.ModePlan {
+		return fmt.Errorf("can only enter auto mode from plan mode (current: %s)", m.currentMode)
+	}
+
+	if ctx == nil || !ctx.Approved {
+		return fmt.Errorf("cannot enter auto mode without approved plan")
+	}
+
+	m.currentMode = config.ModeAuto
+	m.planContext = ctx
+	return nil
+}
+
+// Stop returns to interactive mode from any mode
+func (m *Manager) Stop() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.currentMode = config.ModeInteractive
+	m.planContext = nil
+}
+
+// GetPlanContext returns the current plan context (nil if not in plan/auto mode)
+func (m *Manager) GetPlanContext() *PlanContext {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.planContext
+}
+
+// SetPlanApproved marks the current plan as approved
+func (m *Manager) SetPlanApproved(approved bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.planContext != nil {
+		m.planContext.Approved = approved
+	}
+}
+
+// AddIssue adds an issue number to the plan context
+func (m *Manager) AddIssue(issueNum int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.planContext != nil {
+		m.planContext.IssueNumbers = append(m.planContext.IssueNumbers, issueNum)
+	}
+}
+
+// StatusString returns a human-readable status string
+func (m *Manager) StatusString() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	switch m.currentMode {
+	case config.ModeInteractive:
+		return "Interactive Mode - Free conversation with the team"
+	case config.ModePlan:
+		if m.planContext != nil && m.planContext.Approved {
+			return "Plan Mode - Plan approved, ready for auto execution"
+		}
+		return "Plan Mode - Analyzing project and creating plan"
+	case config.ModeAuto:
+		if m.planContext != nil && len(m.planContext.IssueNumbers) > 0 {
+			return fmt.Sprintf("Auto Mode - Implementing Issues: %v", m.planContext.IssueNumbers)
+		}
+		return "Auto Mode - Automated implementation in progress"
+	default:
+		return fmt.Sprintf("Unknown Mode: %s", m.currentMode)
+	}
+}

--- a/internal/mode/mode_test.go
+++ b/internal/mode/mode_test.go
@@ -1,0 +1,234 @@
+package mode
+
+import (
+	"testing"
+
+	"github.com/ytnobody/MAXAM/internal/config"
+)
+
+func TestNewManager(t *testing.T) {
+	tests := []struct {
+		name        string
+		defaultMode config.Mode
+		wantMode    config.Mode
+	}{
+		{
+			name:        "empty default mode defaults to interactive",
+			defaultMode: "",
+			wantMode:    config.ModeInteractive,
+		},
+		{
+			name:        "explicit interactive mode",
+			defaultMode: config.ModeInteractive,
+			wantMode:    config.ModeInteractive,
+		},
+		{
+			name:        "explicit plan mode",
+			defaultMode: config.ModePlan,
+			wantMode:    config.ModePlan,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager(tt.defaultMode)
+			if got := m.Current(); got != tt.wantMode {
+				t.Errorf("Current() = %v, want %v", got, tt.wantMode)
+			}
+		})
+	}
+}
+
+func TestModeTransitions(t *testing.T) {
+	t.Run("interactive to plan mode", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+
+		if err := m.EnterPlanMode(); err != nil {
+			t.Errorf("EnterPlanMode() unexpected error: %v", err)
+		}
+
+		if !m.IsPlan() {
+			t.Error("expected to be in plan mode")
+		}
+	})
+
+	t.Run("plan to auto mode with approval", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+		m.EnterPlanMode()
+
+		ctx := &PlanContext{Approved: true}
+		if err := m.EnterAutoMode(ctx); err != nil {
+			t.Errorf("EnterAutoMode() unexpected error: %v", err)
+		}
+
+		if !m.IsAuto() {
+			t.Error("expected to be in auto mode")
+		}
+	})
+
+	t.Run("plan to auto mode without approval fails", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+		m.EnterPlanMode()
+
+		ctx := &PlanContext{Approved: false}
+		if err := m.EnterAutoMode(ctx); err == nil {
+			t.Error("EnterAutoMode() expected error for unapproved plan")
+		}
+	})
+
+	t.Run("direct auto mode from interactive fails", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+
+		ctx := &PlanContext{Approved: true}
+		if err := m.EnterAutoMode(ctx); err == nil {
+			t.Error("EnterAutoMode() expected error when not in plan mode")
+		}
+	})
+
+	t.Run("stop returns to interactive", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+		m.EnterPlanMode()
+
+		m.Stop()
+
+		if !m.IsInteractive() {
+			t.Error("expected to be in interactive mode after stop")
+		}
+	})
+
+	t.Run("stop from auto returns to interactive", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+		m.EnterPlanMode()
+		m.EnterAutoMode(&PlanContext{Approved: true})
+
+		m.Stop()
+
+		if !m.IsInteractive() {
+			t.Error("expected to be in interactive mode after stop")
+		}
+	})
+}
+
+func TestPlanContext(t *testing.T) {
+	t.Run("plan context is set in plan mode", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+		m.EnterPlanMode()
+
+		ctx := m.GetPlanContext()
+		if ctx == nil {
+			t.Error("expected plan context to be set")
+		}
+	})
+
+	t.Run("set plan approved", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+		m.EnterPlanMode()
+
+		m.SetPlanApproved(true)
+
+		ctx := m.GetPlanContext()
+		if !ctx.Approved {
+			t.Error("expected plan to be approved")
+		}
+	})
+
+	t.Run("add issue to plan", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+		m.EnterPlanMode()
+
+		m.AddIssue(123)
+		m.AddIssue(456)
+
+		ctx := m.GetPlanContext()
+		if len(ctx.IssueNumbers) != 2 {
+			t.Errorf("expected 2 issues, got %d", len(ctx.IssueNumbers))
+		}
+		if ctx.IssueNumbers[0] != 123 || ctx.IssueNumbers[1] != 456 {
+			t.Errorf("unexpected issue numbers: %v", ctx.IssueNumbers)
+		}
+	})
+
+	t.Run("plan context cleared on stop", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+		m.EnterPlanMode()
+		m.AddIssue(123)
+
+		m.Stop()
+
+		if ctx := m.GetPlanContext(); ctx != nil {
+			t.Error("expected plan context to be nil after stop")
+		}
+	})
+}
+
+func TestStatusString(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(*Manager)
+		contains string
+	}{
+		{
+			name:     "interactive mode",
+			setup:    func(m *Manager) {},
+			contains: "Interactive",
+		},
+		{
+			name: "plan mode",
+			setup: func(m *Manager) {
+				m.EnterPlanMode()
+			},
+			contains: "Plan Mode",
+		},
+		{
+			name: "plan mode approved",
+			setup: func(m *Manager) {
+				m.EnterPlanMode()
+				m.SetPlanApproved(true)
+			},
+			contains: "approved",
+		},
+		{
+			name: "auto mode",
+			setup: func(m *Manager) {
+				m.EnterPlanMode()
+				m.EnterAutoMode(&PlanContext{Approved: true})
+			},
+			contains: "Auto Mode",
+		},
+		{
+			name: "auto mode with issues",
+			setup: func(m *Manager) {
+				m.EnterPlanMode()
+				m.AddIssue(42)
+				m.EnterAutoMode(&PlanContext{Approved: true, IssueNumbers: []int{42}})
+			},
+			contains: "42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager(config.ModeInteractive)
+			tt.setup(m)
+
+			status := m.StatusString()
+			if !containsString(status, tt.contains) {
+				t.Errorf("StatusString() = %q, expected to contain %q", status, tt.contains)
+			}
+		})
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Add `Mode` type (`interactive`/`plan`/`auto`) to config with `DefaultMode` field
- Add `internal/mode` package with `Manager` for mode state management
- Add command parser for `/plan`, `/stop`, `/status` commands
- Full test coverage for new functionality

## Test plan
- [x] `go test ./internal/config/...` - Mode type and config tests pass
- [x] `go test ./internal/mode/...` - Manager and command parser tests pass
- [x] `go test ./...` - All existing tests still pass

## Notes
This is Phase 1 (foundation). TUI integration and actual mode behaviors will be added in subsequent Issues (#167, #168, #169).

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)