### PR TITLE
feat: TUIステータスバーにモード表示を追加

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -104,6 +104,19 @@ var (
 	systemStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#FFD700")).
 			Bold(true)
+
+	// Mode indicator styles
+	modeInteractiveStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#888888")).
+				Bold(false)
+
+	modePlanStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#00BFFF")).
+			Bold(true)
+
+	modeAutoStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FF6347")).
+			Bold(true)
 )
 
 type tuiMessage struct {
@@ -1151,8 +1164,9 @@ func (m tuiModel) View() string {
 			}
 			statusContent = statusStyle.Render(fmt.Sprintf(" %s 処理中... ", strings.Join(names, ", ")))
 		} else {
-			// Build status with optional cost display
-			statusText := fmt.Sprintf(" 履歴:%d ↑↓:履歴 PgUp/Dn:スクロール ", len(m.inputHist))
+			// Build status with mode indicator and optional cost display
+			modeIndicator := m.renderModeIndicator()
+			statusText := fmt.Sprintf(" %s 履歴:%d ↑↓:履歴 PgUp/Dn:スクロール ", modeIndicator, len(m.inputHist))
 			if m.ccusageClient != nil && m.todayCost > 0 {
 				statusText += fmt.Sprintf("| %s today ", ccusage.FormatCost(m.todayCost))
 			}
@@ -1621,6 +1635,23 @@ func (m *tuiModel) fetchIssueList() tea.Cmd {
 		}
 
 		return issueListMsg{issues: result}
+	}
+}
+
+// renderModeIndicator はモード表示用の文字列を返す
+func (m *tuiModel) renderModeIndicator() string {
+	if m.modeManager == nil {
+		return modeInteractiveStyle.Render("[Interactive]")
+	}
+
+	currentMode := m.modeManager.Current()
+	switch currentMode {
+	case config.ModePlan:
+		return modePlanStyle.Render("[Plan]")
+	case config.ModeAuto:
+		return modeAutoStyle.Render("[Auto]")
+	default:
+		return modeInteractiveStyle.Render("[Interactive]")
 	}
 }
 

--- a/cmd/maxam/tui_analysis_test.go
+++ b/cmd/maxam/tui_analysis_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ytnobody/MAXAM/internal/config"
+	"github.com/ytnobody/MAXAM/internal/mode"
 )
 
 func TestIsNoIssueResponse(t *testing.T) {
@@ -319,11 +320,11 @@ func TestSelectHistoryMessages(t *testing.T) {
 	// モデル作成（簡易版）
 	m := &tuiModel{
 		messages: []tuiMessage{
-			{role: "user", content: "おはよう"},                        // 低優先 (雑談)
-			{role: "mei", content: "おはようございます"},                // 低優先 (雑談)
+			{role: "user", content: "おはよう"},     // 低優先 (雑談)
+			{role: "mei", content: "おはようございます"}, // 低優先 (雑談)
 			{role: "user", content: "トークン消費を減らしたい。調整案ある？"},
 			{role: "yuki", content: "調整案として4つ提案する。1. 15→8に減らす..."},
-			{role: "user", content: "うん"},                           // 低優先 (短い)
+			{role: "user", content: "うん"}, // 低優先 (短い)
 			{role: "user", content: "これは全部やろう。実装よろしく"},
 			{role: "yuki", content: "了解。4つ全部やる。作業入る。"},
 		},
@@ -353,10 +354,10 @@ func TestSelectHistoryMessages(t *testing.T) {
 
 func TestAnalysisMinMessagesThreshold(t *testing.T) {
 	tests := []struct {
-		name              string
-		messageCount      int
-		minMessages       int
-		expectAnalysis    bool
+		name           string
+		messageCount   int
+		minMessages    int
+		expectAnalysis bool
 	}{
 		{
 			name:           "閾値以上で分析実行",
@@ -532,9 +533,9 @@ func TestIssueListConstants(t *testing.T) {
 
 func TestMentionWarningChainTrigger(t *testing.T) {
 	tests := []struct {
-		name           string
-		warningCount   int
-		expectRetry    bool
+		name         string
+		warningCount int
+		expectRetry  bool
 	}{
 		{
 			name:         "初回警告 - リトライする",
@@ -589,10 +590,10 @@ func TestMentionWarningCountReset(t *testing.T) {
 
 func TestTaskPrefixParsing(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		isTask   bool
-		content  string
+		name    string
+		input   string
+		isTask  bool
+		content string
 	}{
 		{
 			name:    "/task で始まる入力",
@@ -646,6 +647,71 @@ func TestTaskPrefixParsing(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRenderModeIndicator(t *testing.T) {
+	tests := []struct {
+		name        string
+		defaultMode config.Mode
+		setupFunc   func(mm *mode.Manager) // モード設定用のセットアップ関数
+		contains    string                 // 表示に含まれるべき文字列
+	}{
+		{
+			name:        "Interactiveモード（デフォルト）",
+			defaultMode: config.ModeInteractive,
+			setupFunc:   nil,
+			contains:    "Interactive",
+		},
+		{
+			name:        "Planモード",
+			defaultMode: config.ModeInteractive,
+			setupFunc: func(mm *mode.Manager) {
+				mm.EnterPlanMode()
+			},
+			contains: "Plan",
+		},
+		{
+			name:        "Autoモード",
+			defaultMode: config.ModeInteractive,
+			setupFunc: func(mm *mode.Manager) {
+				mm.EnterPlanMode()
+				mm.SetPlanApproved(true)
+				mm.EnterAutoMode(mm.GetPlanContext())
+			},
+			contains: "Auto",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// mode.Managerを作成
+			mm := mode.NewManager(tt.defaultMode)
+			if tt.setupFunc != nil {
+				tt.setupFunc(mm)
+			}
+
+			m := &tuiModel{
+				modeManager: mm,
+			}
+
+			got := m.renderModeIndicator()
+			if !strings.Contains(got, tt.contains) {
+				t.Errorf("renderModeIndicator() = %q, want to contain %q", got, tt.contains)
+			}
+		})
+	}
+}
+
+func TestRenderModeIndicatorNilManager(t *testing.T) {
+	// modeManagerがnilの場合はInteractiveを表示
+	m := &tuiModel{
+		modeManager: nil,
+	}
+
+	got := m.renderModeIndicator()
+	if !strings.Contains(got, "Interactive") {
+		t.Errorf("renderModeIndicator() with nil manager = %q, want to contain 'Interactive'", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- ステータスバーに現在のモード（Interactive/Plan/Auto）を表示
- モードに応じた色分けで視認性を確保
- テストケース追加

## 動作確認方法
1. `maxam` を起動
2. ステータスバーに `[Interactive]` が表示されることを確認
3. （Planモード/Autoモード対応時）モード表示が切り替わることを確認

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)