### PR TITLE
feat: ひらがなメンションのサポート

### DIFF
--- a/.maxam/config.yaml
+++ b/.maxam/config.yaml
@@ -4,18 +4,24 @@ agents:
     - name: mei
       full_name: mei
       role: PM + アーキテクト
+      aliases: ["めい"]
     - name: yuki
       full_name: yuki
       role: バックエンド + インフラ
+      aliases: ["ゆき"]
     - name: rin
       full_name: rin
       role: フロントエンド + バックエンド
+      aliases: ["りん"]
     - name: shiori
       full_name: shiori
       role: テスト + ドキュメント
+      aliases: ["しおり"]
     - name: priya
       full_name: priya
       role: レビュー + セキュリティ + QA
+      aliases: ["ぷりや"]
     - name: amara
       full_name: amara
       role: 分析 + 法的基礎知識
+      aliases: ["あまら"]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,12 +60,13 @@ type Config struct {
 
 // AgentConfig represents an agent configuration
 type AgentConfig struct {
-	Name       string `yaml:"name"`
-	FullName   string `yaml:"full_name"`
-	Role       string `yaml:"role"`
-	Model      string `yaml:"model,omitempty"`       // opus, sonnet, haiku
-	Color      string `yaml:"color,omitempty"`       // hex color code (e.g., "#FF9933")
-	InstanceID string `yaml:"instance_id,omitempty"` // for multi-instance support (e.g., "1", "2")
+	Name       string   `yaml:"name"`
+	FullName   string   `yaml:"full_name"`
+	Role       string   `yaml:"role"`
+	Model      string   `yaml:"model,omitempty"`       // opus, sonnet, haiku
+	Color      string   `yaml:"color,omitempty"`       // hex color code (e.g., "#FF9933")
+	InstanceID string   `yaml:"instance_id,omitempty"` // for multi-instance support (e.g., "1", "2")
+	Aliases    []string `yaml:"aliases,omitempty"`     // alternative names (e.g., ["ゆき", "yuki-san"])
 }
 
 // TODO: Move to config.yaml when multi-instance feature is stabilized

--- a/internal/member/member.go
+++ b/internal/member/member.go
@@ -12,14 +12,16 @@ import (
 
 // Member represents a team member
 type Member struct {
-	Name     string // Short name (e.g., "yuki")
-	FullName string // Full name (e.g., "Yuki Tanaka")
-	Role     string // Role description
+	Name     string   // Short name (e.g., "yuki")
+	FullName string   // Full name (e.g., "Yuki Tanaka")
+	Role     string   // Role description
+	Aliases  []string // Alternative names (e.g., ["ゆき", "yuki-san"])
 }
 
 // Members holds all team members
 type Members struct {
 	members map[string]*Member // key: lowercase short name
+	aliases map[string]string  // key: lowercase alias, value: canonical name
 }
 
 // NewMembers creates a Members instance from config and CLAUDE.md
@@ -27,6 +29,7 @@ type Members struct {
 func NewMembers(workDir string) *Members {
 	m := &Members{
 		members: make(map[string]*Member),
+		aliases: make(map[string]string),
 	}
 
 	// 1. Load from config with project overrides
@@ -35,10 +38,17 @@ func NewMembers(workDir string) *Members {
 		cfg = config.DefaultConfig()
 	}
 	for _, ac := range cfg.Agents {
-		m.members[strings.ToLower(ac.Name)] = &Member{
+		member := &Member{
 			Name:     ac.Name,
 			FullName: ac.FullName,
 			Role:     ac.Role,
+			Aliases:  ac.Aliases,
+		}
+		m.members[strings.ToLower(ac.Name)] = member
+
+		// Register aliases
+		for _, alias := range ac.Aliases {
+			m.aliases[strings.ToLower(alias)] = strings.ToLower(ac.Name)
 		}
 	}
 
@@ -71,10 +81,21 @@ func NewMembers(workDir string) *Members {
 	return m
 }
 
-// Get returns a member by name (case-insensitive)
+// Get returns a member by name or alias (case-insensitive)
 func (m *Members) Get(name string) (*Member, bool) {
-	member, ok := m.members[strings.ToLower(name)]
-	return member, ok
+	lower := strings.ToLower(name)
+
+	// Try direct lookup first
+	if member, ok := m.members[lower]; ok {
+		return member, true
+	}
+
+	// Try alias lookup
+	if canonical, ok := m.aliases[lower]; ok {
+		return m.members[canonical], true
+	}
+
+	return nil, false
 }
 
 // All returns all members

--- a/internal/member/mention.go
+++ b/internal/member/mention.go
@@ -6,11 +6,13 @@ import (
 
 // DetectMentions extracts all mentioned member names from text
 // Returns lowercase short names of mentioned members
+// Also resolves aliases to their canonical names
 func (m *Members) DetectMentions(text string) []string {
 	lower := strings.ToLower(text)
 	var mentioned []string
 	seen := make(map[string]bool)
 
+	// Check direct member names
 	for name := range m.members {
 		// Check @mention pattern
 		pattern := "@" + name
@@ -18,6 +20,17 @@ func (m *Members) DetectMentions(text string) []string {
 			if !seen[name] {
 				mentioned = append(mentioned, name)
 				seen[name] = true
+			}
+		}
+	}
+
+	// Check aliases
+	for alias, canonical := range m.aliases {
+		pattern := "@" + alias
+		if strings.Contains(lower, pattern) {
+			if !seen[canonical] {
+				mentioned = append(mentioned, canonical)
+				seen[canonical] = true
 			}
 		}
 	}

--- a/internal/member/mention_test.go
+++ b/internal/member/mention_test.go
@@ -9,12 +9,13 @@ func TestDetectMentions(t *testing.T) {
 	// Create members with test data
 	m := &Members{
 		members: map[string]*Member{
-			"mei":    {Name: "mei", FullName: "Mei Chen", Role: "PM"},
-			"yuki":   {Name: "yuki", FullName: "Yuki Tanaka", Role: "Backend"},
-			"priya":  {Name: "priya", FullName: "Priya Sharma", Role: "QA"},
-			"alex":   {Name: "alex", FullName: "Alex Johnson", Role: "Frontend"},
-			"hana":   {Name: "hana", FullName: "Hana Kim", Role: "Designer"},
+			"mei":   {Name: "mei", FullName: "Mei Chen", Role: "PM"},
+			"yuki":  {Name: "yuki", FullName: "Yuki Tanaka", Role: "Backend"},
+			"priya": {Name: "priya", FullName: "Priya Sharma", Role: "QA"},
+			"alex":  {Name: "alex", FullName: "Alex Johnson", Role: "Frontend"},
+			"hana":  {Name: "hana", FullName: "Hana Kim", Role: "Designer"},
 		},
+		aliases: map[string]string{},
 	}
 
 	tests := []struct {
@@ -82,19 +83,87 @@ func TestDetectMentions(t *testing.T) {
 	}
 }
 
+func TestDetectMentionsWithAliases(t *testing.T) {
+	// Create members with aliases (hiragana names)
+	m := &Members{
+		members: map[string]*Member{
+			"mei":   {Name: "mei", FullName: "Mei Chen", Role: "PM", Aliases: []string{"めい"}},
+			"yuki":  {Name: "yuki", FullName: "Yuki Tanaka", Role: "Backend", Aliases: []string{"ゆき"}},
+			"rin":   {Name: "rin", FullName: "Rin Sato", Role: "Frontend", Aliases: []string{"りん"}},
+			"priya": {Name: "priya", FullName: "Priya Sharma", Role: "QA", Aliases: []string{"ぷりや"}},
+		},
+		aliases: map[string]string{
+			"めい":  "mei",
+			"ゆき":  "yuki",
+			"りん":  "rin",
+			"ぷりや": "priya",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		text     string
+		expected []string
+	}{
+		{
+			name:     "hiragana mention",
+			text:     "@ゆき お願いします",
+			expected: []string{"yuki"},
+		},
+		{
+			name:     "mixed mentions",
+			text:     "@yuki @りん 一緒にやろう",
+			expected: []string{"rin", "yuki"},
+		},
+		{
+			name:     "multiple hiragana mentions",
+			text:     "@めい @ぷりや レビューお願いします",
+			expected: []string{"mei", "priya"},
+		},
+		{
+			name:     "alias and canonical same person",
+			text:     "@yuki と @ゆき は同じ人",
+			expected: []string{"yuki"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := m.DetectMentions(tt.text)
+
+			// Sort for comparison
+			sort.Strings(result)
+			sort.Strings(tt.expected)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("got %v, want %v", result, tt.expected)
+				return
+			}
+
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("got %v, want %v", result, tt.expected)
+					return
+				}
+			}
+		})
+	}
+}
+
 func TestDetectMention(t *testing.T) {
 	m := &Members{
 		members: map[string]*Member{
 			"mei":  {Name: "mei", FullName: "Mei Chen", Role: "PM"},
 			"yuki": {Name: "yuki", FullName: "Yuki Tanaka", Role: "Backend"},
 		},
+		aliases: map[string]string{},
 	}
 
 	tests := []struct {
-		name    string
-		text    string
-		def     string
-		want    string
+		name string
+		text string
+		def  string
+		want string
 	}{
 		{
 			name: "with mention",
@@ -120,11 +189,47 @@ func TestDetectMention(t *testing.T) {
 	}
 }
 
+func TestGetWithAlias(t *testing.T) {
+	m := &Members{
+		members: map[string]*Member{
+			"yuki": {Name: "yuki", FullName: "Yuki Tanaka", Role: "Backend", Aliases: []string{"ゆき"}},
+		},
+		aliases: map[string]string{
+			"ゆき": "yuki",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		query     string
+		wantFound bool
+		wantName  string
+	}{
+		{"canonical name", "yuki", true, "yuki"},
+		{"alias hiragana", "ゆき", true, "yuki"},
+		{"unknown", "unknown", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			member, found := m.Get(tt.query)
+			if found != tt.wantFound {
+				t.Errorf("Get(%q) found = %v, want %v", tt.query, found, tt.wantFound)
+				return
+			}
+			if found && member.Name != tt.wantName {
+				t.Errorf("Get(%q).Name = %q, want %q", tt.query, member.Name, tt.wantName)
+			}
+		})
+	}
+}
+
 func TestGetFullName(t *testing.T) {
 	m := &Members{
 		members: map[string]*Member{
 			"yuki": {Name: "yuki", FullName: "Yuki Tanaka", Role: "Backend"},
 		},
+		aliases: map[string]string{},
 	}
 
 	tests := []struct {


### PR DESCRIPTION
## Summary
- AgentConfigに`aliases`フィールドを追加
- `@ゆき`, `@りん` 等のひらがなメンションを正規名に解決
- `.maxam/config.yaml`にデフォルトのひらがなエイリアスを設定

## Test plan
- [ ] `go test ./internal/member/...` でテストが通ることを確認
- [ ] TUIで `@ゆき` 等のひらがなメンションが機能することを確認

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)