### PR TITLE
fix: TUIがタスク完了まで会話をブロックする問題を修正

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -509,16 +509,15 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.updateViewport()
 
 			// /task プレフィックスで分岐: SendTask or SendChat
+			// 処理中でもWorkerに送信し、作業中ならWorkerが即座にステータスを返す
 			if strings.HasPrefix(input, taskPrefix) {
 				// /task 〇〇 → 実装指示として SendTask を使う
 				taskContent := strings.TrimPrefix(input, taskPrefix)
 				targetAgents := m.detectAgents(taskContent)
 				var cmds []tea.Cmd
 				for _, agentName := range targetAgents {
-					if !m.processingAgents[agentName] {
-						m.processingAgents[agentName] = true
-						cmds = append(cmds, m.runTaskAsync(taskContent, agentName))
-					}
+					m.processingAgents[agentName] = true
+					cmds = append(cmds, m.runTaskAsync(taskContent, agentName))
 				}
 				if len(cmds) > 0 {
 					m.updateViewport()
@@ -528,14 +527,12 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			// 通常の会話として SendChat を使う
+			// 処理中でもWorkerに送信し、作業中ならWorkerが即座にステータスを返す
 			targetAgents := m.detectAgents(input)
 			var cmds []tea.Cmd
 			for _, agentName := range targetAgents {
-				// そのエージェントが処理中でなければ開始
-				if !m.processingAgents[agentName] {
-					m.processingAgents[agentName] = true
-					cmds = append(cmds, m.runAgentAsync(input, agentName, 0))
-				}
+				m.processingAgents[agentName] = true
+				cmds = append(cmds, m.runAgentAsync(input, agentName, 0))
 			}
 
 			if len(cmds) > 0 {

--- a/internal/agent/worker/worker.go
+++ b/internal/agent/worker/worker.go
@@ -185,6 +185,17 @@ func (w *Worker) taskLoop() {
 
 // handleTask processes a single task request
 func (w *Worker) handleTask(req TaskRequest) {
+	// If already working on another task, return status message
+	if w.state.IsWorking() {
+		status := w.state.GetStatus()
+		req.Response <- TaskResponse{
+			Content: fmt.Sprintf("今%sの作業中。完了したら対応する。", status),
+			Elapsed: 0,
+			Err:     nil,
+		}
+		return
+	}
+
 	// Mark as working
 	w.state.StartTask(req.Description)
 	defer w.state.CompleteTask()

--- a/internal/agent/worker/worker_test.go
+++ b/internal/agent/worker/worker_test.go
@@ -101,6 +101,39 @@ func TestWorkerChatWhileWorking(t *testing.T) {
 	})
 }
 
+func TestWorkerTaskWhileWorking(t *testing.T) {
+	t.Run("returns busy message when already working on task", func(t *testing.T) {
+		// Create a worker with nil runner (won't be used for busy response)
+		w := NewWorker("yuki", nil)
+		w.Start()
+		defer w.Stop()
+
+		// Set state to working (simulating existing task)
+		w.state.StartTask("#90 実装中")
+
+		// Send another task request
+		responseChan := make(chan TaskResponse, 1)
+		w.SendTask("#91 も頼まれた", "prompt", responseChan)
+
+		// Should get immediate busy response
+		select {
+		case resp := <-responseChan:
+			if resp.Err != nil {
+				t.Errorf("unexpected error: %v", resp.Err)
+			}
+			if resp.Content == "" {
+				t.Error("expected non-empty response")
+			}
+			// Should contain task description
+			if len(resp.Content) < 10 {
+				t.Errorf("expected response to contain task info, got '%s'", resp.Content)
+			}
+		case <-time.After(1 * time.Second):
+			t.Error("timeout waiting for response")
+		}
+	})
+}
+
 func TestPool(t *testing.T) {
 	t.Run("add and get worker", func(t *testing.T) {
 		pool := NewPool()


### PR DESCRIPTION
## Summary
- TUI側で処理中エージェントへのリクエストをブロックしていた問題を修正
- 処理中でもWorkerにリクエストを送信し、作業中なら即座にステータスを返す
- handleTaskにも作業中チェックを追加

## Test plan
- [x] go test ./... 通過
- [x] go vet 通過
- [ ] 手動テスト: タスク実行中に別のメッセージを送信できることを確認

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)