### PR TITLE
feat: エラー発生時のautoモード自動切り替え

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -869,6 +869,14 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					content: fmt.Sprintf("[自動声かけ] %s", followUpResult.Message),
 				})
 
+				// Add system message about auto mode switch
+				if followUpResult.SwitchedToAuto {
+					m.messages = append(m.messages, tuiMessage{
+						role:    "system",
+						content: fmt.Sprintf("[autoモード] %s をautoモードに切り替えました（手動で戻す必要があります）", msg.agent),
+					})
+				}
+
 				// Trigger PM to send follow-up message
 				m.processingAgents[pmAgent] = true
 				m.updateViewport()
@@ -1881,10 +1889,57 @@ func (m *tuiModel) handleModeCommand(result mode.ParseResult) (tea.Model, tea.Cm
 			}
 		}
 
+		// Show agents in auto mode
+		if m.errorDetector != nil {
+			autoAgents := m.errorDetector.ModeManager().AllAutoAgents()
+			if len(autoAgents) > 0 {
+				statusContent += fmt.Sprintf("\n🔄 autoモードのエージェント: %s", strings.Join(autoAgents, ", "))
+			}
+		}
+
 		m.messages = append(m.messages, tuiMessage{
 			role:    "system",
 			content: statusContent,
 		})
+
+	case mode.CommandResetAuto:
+		// Reset agent auto mode
+		if m.errorDetector == nil {
+			m.messages = append(m.messages, tuiMessage{
+				role:    "system",
+				content: "⚠️ エラー検出が初期化されていません。",
+			})
+		} else if result.Args == "" {
+			// Reset all agents
+			autoAgents := m.errorDetector.ModeManager().AllAutoAgents()
+			if len(autoAgents) == 0 {
+				m.messages = append(m.messages, tuiMessage{
+					role:    "system",
+					content: "ℹ️ autoモードのエージェントはいません。",
+				})
+			} else {
+				m.errorDetector.ModeManager().ResetAll()
+				m.messages = append(m.messages, tuiMessage{
+					role:    "system",
+					content: fmt.Sprintf("✅ 全エージェントのautoモードをリセットしました: %s", strings.Join(autoAgents, ", ")),
+				})
+			}
+		} else {
+			// Reset specific agent
+			agentName := result.Args
+			if m.errorDetector.IsAgentInAutoMode(agentName) {
+				m.errorDetector.ResetAgentMode(agentName)
+				m.messages = append(m.messages, tuiMessage{
+					role:    "system",
+					content: fmt.Sprintf("✅ %s のautoモードをリセットしました。", agentName),
+				})
+			} else {
+				m.messages = append(m.messages, tuiMessage{
+					role:    "system",
+					content: fmt.Sprintf("ℹ️ %s はautoモードではありません。", agentName),
+				})
+			}
+		}
 	}
 
 	m.updateViewport()
@@ -1997,14 +2052,25 @@ func (m *tuiModel) renderModeIndicator() string {
 	}
 
 	currentMode := m.modeManager.Current()
+	var modeStr string
 	switch currentMode {
 	case config.ModePlan:
-		return modePlanStyle.Render("[Plan]")
+		modeStr = modePlanStyle.Render("[Plan]")
 	case config.ModeAuto:
-		return modeAutoStyle.Render("[Auto]")
+		modeStr = modeAutoStyle.Render("[Auto]")
 	default:
-		return modeInteractiveStyle.Render("[Interactive]")
+		modeStr = modeInteractiveStyle.Render("[Interactive]")
 	}
+
+	// Show agents in auto mode (per-agent auto mode)
+	if m.errorDetector != nil {
+		autoAgents := m.errorDetector.ModeManager().AllAutoAgents()
+		if len(autoAgents) > 0 {
+			modeStr += " " + warningStyle.Render(fmt.Sprintf("🔄 auto: %s", strings.Join(autoAgents, ", ")))
+		}
+	}
+
+	return modeStr
 }
 
 // getFooterStyle はモードに応じたフッタースタイルを返す

