### PR TITLE
feat: add ProposalWorkflow for automated issue analysis

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -240,3 +240,38 @@ func (c *Client) GetPRFiles(ctx context.Context, number int) ([]*github.CommitFi
 	}
 	return files, nil
 }
+
+// Label operations
+
+// AddLabel adds a label to an issue
+func (c *Client) AddLabel(ctx context.Context, number int, label string) error {
+	_, _, err := c.client.Issues.AddLabelsToIssue(ctx, c.owner, c.repo, number, []string{label})
+	if err != nil {
+		return fmt.Errorf("add label: %w", err)
+	}
+	return nil
+}
+
+// RemoveLabel removes a label from an issue
+func (c *Client) RemoveLabel(ctx context.Context, number int, label string) error {
+	_, err := c.client.Issues.RemoveLabelForIssue(ctx, c.owner, c.repo, number, label)
+	if err != nil {
+		return fmt.Errorf("remove label: %w", err)
+	}
+	return nil
+}
+
+// HasLabel checks if an issue has a specific label
+func (c *Client) HasLabel(ctx context.Context, number int, label string) (bool, error) {
+	issue, _, err := c.client.Issues.Get(ctx, c.owner, c.repo, number)
+	if err != nil {
+		return false, fmt.Errorf("get issue: %w", err)
+	}
+
+	for _, l := range issue.Labels {
+		if l.GetName() == label {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/workflow/proposal.go
+++ b/internal/workflow/proposal.go
@@ -1,0 +1,190 @@
+// Package workflow implements agent collaboration workflows
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ytnobody/MAXAM/internal/agent"
+	"github.com/ytnobody/MAXAM/internal/github"
+	"github.com/ytnobody/MAXAM/internal/logger"
+)
+
+// Label constants for proposal workflow
+const (
+	LabelProposal      = "proposal"
+	LabelProposalReady = "proposal-ready"
+)
+
+// ProposalWorkflow represents the proposal analysis and generation workflow
+type ProposalWorkflow struct {
+	agents   *agent.Agents
+	logMgr   *logger.Manager
+	ghClient *github.Client
+}
+
+// NewProposalWorkflow creates a new proposal workflow
+func NewProposalWorkflow(agents *agent.Agents, logMgr *logger.Manager, ghClient *github.Client) *ProposalWorkflow {
+	return &ProposalWorkflow{
+		agents:   agents,
+		logMgr:   logMgr,
+		ghClient: ghClient,
+	}
+}
+
+// ProposalResult contains the outcome of the proposal workflow
+type ProposalResult struct {
+	IssueNumber int
+	Analysis    string
+	Proposal    string
+	Success     bool
+	Error       error
+}
+
+// Run executes the proposal workflow for a given issue
+func (pw *ProposalWorkflow) Run(ctx context.Context, issueNumber int) (*ProposalResult, error) {
+	result := &ProposalResult{
+		IssueNumber: issueNumber,
+	}
+
+	fmt.Printf("[ProposalWorkflow] Starting for issue #%d\n", issueNumber)
+
+	// Get issue details
+	issue, err := pw.ghClient.GetIssue(ctx, issueNumber)
+	if err != nil {
+		return nil, fmt.Errorf("get issue: %w", err)
+	}
+
+	// Get analyst agent (Amara)
+	analyst, ok := pw.agents.GetByRole("analyst")
+	if !ok {
+		return nil, fmt.Errorf("no agent with 'analyst' role found")
+	}
+
+	// Build analysis prompt
+	prompt := pw.buildAnalysisPrompt(issue.GetTitle(), issue.GetBody())
+
+	// Run analysis
+	fmt.Printf("[%s] Analyzing issue...\n", analyst.Name)
+	start := time.Now()
+	analysis, err := analyst.Run(ctx, prompt)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		result.Error = fmt.Errorf("analysis: %w", err)
+		return result, nil
+	}
+	result.Analysis = analysis
+	fmt.Printf("[%s] Analysis complete (%v)\n", analyst.Name, elapsed.Round(time.Millisecond))
+
+	// Log analyst's work
+	if log, err := pw.logMgr.Get(strings.ToLower(strings.Split(analyst.Name, " ")[0])); err == nil {
+		log.LogSimple(prompt, analysis, elapsed)
+	}
+
+	// Generate proposal from analysis
+	proposal := pw.buildProposal(issue.GetTitle(), analysis)
+	result.Proposal = proposal
+
+	// Post proposal as comment
+	fmt.Printf("[ProposalWorkflow] Posting proposal to issue #%d\n", issueNumber)
+	if err := pw.ghClient.CommentIssue(ctx, issueNumber, proposal); err != nil {
+		result.Error = fmt.Errorf("post comment: %w", err)
+		return result, nil
+	}
+
+	// Add proposal-ready label
+	if err := pw.ghClient.AddLabel(ctx, issueNumber, LabelProposalReady); err != nil {
+		result.Error = fmt.Errorf("add label: %w", err)
+		return result, nil
+	}
+
+	// Remove proposal label (workflow completed)
+	if err := pw.ghClient.RemoveLabel(ctx, issueNumber, LabelProposal); err != nil {
+		// Non-critical, just log
+		fmt.Printf("[ProposalWorkflow] Warning: could not remove '%s' label: %v\n", LabelProposal, err)
+	}
+
+	result.Success = true
+	fmt.Printf("[ProposalWorkflow] Completed for issue #%d\n", issueNumber)
+
+	return result, nil
+}
+
+func (pw *ProposalWorkflow) buildAnalysisPrompt(title, body string) string {
+	return fmt.Sprintf(`以下のIssueを分析し、実装提案を作成してください。
+
+## Issue タイトル
+%s
+
+## Issue 本文
+%s
+
+## 分析観点
+1. 要件の明確化（曖昧な点の指摘）
+2. 技術的な実現可能性
+3. 影響範囲の特定
+4. リスクの洗い出し
+5. 実装方針の提案
+
+## 出力形式
+### 要件サマリ
+（Issue の要件を箇条書きで整理）
+
+### 技術的考察
+（実現方法、選択肢、トレードオフ）
+
+### 影響範囲
+（変更が必要なファイル、モジュール）
+
+### リスク・懸念事項
+（注意すべき点）
+
+### 推奨実装方針
+（具体的な進め方）
+`, title, body)
+}
+
+func (pw *ProposalWorkflow) buildProposal(title, analysis string) string {
+	return fmt.Sprintf(`## 提案: %s
+
+%s
+
+---
+_この提案は MAXAM の ProposalWorkflow によって自動生成されました。_
+`, title, analysis)
+}
+
+// HandleLabeledEvent processes an issue labeled event and triggers workflow if applicable
+func (pw *ProposalWorkflow) HandleLabeledEvent(ctx context.Context, event *github.IssuesEvent) error {
+	if event.Action != "labeled" {
+		return nil
+	}
+
+	// Check if the proposal label was added
+	hasProposalLabel := false
+	for _, label := range event.Issue.Labels {
+		if label.Name == LabelProposal {
+			hasProposalLabel = true
+			break
+		}
+	}
+
+	if !hasProposalLabel {
+		return nil
+	}
+
+	// Run the proposal workflow
+	result, err := pw.Run(ctx, event.Issue.Number)
+	if err != nil {
+		return fmt.Errorf("proposal workflow: %w", err)
+	}
+
+	if result.Error != nil {
+		return fmt.Errorf("proposal workflow result: %w", result.Error)
+	}
+
+	return nil
+}

--- a/internal/workflow/proposal_test.go
+++ b/internal/workflow/proposal_test.go
@@ -1,0 +1,107 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ytnobody/MAXAM/internal/github"
+)
+
+func TestBuildAnalysisPrompt(t *testing.T) {
+	pw := &ProposalWorkflow{}
+
+	title := "Add dark mode support"
+	body := "We need dark mode for better user experience"
+
+	prompt := pw.buildAnalysisPrompt(title, body)
+
+	// Check that title and body are included
+	if !strings.Contains(prompt, title) {
+		t.Error("prompt should contain issue title")
+	}
+	if !strings.Contains(prompt, body) {
+		t.Error("prompt should contain issue body")
+	}
+
+	// Check analysis sections are defined
+	expectedSections := []string{
+		"要件の明確化",
+		"技術的な実現可能性",
+		"影響範囲",
+		"リスク",
+		"実装方針",
+	}
+
+	for _, section := range expectedSections {
+		if !strings.Contains(prompt, section) {
+			t.Errorf("prompt should contain section %q", section)
+		}
+	}
+}
+
+func TestBuildProposal(t *testing.T) {
+	pw := &ProposalWorkflow{}
+
+	title := "Add dark mode support"
+	analysis := "### 要件サマリ\n- ダークモード対応\n\n### 推奨実装方針\n- CSS変数を使用"
+
+	proposal := pw.buildProposal(title, analysis)
+
+	// Check structure
+	if !strings.Contains(proposal, "## 提案: "+title) {
+		t.Error("proposal should have title header")
+	}
+	if !strings.Contains(proposal, analysis) {
+		t.Error("proposal should contain analysis")
+	}
+	if !strings.Contains(proposal, "ProposalWorkflow") {
+		t.Error("proposal should have attribution footer")
+	}
+}
+
+func TestHandleLabeledEvent_IgnoresNonLabeledAction(t *testing.T) {
+	pw := &ProposalWorkflow{}
+
+	event := &github.IssuesEvent{
+		Action: "opened", // Not "labeled"
+	}
+	event.Issue.Number = 1
+	event.Issue.Labels = []struct {
+		Name string `json:"name"`
+	}{{Name: LabelProposal}}
+
+	// This should return nil without doing anything
+	// (since Action != "labeled")
+	err := pw.HandleLabeledEvent(nil, event)
+	if err != nil {
+		t.Errorf("expected nil error for non-labeled action, got %v", err)
+	}
+}
+
+func TestHandleLabeledEvent_IgnoresNonProposalLabel(t *testing.T) {
+	pw := &ProposalWorkflow{}
+
+	event := &github.IssuesEvent{
+		Action: "labeled",
+	}
+	event.Issue.Number = 1
+	event.Issue.Labels = []struct {
+		Name string `json:"name"`
+	}{{Name: "bug"}} // Not "proposal"
+
+	// This should return nil without doing anything
+	err := pw.HandleLabeledEvent(nil, event)
+	if err != nil {
+		t.Errorf("expected nil error for non-proposal label, got %v", err)
+	}
+}
+
+func TestLabelConstants(t *testing.T) {
+	// Ensure label constants are defined correctly
+	if LabelProposal != "proposal" {
+		t.Errorf("LabelProposal = %q, want %q", LabelProposal, "proposal")
+	}
+	if LabelProposalReady != "proposal-ready" {
+		t.Errorf("LabelProposalReady = %q, want %q", LabelProposalReady, "proposal-ready")
+	}
+}


### PR DESCRIPTION
## Summary
- `proposal` ラベルが付いたIssueを自動分析し、提案をコメントで投稿するワークフロー
- ラベル操作API（AddLabel/RemoveLabel/HasLabel）を追加
- 分析完了後は `proposal-ready` ラベルを付与

## Changes
- `internal/github/client.go`: ラベル操作関数を追加
- `internal/workflow/proposal.go`: ProposalWorkflow本体
- `internal/workflow/proposal_test.go`: テスト

## Test plan
- [x] `go test ./internal/workflow/...` パス確認
- [x] `go build ./...` ビルド確認
- [ ] 実際にIssueに `proposal` ラベルを付けて動作確認（webhook統合後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)