### PR TITLE
feat: GitHub Issue based plan mode

### DIFF
--- a/internal/approval/comment.go
+++ b/internal/approval/comment.go
@@ -23,6 +23,8 @@ var ApprovalKeywords = []string{
 	"Approved",
 	"APPROVED",
 	"/approve",
+	":+1:",
+	"👍",
 }
 
 // CommentChecker checks comments for approval signals

--- a/internal/approval/comment_test.go
+++ b/internal/approval/comment_test.go
@@ -35,6 +35,12 @@ func TestCommentChecker_IsApprovalComment(t *testing.T) {
 		{"approved lowercase", "approved", true},
 		{"Approved titlecase", "Approved", true},
 
+		// Thumbs up emoji
+		{":+1: shortcode", ":+1:", true},
+		{"👍 emoji", "👍", true},
+		{":+1: in sentence", "Looks good :+1:", true},
+		{"👍 with message", "Great work! 👍", true},
+
 		// Non-approval cases
 		{"empty string", "", false},
 		{"random text", "This is a random comment", false},

--- a/internal/mode/plan.go
+++ b/internal/mode/plan.go
@@ -223,3 +223,104 @@ func (pe *PlanExecutor) CheckApprovalOnce(ctx context.Context, issueNumber int, 
 
 	return pe.checker.FindApprovalSince(comments, since), nil
 }
+
+// PlanLabel is the label used to identify plan issues
+const PlanLabel = "maxam-plan"
+
+// FindExistingPlanIssue searches for an existing open plan issue by label
+func (pe *PlanExecutor) FindExistingPlanIssue(ctx context.Context) (*PlanIssue, error) {
+	issues, err := pe.ghClient.ListIssuesWithOptions(ctx, "open", "", []string{PlanLabel})
+	if err != nil {
+		return nil, fmt.Errorf("list issues with label: %w", err)
+	}
+
+	// Skip PRs and find the most recent plan issue
+	var latestIssue *github.Issue
+	for _, issue := range issues {
+		if issue.PullRequestLinks != nil {
+			continue
+		}
+		if latestIssue == nil || issue.CreatedAt.After(latestIssue.CreatedAt.Time) {
+			latestIssue = issue
+		}
+	}
+
+	if latestIssue == nil {
+		return nil, nil
+	}
+
+	return &PlanIssue{
+		IssueNumber: latestIssue.GetNumber(),
+		Title:       latestIssue.GetTitle(),
+		Body:        latestIssue.GetBody(),
+		CreatedAt:   latestIssue.CreatedAt.Time,
+		URL:         latestIssue.GetHTMLURL(),
+	}, nil
+}
+
+// GetOrCreatePlanIssue finds an existing plan issue or creates a new one
+func (pe *PlanExecutor) GetOrCreatePlanIssue(ctx context.Context, analysis *ProjectAnalysis, proposal string) (*PlanIssue, bool, error) {
+	existing, err := pe.FindExistingPlanIssue(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("find existing plan issue: %w", err)
+	}
+
+	if existing != nil {
+		return existing, false, nil
+	}
+
+	// Create new issue
+	issue, err := pe.CreatePlanIssueWithLabel(ctx, analysis, proposal)
+	if err != nil {
+		return nil, false, fmt.Errorf("create plan issue: %w", err)
+	}
+
+	return issue, true, nil
+}
+
+// CreatePlanIssueWithLabel creates an issue with the plan proposal and maxam-plan label
+func (pe *PlanExecutor) CreatePlanIssueWithLabel(ctx context.Context, analysis *ProjectAnalysis, proposal string) (*PlanIssue, error) {
+	title := "[Plan] プロジェクト方針の提案"
+
+	body := fmt.Sprintf(`%s
+
+## 提案内容
+
+%s
+
+---
+
+**承認する場合は、このIssueにコメントで「OK」「LGTM」「承認」「👍」などと返信してください。**
+
+_このIssueはMAXAM Plan Modeによって自動生成されました。_
+`, analysis.Summary, proposal)
+
+	issue, err := pe.ghClient.CreateIssue(ctx, title, body, []string{PlanLabel})
+	if err != nil {
+		return nil, fmt.Errorf("create plan issue: %w", err)
+	}
+
+	return &PlanIssue{
+		IssueNumber: issue.GetNumber(),
+		Title:       issue.GetTitle(),
+		Body:        issue.GetBody(),
+		CreatedAt:   issue.CreatedAt.Time,
+		URL:         issue.GetHTMLURL(),
+	}, nil
+}
+
+// PostPlanComment posts a plan proposal as a comment to an existing issue
+func (pe *PlanExecutor) PostPlanComment(ctx context.Context, issueNumber int, proposal string) error {
+	body := fmt.Sprintf(`## 新しいプラン提案
+
+%s
+
+---
+
+**承認する場合は「OK」「LGTM」「承認」「👍」などと返信してください。**
+
+_このコメントはMAXAM Plan Modeによって自動生成されました。_
+`, proposal)
+
+	return pe.ghClient.CommentIssue(ctx, issueNumber, body)
+}

--- a/internal/mode/plan_test.go
+++ b/internal/mode/plan_test.go
@@ -104,3 +104,82 @@ func TestPlanModeConfig_CustomInterval(t *testing.T) {
 		t.Errorf("PollingInterval = %v, want 60s", config.PollingInterval)
 	}
 }
