### PR TITLE
feat: モードに応じたメンション強制機能を追加

### DIFF
--- a/internal/mode/mode.go
+++ b/internal/mode/mode.go
@@ -124,6 +124,20 @@ func (m *Manager) AddIssue(issueNum int) {
 	}
 }
 
+// ShouldEnforceMention returns whether mention check should be enforced
+// Plan mode and Auto mode require mentions, Interactive mode does not
+func (m *Manager) ShouldEnforceMention() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	switch m.currentMode {
+	case config.ModePlan, config.ModeAuto:
+		return true
+	default:
+		return false
+	}
+}
+
 // StatusString returns a human-readable status string
 func (m *Manager) StatusString() string {
 	m.mu.RLock()

--- a/internal/mode/mode_test.go
+++ b/internal/mode/mode_test.go
@@ -232,3 +232,53 @@ func findSubstring(s, substr string) bool {
 	}
 	return false
 }
+
+func TestShouldEnforceMention(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(*Manager)
+		expected bool
+	}{
+		{
+			name:     "interactive mode - OFF",
+			setup:    func(m *Manager) {},
+			expected: false,
+		},
+		{
+			name: "plan mode - ON",
+			setup: func(m *Manager) {
+				m.EnterPlanMode()
+			},
+			expected: true,
+		},
+		{
+			name: "auto mode - ON",
+			setup: func(m *Manager) {
+				m.EnterPlanMode()
+				m.EnterAutoMode(&PlanContext{Approved: true})
+			},
+			expected: true,
+		},
+		{
+			name: "after stop - OFF",
+			setup: func(m *Manager) {
+				m.EnterPlanMode()
+				m.EnterAutoMode(&PlanContext{Approved: true})
+				m.Stop()
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager(config.ModeInteractive)
+			tt.setup(m)
+
+			got := m.ShouldEnforceMention()
+			if got != tt.expected {
+				t.Errorf("ShouldEnforceMention() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- mode.ManagerにShouldEnforceMention()メソッドを追加
- Interactive mode: OFF、Plan/Auto mode: ON
- テスト追加

## Test plan
- [x] `go test ./internal/mode/...` 通過
- [x] `go vet` 通過
- [x] `gofmt` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)