### PR TITLE
feat: /auto コマンドで直接autoモードに入れるようにする

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -1864,6 +1864,22 @@ func (m *tuiModel) handleModeCommand(result mode.ParseResult) (tea.Model, tea.Cm
 		// Start plan workflow asynchronously
 		return m, m.startPlanWorkflow()
 
+	case mode.CommandAuto:
+		// Enter auto mode directly (without plan)
+		if err := m.modeManager.EnterAutoModeWithoutPlan(); err != nil {
+			m.messages = append(m.messages, tuiMessage{
+				role:    "system",
+				content: fmt.Sprintf("⚠️ %s", err.Error()),
+			})
+			m.updateViewport()
+			return m, nil
+		}
+
+		m.messages = append(m.messages, tuiMessage{
+			role:    "system",
+			content: "🚀 Autoモードに切り替えました。プランなしで自動実行モードに入ります。\n/stop でInteractiveモードに戻れます。",
+		})
+
 	case mode.CommandStop:
 		// Stop approval watching if active
 		if m.approvalWatcher != nil && m.currentPlanIssue > 0 {

--- a/internal/mode/command.go
+++ b/internal/mode/command.go
@@ -10,6 +10,8 @@ type Command string
 const (
 	// CommandPlan enters plan mode
 	CommandPlan Command = "/plan"
+	// CommandAuto enters auto mode directly (without plan)
+	CommandAuto Command = "/auto"
 	// CommandStop stops current mode and returns to interactive
 	CommandStop Command = "/stop"
 	// CommandStatus shows current mode status
@@ -30,7 +32,7 @@ func Parse(input string) ParseResult {
 	trimmed := strings.TrimSpace(input)
 
 	// Check for known commands
-	commands := []Command{CommandPlan, CommandStop, CommandStatus, CommandResetAuto}
+	commands := []Command{CommandPlan, CommandAuto, CommandStop, CommandStatus, CommandResetAuto}
 	for _, cmd := range commands {
 		cmdStr := string(cmd)
 		if trimmed == cmdStr {

--- a/internal/mode/command_test.go
+++ b/internal/mode/command_test.go
@@ -41,6 +41,20 @@ func TestParse(t *testing.T) {
 			wantArgs:    "",
 		},
 		{
+			name:        "/auto command",
+			input:       "/auto",
+			wantCommand: true,
+			wantCmd:     CommandAuto,
+			wantArgs:    "",
+		},
+		{
+			name:        "/auto with args",
+			input:       "/auto yuki",
+			wantCommand: true,
+			wantCmd:     CommandAuto,
+			wantArgs:    "yuki",
+		},
+		{
 			name:        "regular message",
 			input:       "hello team",
 			wantCommand: false,

--- a/internal/mode/mode.go
+++ b/internal/mode/mode.go
@@ -88,6 +88,21 @@ func (m *Manager) EnterAutoMode(ctx *PlanContext) error {
 	return nil
 }
 
+// EnterAutoModeWithoutPlan transitions to auto mode directly from interactive mode
+// This bypasses the plan mode and allows immediate auto execution
+func (m *Manager) EnterAutoModeWithoutPlan() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.currentMode != config.ModeInteractive {
+		return fmt.Errorf("can only enter auto mode directly from interactive mode (current: %s)", m.currentMode)
+	}
+
+	m.currentMode = config.ModeAuto
+	m.planContext = nil // No plan context when entering directly
+	return nil
+}
+
 // Stop returns to interactive mode from any mode
 func (m *Manager) Stop() {
 	m.mu.Lock()

--- a/internal/mode/mode_test.go
+++ b/internal/mode/mode_test.go
@@ -76,12 +76,47 @@ func TestModeTransitions(t *testing.T) {
 		}
 	})
 
-	t.Run("direct auto mode from interactive fails", func(t *testing.T) {
+	t.Run("direct auto mode from interactive fails (via EnterAutoMode)", func(t *testing.T) {
 		m := NewManager(config.ModeInteractive)
 
 		ctx := &PlanContext{Approved: true}
 		if err := m.EnterAutoMode(ctx); err == nil {
 			t.Error("EnterAutoMode() expected error when not in plan mode")
+		}
+	})
+
+	t.Run("direct auto mode from interactive succeeds (via EnterAutoModeWithoutPlan)", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+
+		if err := m.EnterAutoModeWithoutPlan(); err != nil {
+			t.Errorf("EnterAutoModeWithoutPlan() unexpected error: %v", err)
+		}
+
+		if !m.IsAuto() {
+			t.Error("expected to be in auto mode")
+		}
+
+		// Plan context should be nil when entering without plan
+		if ctx := m.GetPlanContext(); ctx != nil {
+			t.Error("expected plan context to be nil when entering auto mode without plan")
+		}
+	})
+
+	t.Run("EnterAutoModeWithoutPlan fails from plan mode", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+		m.EnterPlanMode()
+
+		if err := m.EnterAutoModeWithoutPlan(); err == nil {
+			t.Error("EnterAutoModeWithoutPlan() expected error when in plan mode")
+		}
+	})
+
+	t.Run("EnterAutoModeWithoutPlan fails from auto mode", func(t *testing.T) {
+		m := NewManager(config.ModeInteractive)
+		m.EnterAutoModeWithoutPlan()
+
+		if err := m.EnterAutoModeWithoutPlan(); err == nil {
+			t.Error("EnterAutoModeWithoutPlan() expected error when already in auto mode")
 		}
 	})
 


### PR DESCRIPTION
## Summary

- `/auto` コマンドを追加し、プランなしで直接autoモードに入れるようにした
- `EnterAutoModeWithoutPlan()` を新設し、既存の `EnterAutoMode` は変更なし
- テストを追加（command_test, mode_test）

## 変更内容

- `internal/mode/command.go`: `CommandAuto` を追加
- `internal/mode/mode.go`: `EnterAutoModeWithoutPlan()` を追加
- `cmd/maxam/tui.go`: `/auto` コマンドのハンドリング追加

## Test plan

- [x] `go test ./internal/mode/...` PASS
- [x] `go test ./...` PASS
- [x] `go build ./cmd/maxam/...` 成功

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)