+
+func TestPlanLabel(t *testing.T) {
+	if PlanLabel != "maxam-plan" {
+		t.Errorf("PlanLabel = %q, want %q", PlanLabel, "maxam-plan")
+	}
+}
+
+func TestCreatePlanIssueWithLabel_BodyFormat(t *testing.T) {
+	// Test that the body contains expected elements
+	analysis := &ProjectAnalysis{
+		OpenIssues:       5,
+		UnassignedIssues: 2,
+	}
+
+	pe := &PlanExecutor{}
+	summary := pe.generateSummary(analysis)
+
+	// Simulate what CreatePlanIssueWithLabel would generate
+	expectedParts := []string{
+		"## 提案内容",
+		"承認する場合は",
+		"👍",
+		"LGTM",
+		"MAXAM Plan Mode",
+	}
+
+	// The summary should be generated correctly
+	if !strings.Contains(summary, "オープンIssue: 5件") {
+		t.Errorf("Summary should contain issue count")
+	}
+
+	// Check expected body format elements (used in CreatePlanIssueWithLabel)
+	bodyTemplate := `**承認する場合は、このIssueにコメントで「OK」「LGTM」「承認」「👍」などと返信してください。**`
+	for _, part := range expectedParts {
+		if part == "## 提案内容" || part == "MAXAM Plan Mode" {
+			continue // These are in body template but not in summary
+		}
+		if strings.Contains(bodyTemplate, part) != true && part != "👍" && part != "LGTM" {
+			t.Logf("Part %q checked against template", part)
+		}
+	}
+
+	// Verify 👍 is mentioned in approval instruction
+	if !strings.Contains(bodyTemplate, "👍") {
+		t.Errorf("Body template should mention 👍 emoji for approval")
+	}
+}
+
+func TestPostPlanComment_Format(t *testing.T) {
+	// Test the comment format includes expected elements
+	proposal := "Test proposal content"
+
+	// Simulate PostPlanComment body format
+	body := `## 新しいプラン提案
+
+` + proposal + `
+
+---
+
+**承認する場合は「OK」「LGTM」「承認」「👍」などと返信してください。**
+
+_このコメントはMAXAM Plan Modeによって自動生成されました。_
+`
+
+	expectedParts := []string{
+		"新しいプラン提案",
+		proposal,
+		"承認",
+		"👍",
+		"LGTM",
+		"MAXAM Plan Mode",
+	}
+
+	for _, part := range expectedParts {
+		if !strings.Contains(body, part) {
+			t.Errorf("PostPlanComment body should contain %q", part)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `maxam-plan` ラベルで既存Issue検索機能を追加
- 既存Issueがあれば再利用、なければ新規作成（`GetOrCreatePlanIssue`）
- 既存Issueへプランをコメント投稿（`PostPlanComment`）
- 👍 絵文字（`:+1:` と `👍`）での承認をサポート

## Test plan
- [x] `go test ./internal/approval/...` → 全テスト通過
- [x] `go test ./internal/mode/...` → 全テスト通過
- [x] `gofmt` チェック済み
- [x] `go vet` チェック済み

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)