### PR TITLE
feat: モード間遷移管理を追加 (#169)

### DIFF
--- a/internal/mode/transition.go
+++ b/internal/mode/transition.go
@@ -1,0 +1,202 @@
+// Package mode manages MAXAM operating modes
+package mode
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/ytnobody/MAXAM/internal/auto"
+	"github.com/ytnobody/MAXAM/internal/config"
+)
+
+// TransitionManager manages mode transitions
+type TransitionManager struct {
+	mu sync.RWMutex
+
+	modeManager *Manager
+	runner      *auto.Runner
+
+	// Callbacks
+	onTransition func(from, to config.Mode)
+	onError      func(err error)
+}
+
+// NewTransitionManager creates a new transition manager
+func NewTransitionManager(modeManager *Manager, runner *auto.Runner) *TransitionManager {
+	return &TransitionManager{
+		modeManager: modeManager,
+		runner:      runner,
+	}
+}
+
+// SetOnTransition sets the callback for mode transitions
+func (t *TransitionManager) SetOnTransition(fn func(from, to config.Mode)) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.onTransition = fn
+}
+
+// SetOnError sets the callback for transition errors
+func (t *TransitionManager) SetOnError(fn func(err error)) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.onError = fn
+}
+
+// TransitionRequest represents a request to transition modes
+type TransitionRequest struct {
+	// From is the expected current mode (optional, for validation)
+	From config.Mode
+	// To is the target mode
+	To config.Mode
+	// PlanContext is required when transitioning to auto mode
+	PlanContext *PlanContext
+	// Issues is the list of issues to execute (for auto mode)
+	Issues []auto.IssueInfo
+}
+
+// TransitionResult represents the result of a transition
+type TransitionResult struct {
+	Success bool
+	From    config.Mode
+	To      config.Mode
+	Error   error
+}
+
+// Transition performs a mode transition
+func (t *TransitionManager) Transition(req TransitionRequest) TransitionResult {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	currentMode := t.modeManager.Current()
+
+	// Validate from mode if specified
+	if req.From != "" && req.From != currentMode {
+		return TransitionResult{
+			Success: false,
+			From:    currentMode,
+			To:      req.To,
+			Error:   fmt.Errorf("expected mode %s but current is %s", req.From, currentMode),
+		}
+	}
+
+	var err error
+	switch req.To {
+	case config.ModeInteractive:
+		t.modeManager.Stop()
+	case config.ModePlan:
+		err = t.modeManager.EnterPlanMode()
+	case config.ModeAuto:
+		err = t.transitionToAuto(req.PlanContext)
+	default:
+		err = fmt.Errorf("unknown target mode: %s", req.To)
+	}
+
+	if err != nil {
+		if t.onError != nil {
+			t.onError(err)
+		}
+		return TransitionResult{
+			Success: false,
+			From:    currentMode,
+			To:      req.To,
+			Error:   err,
+		}
+	}
+
+	// Notify transition
+	if t.onTransition != nil {
+		t.onTransition(currentMode, req.To)
+	}
+
+	return TransitionResult{
+		Success: true,
+		From:    currentMode,
+		To:      req.To,
+	}
+}
+
+// transitionToAuto handles the transition to auto mode
+func (t *TransitionManager) transitionToAuto(planCtx *PlanContext) error {
+	if planCtx == nil {
+		return fmt.Errorf("plan context is required for auto mode")
+	}
+	if !planCtx.Approved {
+		return fmt.Errorf("plan must be approved before transitioning to auto mode")
+	}
+
+	return t.modeManager.EnterAutoMode(planCtx)
+}
+
+// TransitionToAutoAndRun transitions to auto mode and starts execution
+// This is a convenience method that combines transition and execution
+func (t *TransitionManager) TransitionToAutoAndRun(ctx context.Context, planCtx *PlanContext, issues []auto.IssueInfo) error {
+	result := t.Transition(TransitionRequest{
+		From:        config.ModePlan,
+		To:          config.ModeAuto,
+		PlanContext: planCtx,
+		Issues:      issues,
+	})
+
+	if !result.Success {
+		return result.Error
+	}
+
+	// Add tasks to runner
+	t.runner.AddTasks(issues)
+
+	// Start runner in background
+	go func() {
+		if err := t.runner.Run(ctx); err != nil {
+			log.Printf("Auto runner failed: %v", err)
+			if t.onError != nil {
+				t.onError(fmt.Errorf("auto runner failed: %w", err))
+			}
+		}
+	}()
+
+	return nil
+}
+
+// CanTransition checks if a transition is valid without performing it
+func (t *TransitionManager) CanTransition(from, to config.Mode) bool {
+	switch from {
+	case config.ModeInteractive:
+		return to == config.ModePlan
+	case config.ModePlan:
+		return to == config.ModeAuto || to == config.ModeInteractive
+	case config.ModeAuto:
+		return to == config.ModeInteractive
+	default:
+		return false
+	}
+}
+
+// ValidTransitions returns all valid transitions from the current mode
+func (t *TransitionManager) ValidTransitions() []config.Mode {
+	currentMode := t.modeManager.Current()
+	var valid []config.Mode
+
+	switch currentMode {
+	case config.ModeInteractive:
+		valid = append(valid, config.ModePlan)
+	case config.ModePlan:
+		valid = append(valid, config.ModeAuto, config.ModeInteractive)
+	case config.ModeAuto:
+		valid = append(valid, config.ModeInteractive)
+	}
+
+	return valid
+}
+
+// CurrentMode returns the current mode
+func (t *TransitionManager) CurrentMode() config.Mode {
+	return t.modeManager.Current()
+}
+
+// Runner returns the auto runner
+func (t *TransitionManager) Runner() *auto.Runner {
+	return t.runner
+}