--- a/internal/errorwatch/agent_mode.go
+++ b/internal/errorwatch/agent_mode.go
@@ -1,0 +1,173 @@
+// Package errorwatch provides error detection and automatic follow-up for agent errors.
+package errorwatch
+
+import (
+	"sync"
+	"time"
+)
+
+// AgentMode represents the mode of an individual agent
+type AgentMode string
+
+const (
+	// AgentModeNormal is the default mode where the agent operates normally
+	AgentModeNormal AgentMode = "normal"
+	// AgentModeAuto is the mode where the agent operates automatically after error recovery
+	AgentModeAuto AgentMode = "auto"
+)
+
+// AgentModeState tracks the mode state of an agent
+type AgentModeState struct {
+	Mode         AgentMode
+	SwitchedAt   time.Time
+	ErrorMessage string // The error that triggered auto mode
+}
+
+// AgentModeManager manages per-agent mode states
+type AgentModeManager struct {
+	mu     sync.RWMutex
+	states map[string]*AgentModeState
+
+	// Callback for mode changes
+	onModeChange func(agentName string, from, to AgentMode)
+}
+
+// NewAgentModeManager creates a new agent mode manager
+func NewAgentModeManager() *AgentModeManager {
+	return &AgentModeManager{
+		states: make(map[string]*AgentModeState),
+	}
+}
+
+// SetOnModeChange sets the callback for mode changes
+func (m *AgentModeManager) SetOnModeChange(fn func(agentName string, from, to AgentMode)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onModeChange = fn
+}
+
+// GetMode returns the current mode of an agent
+func (m *AgentModeManager) GetMode(agentName string) AgentMode {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	state, exists := m.states[agentName]
+	if !exists {
+		return AgentModeNormal
+	}
+	return state.Mode
+}
+
+// GetState returns the full state of an agent
+func (m *AgentModeManager) GetState(agentName string) *AgentModeState {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	state, exists := m.states[agentName]
+	if !exists {
+		return &AgentModeState{Mode: AgentModeNormal}
+	}
+	// Return a copy to avoid race conditions
+	return &AgentModeState{
+		Mode:         state.Mode,
+		SwitchedAt:   state.SwitchedAt,
+		ErrorMessage: state.ErrorMessage,
+	}
+}
+
+// IsAuto returns true if the agent is in auto mode
+func (m *AgentModeManager) IsAuto(agentName string) bool {
+	return m.GetMode(agentName) == AgentModeAuto
+}
+
+// SwitchToAuto switches an agent to auto mode
+func (m *AgentModeManager) SwitchToAuto(agentName string, errorMessage string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	oldMode := AgentModeNormal
+	if state, exists := m.states[agentName]; exists {
+		oldMode = state.Mode
+	}
+
+	// Already in auto mode, update error message
+	if oldMode == AgentModeAuto {
+		m.states[agentName].ErrorMessage = errorMessage
+		return
+	}
+
+	m.states[agentName] = &AgentModeState{
+		Mode:         AgentModeAuto,
+		SwitchedAt:   time.Now(),
+		ErrorMessage: errorMessage,
+	}
+
+	if m.onModeChange != nil {
+		m.onModeChange(agentName, oldMode, AgentModeAuto)
+	}
+}
+
+// SwitchToNormal switches an agent back to normal mode
+func (m *AgentModeManager) SwitchToNormal(agentName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, exists := m.states[agentName]
+	if !exists || state.Mode == AgentModeNormal {
+		return
+	}
+
+	oldMode := state.Mode
+	m.states[agentName] = &AgentModeState{
+		Mode:       AgentModeNormal,
+		SwitchedAt: time.Now(),
+	}
+
+	if m.onModeChange != nil {
+		m.onModeChange(agentName, oldMode, AgentModeNormal)
+	}
+}
+
+// Reset clears the mode state for an agent
+func (m *AgentModeManager) Reset(agentName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.states, agentName)
+}
+
+// ResetAll clears all mode states
+func (m *AgentModeManager) ResetAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.states = make(map[string]*AgentModeState)
+}
+
+// AllAutoAgents returns a list of agents currently in auto mode
+func (m *AgentModeManager) AllAutoAgents() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var agents []string
+	for name, state := range m.states {
+		if state.Mode == AgentModeAuto {
+			agents = append(agents, name)
+		}
+	}
+	return agents
+}
+
+// AllStates returns all current states
+func (m *AgentModeManager) AllStates() map[string]*AgentModeState {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make(map[string]*AgentModeState)
+	for name, state := range m.states {
+		result[name] = &AgentModeState{
+			Mode:         state.Mode,
+			SwitchedAt:   state.SwitchedAt,
+			ErrorMessage: state.ErrorMessage,
+		}
+	}
+	return result
+}