--- a/internal/mode/transition_test.go
+++ b/internal/mode/transition_test.go
@@ -1,0 +1,346 @@
+package mode
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ytnobody/MAXAM/internal/auto"
+	"github.com/ytnobody/MAXAM/internal/config"
+)
+
+// stubExecutor is a test stub for TaskExecutor
+type stubExecutor struct {
+	executeFunc func(ctx context.Context, issueNumber int, title string) (int, error)
+}
+
+func (s *stubExecutor) Execute(ctx context.Context, issueNumber int, title string) (int, error) {
+	if s.executeFunc != nil {
+		return s.executeFunc(ctx, issueNumber, title)
+	}
+	return issueNumber * 10, nil // default: return PR number as issue*10
+}
+
+func newTestRunner() *auto.Runner {
+	return auto.NewRunner(&stubExecutor{}, auto.DefaultConfig())
+}
+
+func TestNewTransitionManager(t *testing.T) {
+	mm := NewManager(config.ModeInteractive)
+	runner := newTestRunner()
+
+	tm := NewTransitionManager(mm, runner)
+
+	if tm == nil {
+		t.Fatal("expected non-nil TransitionManager")
+	}
+	if tm.modeManager != mm {
+		t.Error("modeManager not set correctly")
+	}
+	if tm.runner != runner {
+		t.Error("runner not set correctly")
+	}
+}
+
+func TestTransitionManager_Transition(t *testing.T) {
+	tests := []struct {
+		name        string
+		initialMode config.Mode
+		request     TransitionRequest
+		wantSuccess bool
+		wantTo      config.Mode
+	}{
+		{
+			name:        "interactive to plan",
+			initialMode: config.ModeInteractive,
+			request: TransitionRequest{
+				To: config.ModePlan,
+			},
+			wantSuccess: true,
+			wantTo:      config.ModePlan,
+		},
+		{
+			name:        "plan to auto with approved context",
+			initialMode: config.ModePlan,
+			request: TransitionRequest{
+				To:          config.ModeAuto,
+				PlanContext: &PlanContext{Approved: true},
+			},
+			wantSuccess: true,
+			wantTo:      config.ModeAuto,
+		},
+		{
+			name:        "plan to auto without approval",
+			initialMode: config.ModePlan,
+			request: TransitionRequest{
+				To:          config.ModeAuto,
+				PlanContext: &PlanContext{Approved: false},
+			},
+			wantSuccess: false,
+			wantTo:      config.ModeAuto,
+		},
+		{
+			name:        "plan to auto without context",
+			initialMode: config.ModePlan,
+			request: TransitionRequest{
+				To: config.ModeAuto,
+			},
+			wantSuccess: false,
+			wantTo:      config.ModeAuto,
+		},
+		{
+			name:        "auto to interactive",
+			initialMode: config.ModeAuto,
+			request: TransitionRequest{
+				To: config.ModeInteractive,
+			},
+			wantSuccess: true,
+			wantTo:      config.ModeInteractive,
+		},
+		{
+			name:        "wrong from mode",
+			initialMode: config.ModeInteractive,
+			request: TransitionRequest{
+				From: config.ModePlan, // wrong
+				To:   config.ModeAuto,
+			},
+			wantSuccess: false,
+			wantTo:      config.ModeAuto,
+		},
+		{
+			name:        "plan to interactive (cancel)",
+			initialMode: config.ModePlan,
+			request: TransitionRequest{
+				To: config.ModeInteractive,
+			},
+			wantSuccess: true,
+			wantTo:      config.ModeInteractive,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mm := NewManager(config.ModeInteractive)
+			runner := newTestRunner()
+			tm := NewTransitionManager(mm, runner)
+
+			// Set up initial mode
+			switch tt.initialMode {
+			case config.ModePlan:
+				mm.EnterPlanMode()
+			case config.ModeAuto:
+				mm.EnterPlanMode()
+				mm.SetPlanApproved(true)
+				mm.EnterAutoMode(mm.GetPlanContext())
+			}
+
+			result := tm.Transition(tt.request)
+
+			if result.Success != tt.wantSuccess {
+				t.Errorf("Transition() success = %v, want %v (error: %v)", result.Success, tt.wantSuccess, result.Error)
+			}
+			if result.To != tt.wantTo {
+				t.Errorf("Transition() to = %v, want %v", result.To, tt.wantTo)
+			}
+
+			if tt.wantSuccess {
+				if mm.Current() != tt.wantTo {
+					t.Errorf("current mode = %v, want %v", mm.Current(), tt.wantTo)
+				}
+			}
+		})
+	}
+}
+
+func TestTransitionManager_Callbacks(t *testing.T) {
+	mm := NewManager(config.ModeInteractive)
+	runner := newTestRunner()
+	tm := NewTransitionManager(mm, runner)
+
+	var transitionCalled bool
+	var transitionFrom, transitionTo config.Mode
+	var mu sync.Mutex
+
+	tm.SetOnTransition(func(from, to config.Mode) {
+		mu.Lock()
+		defer mu.Unlock()
+		transitionCalled = true
+		transitionFrom = from
+		transitionTo = to
+	})
+
+	result := tm.Transition(TransitionRequest{To: config.ModePlan})
+	if !result.Success {
+		t.Fatalf("transition failed: %v", result.Error)
+	}
+
+	mu.Lock()
+	if !transitionCalled {
+		t.Error("onTransition callback not called")
+	}
+	if transitionFrom != config.ModeInteractive {
+		t.Errorf("transitionFrom = %v, want %v", transitionFrom, config.ModeInteractive)
+	}
+	if transitionTo != config.ModePlan {
+		t.Errorf("transitionTo = %v, want %v", transitionTo, config.ModePlan)
+	}
+	mu.Unlock()
+}
+
+func TestTransitionManager_ErrorCallback(t *testing.T) {
+	mm := NewManager(config.ModeInteractive)
+	runner := newTestRunner()
+	tm := NewTransitionManager(mm, runner)
+
+	var errorCalled bool
+	var errorReceived error
+
+	tm.SetOnError(func(err error) {
+		errorCalled = true
+		errorReceived = err
+	})
+
+	// Try invalid transition (interactive -> auto without plan)
+	result := tm.Transition(TransitionRequest{To: config.ModeAuto})
+
+	if result.Success {
+		t.Error("expected transition to fail")
+	}
+	if !errorCalled {
+		t.Error("onError callback not called")
+	}
+	if errorReceived == nil {
+		t.Error("expected error to be set")
+	}
+}
+
+func TestTransitionManager_CanTransition(t *testing.T) {
+	tests := []struct {
+		from config.Mode
+		to   config.Mode
+		want bool
+	}{
+		{config.ModeInteractive, config.ModePlan, true},
+		{config.ModeInteractive, config.ModeAuto, false},
+		{config.ModeInteractive, config.ModeInteractive, false},
+		{config.ModePlan, config.ModeAuto, true},
+		{config.ModePlan, config.ModeInteractive, true},
+		{config.ModePlan, config.ModePlan, false},
+		{config.ModeAuto, config.ModeInteractive, true},
+		{config.ModeAuto, config.ModePlan, false},
+		{config.ModeAuto, config.ModeAuto, false},
+	}
+
+	mm := NewManager(config.ModeInteractive)
+	runner := newTestRunner()
+	tm := NewTransitionManager(mm, runner)
+
+	for _, tt := range tests {
+		t.Run(string(tt.from)+"->"+string(tt.to), func(t *testing.T) {
+			got := tm.CanTransition(tt.from, tt.to)
+			if got != tt.want {
+				t.Errorf("CanTransition(%s, %s) = %v, want %v", tt.from, tt.to, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransitionManager_ValidTransitions(t *testing.T) {
+	tests := []struct {
+		currentMode config.Mode
+		want        []config.Mode
+	}{
+		{config.ModeInteractive, []config.Mode{config.ModePlan}},
+		{config.ModePlan, []config.Mode{config.ModeAuto, config.ModeInteractive}},
+		{config.ModeAuto, []config.Mode{config.ModeInteractive}},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.currentMode), func(t *testing.T) {
+			mm := NewManager(tt.currentMode)
+			runner := newTestRunner()
+			tm := NewTransitionManager(mm, runner)
+
+			got := tm.ValidTransitions()
+
+			if len(got) != len(tt.want) {
+				t.Errorf("ValidTransitions() = %v, want %v", got, tt.want)
+				return
+			}
+			for i, v := range got {
+				if v != tt.want[i] {
+					t.Errorf("ValidTransitions()[%d] = %v, want %v", i, v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestTransitionManager_TransitionToAutoAndRun(t *testing.T) {
+	mm := NewManager(config.ModeInteractive)
+
+	executed := make(chan bool, 1)
+	executor := &stubExecutor{
+		executeFunc: func(ctx context.Context, issueNumber int, title string) (int, error) {
+			executed <- true
+			return issueNumber * 10, nil
+		},
+	}
+	runner := auto.NewRunner(executor, auto.DefaultConfig())
+
+	tm := NewTransitionManager(mm, runner)
+
+	// First enter plan mode
+	mm.EnterPlanMode()
+	mm.SetPlanApproved(true)
+	planCtx := mm.GetPlanContext()
+
+	issues := []auto.IssueInfo{
+		{Number: 123, Title: "Test Issue"},
+	}
+
+	err := tm.TransitionToAutoAndRun(context.Background(), planCtx, issues)
+	if err != nil {
+		t.Fatalf("TransitionToAutoAndRun() error = %v", err)
+	}
+
+	// Check mode changed
+	if mm.Current() != config.ModeAuto {
+		t.Errorf("current mode = %v, want %v", mm.Current(), config.ModeAuto)
+	}
+
+	// Wait for runner to execute
+	select {
+	case <-executed:
+		// OK
+	case <-time.After(time.Second):
+		t.Error("runner did not execute within timeout")
+	}
+}
+
+func TestTransitionManager_CurrentMode(t *testing.T) {
+	mm := NewManager(config.ModeInteractive)
+	runner := newTestRunner()
+	tm := NewTransitionManager(mm, runner)
+
+	if tm.CurrentMode() != config.ModeInteractive {
+		t.Errorf("CurrentMode() = %v, want %v", tm.CurrentMode(), config.ModeInteractive)
+	}
+
+	tm.Transition(TransitionRequest{To: config.ModePlan})
+
+	if tm.CurrentMode() != config.ModePlan {
+		t.Errorf("CurrentMode() = %v, want %v", tm.CurrentMode(), config.ModePlan)
+	}
+}
+
+func TestTransitionManager_Runner(t *testing.T) {
+	mm := NewManager(config.ModeInteractive)
+	runner := newTestRunner()
+	tm := NewTransitionManager(mm, runner)
+
+	if tm.Runner() != runner {
+		t.Error("Runner() did not return the same runner instance")
+	}
+}


### PR DESCRIPTION
## Summary
- TransitionManagerを追加し、モード間遷移を一元管理
- 遷移ルールの検証（Interactive→Plan→Auto→Interactiveの単方向フロー）
- コールバック通知でUI/ログ連携可能
- TransitionToAutoAndRunで承認後の自動実行開始を簡潔に

## Test plan
- [x] go test ./internal/mode/... - 全テストパス
- [x] 遷移パターン網羅（7パターン）
- [x] コールバック呼び出し確認
- [x] エラーケース（未承認、モード不一致）確認

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)