--- a/internal/errorwatch/agent_mode_test.go
+++ b/internal/errorwatch/agent_mode_test.go
@@ -1,0 +1,315 @@
+package errorwatch
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAgentModeManager_GetMode(t *testing.T) {
+	m := NewAgentModeManager()
+
+	t.Run("returns normal for unknown agent", func(t *testing.T) {
+		mode := m.GetMode("unknown")
+		if mode != AgentModeNormal {
+			t.Errorf("GetMode(unknown) = %v, want %v", mode, AgentModeNormal)
+		}
+	})
+
+	t.Run("returns correct mode after switch", func(t *testing.T) {
+		m.SwitchToAuto("yuki", "test error")
+		mode := m.GetMode("yuki")
+		if mode != AgentModeAuto {
+			t.Errorf("GetMode(yuki) = %v, want %v", mode, AgentModeAuto)
+		}
+	})
+}
+
+func TestAgentModeManager_SwitchToAuto(t *testing.T) {
+	t.Run("switches agent to auto mode", func(t *testing.T) {
+		m := NewAgentModeManager()
+		m.SwitchToAuto("yuki", "context deadline exceeded")
+
+		if !m.IsAuto("yuki") {
+			t.Error("agent should be in auto mode")
+		}
+
+		state := m.GetState("yuki")
+		if state.ErrorMessage != "context deadline exceeded" {
+			t.Errorf("ErrorMessage = %q, want %q", state.ErrorMessage, "context deadline exceeded")
+		}
+	})
+
+	t.Run("updates error message if already in auto mode", func(t *testing.T) {
+		m := NewAgentModeManager()
+		m.SwitchToAuto("yuki", "first error")
+		m.SwitchToAuto("yuki", "second error")
+
+		state := m.GetState("yuki")
+		if state.ErrorMessage != "second error" {
+			t.Errorf("ErrorMessage = %q, want %q", state.ErrorMessage, "second error")
+		}
+	})
+
+	t.Run("triggers callback on mode change", func(t *testing.T) {
+		m := NewAgentModeManager()
+		var called bool
+		var fromMode, toMode AgentMode
+		var agentName string
+
+		m.SetOnModeChange(func(name string, from, to AgentMode) {
+			called = true
+			agentName = name
+			fromMode = from
+			toMode = to
+		})
+
+		m.SwitchToAuto("yuki", "test error")
+
+		if !called {
+			t.Error("callback should be called")
+		}
+		if agentName != "yuki" {
+			t.Errorf("agentName = %q, want %q", agentName, "yuki")
+		}
+		if fromMode != AgentModeNormal {
+			t.Errorf("fromMode = %v, want %v", fromMode, AgentModeNormal)
+		}
+		if toMode != AgentModeAuto {
+			t.Errorf("toMode = %v, want %v", toMode, AgentModeAuto)
+		}
+	})
+
+	t.Run("does not trigger callback if already in auto mode", func(t *testing.T) {
+		m := NewAgentModeManager()
+		m.SwitchToAuto("yuki", "first error")
+
+		var called bool
+		m.SetOnModeChange(func(name string, from, to AgentMode) {
+			called = true
+		})
+
+		m.SwitchToAuto("yuki", "second error")
+
+		if called {
+			t.Error("callback should not be called when already in auto mode")
+		}
+	})
+}
+
+func TestAgentModeManager_SwitchToNormal(t *testing.T) {
+	t.Run("switches agent back to normal mode", func(t *testing.T) {
+		m := NewAgentModeManager()
+		m.SwitchToAuto("yuki", "test error")
+		m.SwitchToNormal("yuki")
+
+		if m.IsAuto("yuki") {
+			t.Error("agent should be in normal mode")
+		}
+	})
+
+	t.Run("triggers callback on mode change", func(t *testing.T) {
+		m := NewAgentModeManager()
+		m.SwitchToAuto("yuki", "test error")
+
+		var called bool
+		var fromMode, toMode AgentMode
+
+		m.SetOnModeChange(func(name string, from, to AgentMode) {
+			called = true
+			fromMode = from
+			toMode = to
+		})
+
+		m.SwitchToNormal("yuki")
+
+		if !called {
+			t.Error("callback should be called")
+		}
+		if fromMode != AgentModeAuto {
+			t.Errorf("fromMode = %v, want %v", fromMode, AgentModeAuto)
+		}
+		if toMode != AgentModeNormal {
+			t.Errorf("toMode = %v, want %v", toMode, AgentModeNormal)
+		}
+	})
+
+	t.Run("no-op if already in normal mode", func(t *testing.T) {
+		m := NewAgentModeManager()
+
+		var called bool
+		m.SetOnModeChange(func(name string, from, to AgentMode) {
+			called = true
+		})
+
+		m.SwitchToNormal("yuki")
+
+		if called {
+			t.Error("callback should not be called when already in normal mode")
+		}
+	})
+}
+
+func TestAgentModeManager_AllAutoAgents(t *testing.T) {
+	m := NewAgentModeManager()
+	m.SwitchToAuto("yuki", "error 1")
+	m.SwitchToAuto("rin", "error 2")
+	m.SwitchToAuto("mei", "error 3")
+	m.SwitchToNormal("rin")
+
+	agents := m.AllAutoAgents()
+
+	if len(agents) != 2 {
+		t.Errorf("len(agents) = %d, want 2", len(agents))
+	}
+
+	agentSet := make(map[string]bool)
+	for _, a := range agents {
+		agentSet[a] = true
+	}
+
+	if !agentSet["yuki"] {
+		t.Error("yuki should be in auto agents")
+	}
+	if agentSet["rin"] {
+		t.Error("rin should not be in auto agents")
+	}
+	if !agentSet["mei"] {
+		t.Error("mei should be in auto agents")
+	}
+}
+
+func TestAgentModeManager_Reset(t *testing.T) {
+	m := NewAgentModeManager()
+	m.SwitchToAuto("yuki", "test error")
+	m.Reset("yuki")
+
+	mode := m.GetMode("yuki")
+	if mode != AgentModeNormal {
+		t.Errorf("GetMode(yuki) = %v, want %v after reset", mode, AgentModeNormal)
+	}
+}
+
+func TestAgentModeManager_ResetAll(t *testing.T) {
+	m := NewAgentModeManager()
+	m.SwitchToAuto("yuki", "error 1")
+	m.SwitchToAuto("rin", "error 2")
+	m.ResetAll()
+
+	if m.IsAuto("yuki") {
+		t.Error("yuki should not be in auto mode after reset all")
+	}
+	if m.IsAuto("rin") {
+		t.Error("rin should not be in auto mode after reset all")
+	}
+}
+
+func TestAgentModeManager_GetState(t *testing.T) {
+	m := NewAgentModeManager()
+	before := time.Now()
+	m.SwitchToAuto("yuki", "test error message")
+	after := time.Now()
+
+	state := m.GetState("yuki")
+
+	if state.Mode != AgentModeAuto {
+		t.Errorf("Mode = %v, want %v", state.Mode, AgentModeAuto)
+	}
+	if state.ErrorMessage != "test error message" {
+		t.Errorf("ErrorMessage = %q, want %q", state.ErrorMessage, "test error message")
+	}
+	if state.SwitchedAt.Before(before) || state.SwitchedAt.After(after) {
+		t.Errorf("SwitchedAt = %v, should be between %v and %v", state.SwitchedAt, before, after)
+	}
+}
+
+func TestAgentModeManager_Concurrency(t *testing.T) {
+	m := NewAgentModeManager()
+	var wg sync.WaitGroup
+
+	// Concurrent switches
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			agentName := "agent"
+			if n%2 == 0 {
+				m.SwitchToAuto(agentName, "error")
+			} else {
+				m.SwitchToNormal(agentName)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Should not panic, state should be consistent
+	mode := m.GetMode("agent")
+	if mode != AgentModeNormal && mode != AgentModeAuto {
+		t.Errorf("unexpected mode: %v", mode)
+	}
+}
+
+func TestDetector_HandleError(t *testing.T) {
+	t.Run("switches to auto mode for recoverable error", func(t *testing.T) {
+		d := DefaultDetector()
+
+		result := d.HandleError("yuki", "context deadline exceeded")
+
+		if !result {
+			t.Error("HandleError should return true for recoverable error")
+		}
+		if !d.IsAgentInAutoMode("yuki") {
+			t.Error("agent should be in auto mode")
+		}
+	})
+
+	t.Run("does not switch for non-recoverable error", func(t *testing.T) {
+		d := DefaultDetector()
+
+		result := d.HandleError("yuki", "syntax error")
+
+		if result {
+			t.Error("HandleError should return false for non-recoverable error")
+		}
+		if d.IsAgentInAutoMode("yuki") {
+			t.Error("agent should not be in auto mode")
+		}
+	})
+
+	t.Run("handles exit status 1", func(t *testing.T) {
+		d := DefaultDetector()
+
+		result := d.HandleError("yuki", "run claude: exit status 1")
+
+		if !result {
+			t.Error("HandleError should return true for exit status 1")
+		}
+		if !d.IsAgentInAutoMode("yuki") {
+			t.Error("agent should be in auto mode")
+		}
+	})
+}
+
+func TestDetector_ResetAgentMode(t *testing.T) {
+	d := DefaultDetector()
+	d.HandleError("yuki", "context deadline exceeded")
+
+	d.ResetAgentMode("yuki")
+
+	if d.IsAgentInAutoMode("yuki") {
+		t.Error("agent should not be in auto mode after reset")
+	}
+}
+
+func TestCheckAndGenerateFollowUp_SwitchesToAutoMode(t *testing.T) {
+	d := DefaultDetector()
+	result := d.CheckAndGenerateFollowUp("yuki", "context deadline exceeded")
+
+	if !result.SwitchedToAuto {
+		t.Error("SwitchedToAuto should be true")
+	}
+	if !d.IsAgentInAutoMode("yuki") {
+		t.Error("agent should be in auto mode")
+	}
+}

--- a/internal/errorwatch/detector.go
+++ b/internal/errorwatch/detector.go
@@ -14,13 +14,15 @@ var ErrorPatterns = []string{
 	"timeout",
 	"connection refused",
 	"connection reset",
+	"exit status 1",
 }
 
 // Detector detects error patterns and manages follow-up cooldowns.
 type Detector struct {
-	mu              sync.Mutex
-	lastFollowUp    map[string]time.Time
-	cooldownPeriod  time.Duration
+	mu             sync.Mutex
+	lastFollowUp   map[string]time.Time
+	cooldownPeriod time.Duration
+	modeManager    *AgentModeManager
 }
 
 // NewDetector creates a new error detector with the specified cooldown period.
@@ -28,6 +30,7 @@ func NewDetector(cooldownPeriod time.Duration) *Detector {
 	return &Detector{
 		lastFollowUp:   make(map[string]time.Time),
 		cooldownPeriod: cooldownPeriod,
+		modeManager:    NewAgentModeManager(),
 	}
 }
 
@@ -84,4 +87,35 @@ func (d *Detector) ResetAll() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.lastFollowUp = make(map[string]time.Time)
+}
+
+// HandleError processes an error and switches to auto mode if applicable.
+// Returns true if the agent was switched to auto mode.
+func (d *Detector) HandleError(agentName string, errMsg string) bool {
+	if !IsRecoverableError(errMsg) {
+		return false
+	}
+
+	d.modeManager.SwitchToAuto(agentName, errMsg)
+	return true
+}
+
+// ModeManager returns the agent mode manager.
+func (d *Detector) ModeManager() *AgentModeManager {
+	return d.modeManager
+}
+
+// SetModeManager sets a custom agent mode manager.
+func (d *Detector) SetModeManager(m *AgentModeManager) {
+	d.modeManager = m
+}
+
+// IsAgentInAutoMode checks if an agent is in auto mode.
+func (d *Detector) IsAgentInAutoMode(agentName string) bool {
+	return d.modeManager.IsAuto(agentName)
+}
+
+// ResetAgentMode resets an agent to normal mode.
+func (d *Detector) ResetAgentMode(agentName string) {
+	d.modeManager.SwitchToNormal(agentName)
 }

--- a/internal/errorwatch/followup.go
+++ b/internal/errorwatch/followup.go
@@ -9,12 +9,14 @@ func FollowUpMessage(agentName string) string {
 
 // FollowUpResult contains the result of checking whether to send a follow-up.
 type FollowUpResult struct {
-	ShouldSend bool
-	AgentName  string
-	Message    string
+	ShouldSend     bool
+	AgentName      string
+	Message        string
+	SwitchedToAuto bool // Whether the agent was switched to auto mode
 }
 
 // CheckAndGenerateFollowUp checks if a follow-up should be sent and generates the message.
+// Also switches the agent to auto mode if the error is recoverable.
 func (d *Detector) CheckAndGenerateFollowUp(agentName string, errMsg string) FollowUpResult {
 	if !d.ShouldFollowUp(agentName, errMsg) {
 		return FollowUpResult{ShouldSend: false}
@@ -22,9 +24,13 @@ func (d *Detector) CheckAndGenerateFollowUp(agentName string, errMsg string) Fol
 
 	d.RecordFollowUp(agentName)
 
+	// Switch agent to auto mode
+	switchedToAuto := d.HandleError(agentName, errMsg)
+
 	return FollowUpResult{
-		ShouldSend: true,
-		AgentName:  agentName,
-		Message:    FollowUpMessage(agentName),
+		ShouldSend:     true,
+		AgentName:      agentName,
+		Message:        FollowUpMessage(agentName),
+		SwitchedToAuto: switchedToAuto,
 	}
 }

--- a/internal/mode/command.go
+++ b/internal/mode/command.go
@@ -14,6 +14,8 @@ const (
 	CommandStop Command = "/stop"
 	// CommandStatus shows current mode status
 	CommandStatus Command = "/status"
+	// CommandResetAuto resets agent auto mode
+	CommandResetAuto Command = "/resetauto"
 )
 
 // ParseResult contains the result of parsing user input for commands
@@ -28,7 +30,7 @@ func Parse(input string) ParseResult {
 	trimmed := strings.TrimSpace(input)
 
 	// Check for known commands
-	commands := []Command{CommandPlan, CommandStop, CommandStatus}
+	commands := []Command{CommandPlan, CommandStop, CommandStatus, CommandResetAuto}
 	for _, cmd := range commands {
 		cmdStr := string(cmd)
 		if trimmed == cmdStr {


### PR DESCRIPTION
## Summary
- エージェントがエラーで応答不能時、自動でautoモードに切り替える機能を追加
- `/resetauto` コマンドで手動復帰可能
- ステータスバーにautoモードのエージェント一覧を表示

## 変更内容
- `AgentModeManager` でエージェントごとのモード状態を管理
- エラーパターン `exit status 1` を検知対象に追加
- TUIにautoモード表示とリセットコマンドを統合

## テスト
- `go test ./internal/errorwatch/...` → PASS
- `go test ./...` → 全テストPASS

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)