### PR TITLE
feat: add GitHub polling watch command (maxam watch)

### DIFF
--- a/cmd/maxam/main.go
+++ b/cmd/maxam/main.go
@@ -44,6 +44,8 @@ func main() {
 		runAnalyze()
 	case "status":
 		showStatus()
+	case "watch":
+		runWatch()
 	case "help":
 		printUsage()
 	default:
@@ -76,6 +78,7 @@ Commands:
   review <description> Run a full review cycle (Yuki → Priya)
   ask <agent> <prompt> Ask a specific agent a question
   analyze              Run Amara's weekly analysis
+  watch <owner/repo>   Watch repository for new Issues/PRs
   status               Show team status
   help                 Show this help
 
@@ -95,7 +98,9 @@ Examples:
   maxam task status 1 in_progress                 # Change task #1 to in_progress
   maxam task "Add a login button to the header"  # Delegate to Yuki
   maxam review "Create unit tests for the auth module"
-  maxam ask yuki "How would you implement caching here?"`)
+  maxam ask yuki "How would you implement caching here?"
+  maxam watch ytnobody/MAXAM              # Watch for new Issues/PRs
+  maxam watch ytnobody/MAXAM --interval 30s`)
 }
 
 func getWorkDir() string {
@@ -106,7 +111,6 @@ func getWorkDir() string {
 	}
 	return dir
 }
-
 
 func runReview() {
 	if len(os.Args) < 3 {

--- a/cmd/maxam/watch.go
+++ b/cmd/maxam/watch.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/ytnobody/MAXAM/internal/github"
+)
+
+func runWatch() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "Usage: maxam watch <owner/repo> [--interval <duration>]")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Examples:")
+		fmt.Fprintln(os.Stderr, "  maxam watch ytnobody/MAXAM")
+		fmt.Fprintln(os.Stderr, "  maxam watch ytnobody/MAXAM --interval 30s")
+		fmt.Fprintln(os.Stderr, "  maxam watch ytnobody/MAXAM --interval 2m")
+		os.Exit(1)
+	}
+
+	// Parse owner/repo
+	repoArg := os.Args[2]
+	parts := strings.Split(repoArg, "/")
+	if len(parts) != 2 {
+		fmt.Fprintf(os.Stderr, "Invalid repository format: %s (expected owner/repo)\n", repoArg)
+		os.Exit(1)
+	}
+	owner, repo := parts[0], parts[1]
+
+	// Parse interval (default: 1 minute)
+	interval := time.Minute
+	for i := 3; i < len(os.Args); i++ {
+		if os.Args[i] == "--interval" && i+1 < len(os.Args) {
+			d, err := time.ParseDuration(os.Args[i+1])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Invalid duration: %s\n", os.Args[i+1])
+				os.Exit(1)
+			}
+			interval = d
+		}
+	}
+
+	// Create GitHub client
+	client, err := github.NewClient(owner, repo)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating GitHub client: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Make sure GITHUB_TOKEN environment variable is set")
+		os.Exit(1)
+	}
+
+	watcher := github.NewEventWatcher(client)
+
+	// Setup graceful shutdown
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	fmt.Printf("🔍 Watching %s/%s for new Issues/PRs (interval: %s)\n", owner, repo, interval)
+	fmt.Println("Press Ctrl+C to stop")
+	fmt.Println()
+
+	// Initial check to populate seen IDs
+	events, err := watcher.CheckEvents(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: initial check failed: %v\n", err)
+	} else if len(events) > 0 {
+		fmt.Printf("Found %d existing event(s), marked as seen\n", len(events))
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-sigCh:
+			fmt.Println("\n👋 Stopping watcher...")
+			return
+		case <-ticker.C:
+			events, err := watcher.CheckEvents(ctx)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error checking events: %v\n", err)
+				continue
+			}
+
+			for _, e := range events {
+				fmt.Println(github.FormatEventNotification(e))
+				fmt.Println()
+			}
+		}
+	}
+}

--- a/internal/github/event_watcher.go
+++ b/internal/github/event_watcher.go
@@ -1,0 +1,228 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/go-github/v60/github"
+)
+
+// EventType represents the type of GitHub event
+type EventType string
+
+const (
+	EventTypeIssue EventType = "issue"
+	EventTypePR    EventType = "pr"
+)
+
+// Event represents a new Issue or PR creation event
+type Event struct {
+	Type      EventType
+	Number    int
+	Title     string
+	Author    string
+	URL       string
+	CreatedAt time.Time
+	Labels    []string
+	Body      string
+}
+
+// EventWatcher monitors new Issue/PR creations
+type EventWatcher struct {
+	client    *Client
+	seenIDs   map[string]bool
+	mu        sync.RWMutex
+	lastCheck time.Time
+}
+
+// NewEventWatcher creates a new event watcher
+func NewEventWatcher(client *Client) *EventWatcher {
+	return &EventWatcher{
+		client:    client,
+		seenIDs:   make(map[string]bool),
+		lastCheck: time.Now(),
+	}
+}
+
+// NewEventWatcherWithSince creates an event watcher with custom start time
+func NewEventWatcherWithSince(client *Client, since time.Time) *EventWatcher {
+	return &EventWatcher{
+		client:    client,
+		seenIDs:   make(map[string]bool),
+		lastCheck: since,
+	}
+}
+
+// CheckEvents fetches new Issue/PR events since last check
+func (w *EventWatcher) CheckEvents(ctx context.Context) ([]Event, error) {
+	var events []Event
+
+	// Fetch new issues
+	issues, err := w.fetchNewIssues(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch issues: %w", err)
+	}
+	events = append(events, issues...)
+
+	// Fetch new PRs
+	prs, err := w.fetchNewPRs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch PRs: %w", err)
+	}
+	events = append(events, prs...)
+
+	// Update last check time
+	w.lastCheck = time.Now()
+
+	return events, nil
+}
+
+// fetchNewIssues fetches issues created since lastCheck
+func (w *EventWatcher) fetchNewIssues(ctx context.Context) ([]Event, error) {
+	opts := &github.IssueListByRepoOptions{
+		State:     "all",
+		Sort:      "created",
+		Direction: "desc",
+		Since:     w.lastCheck,
+		ListOptions: github.ListOptions{
+			PerPage: 30,
+		},
+	}
+
+	issues, _, err := w.client.client.Issues.ListByRepo(ctx, w.client.owner, w.client.repo, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var events []Event
+	for _, issue := range issues {
+		// Skip PRs (GitHub API returns PRs as issues too)
+		if issue.PullRequestLinks != nil {
+			continue
+		}
+
+		id := fmt.Sprintf("issue-%d", issue.GetNumber())
+
+		w.mu.RLock()
+		seen := w.seenIDs[id]
+		w.mu.RUnlock()
+
+		if seen {
+			continue
+		}
+
+		// Only include if created after lastCheck
+		if issue.GetCreatedAt().Time.Before(w.lastCheck) {
+			continue
+		}
+
+		w.mu.Lock()
+		w.seenIDs[id] = true
+		w.mu.Unlock()
+
+		labels := make([]string, 0, len(issue.Labels))
+		for _, l := range issue.Labels {
+			labels = append(labels, l.GetName())
+		}
+
+		events = append(events, Event{
+			Type:      EventTypeIssue,
+			Number:    issue.GetNumber(),
+			Title:     issue.GetTitle(),
+			Author:    issue.GetUser().GetLogin(),
+			URL:       issue.GetHTMLURL(),
+			CreatedAt: issue.GetCreatedAt().Time,
+			Labels:    labels,
+			Body:      issue.GetBody(),
+		})
+	}
+
+	return events, nil
+}
+
+// fetchNewPRs fetches PRs created since lastCheck
+func (w *EventWatcher) fetchNewPRs(ctx context.Context) ([]Event, error) {
+	opts := &github.PullRequestListOptions{
+		State:     "all",
+		Sort:      "created",
+		Direction: "desc",
+		ListOptions: github.ListOptions{
+			PerPage: 30,
+		},
+	}
+
+	prs, _, err := w.client.client.PullRequests.List(ctx, w.client.owner, w.client.repo, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var events []Event
+	for _, pr := range prs {
+		id := fmt.Sprintf("pr-%d", pr.GetNumber())
+
+		w.mu.RLock()
+		seen := w.seenIDs[id]
+		w.mu.RUnlock()
+
+		if seen {
+			continue
+		}
+
+		// Only include if created after lastCheck
+		if pr.GetCreatedAt().Time.Before(w.lastCheck) {
+			continue
+		}
+
+		w.mu.Lock()
+		w.seenIDs[id] = true
+		w.mu.Unlock()
+
+		labels := make([]string, 0, len(pr.Labels))
+		for _, l := range pr.Labels {
+			labels = append(labels, l.GetName())
+		}
+
+		events = append(events, Event{
+			Type:      EventTypePR,
+			Number:    pr.GetNumber(),
+			Title:     pr.GetTitle(),
+			Author:    pr.GetUser().GetLogin(),
+			URL:       pr.GetHTMLURL(),
+			CreatedAt: pr.GetCreatedAt().Time,
+			Labels:    labels,
+			Body:      pr.GetBody(),
+		})
+	}
+
+	return events, nil
+}
+
+// FormatEventNotification formats an event for display
+func FormatEventNotification(e Event) string {
+	switch e.Type {
+	case EventTypeIssue:
+		return fmt.Sprintf("📝 New Issue #%d: %s (by @%s)\n   %s", e.Number, e.Title, e.Author, e.URL)
+	case EventTypePR:
+		return fmt.Sprintf("🔀 New PR #%d: %s (by @%s)\n   %s", e.Number, e.Title, e.Author, e.URL)
+	default:
+		return fmt.Sprintf("Event #%d: %s", e.Number, e.Title)
+	}
+}
+
+// MarkAsSeen marks an event as seen (useful for initialization)
+func (w *EventWatcher) MarkAsSeen(eventType EventType, number int) {
+	id := fmt.Sprintf("%s-%d", eventType, number)
+	w.mu.Lock()
+	w.seenIDs[id] = true
+	w.mu.Unlock()
+}
+
+// Reset clears all seen IDs and resets lastCheck
+func (w *EventWatcher) Reset() {
+	w.mu.Lock()
+	w.seenIDs = make(map[string]bool)
+	w.lastCheck = time.Now()
+	w.mu.Unlock()
+}

--- a/internal/github/event_watcher_test.go
+++ b/internal/github/event_watcher_test.go
@@ -1,0 +1,160 @@
+package github
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewEventWatcher(t *testing.T) {
+	client := &Client{
+		owner: "test",
+		repo:  "repo",
+	}
+
+	watcher := NewEventWatcher(client)
+
+	if watcher.client != client {
+		t.Error("NewEventWatcher() client not set correctly")
+	}
+
+	if watcher.seenIDs == nil {
+		t.Error("NewEventWatcher() seenIDs should be initialized")
+	}
+
+	// lastCheck should be approximately now
+	if time.Since(watcher.lastCheck) > time.Second {
+		t.Errorf("NewEventWatcher() lastCheck too old: %v", watcher.lastCheck)
+	}
+}
+
+func TestNewEventWatcherWithSince(t *testing.T) {
+	client := &Client{
+		owner: "test",
+		repo:  "repo",
+	}
+
+	customTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	watcher := NewEventWatcherWithSince(client, customTime)
+
+	if !watcher.lastCheck.Equal(customTime) {
+		t.Errorf("NewEventWatcherWithSince() lastCheck = %v, want %v",
+			watcher.lastCheck, customTime)
+	}
+}
+
+func TestEventType(t *testing.T) {
+	if EventTypeIssue != "issue" {
+		t.Errorf("EventTypeIssue = %q, want %q", EventTypeIssue, "issue")
+	}
+
+	if EventTypePR != "pr" {
+		t.Errorf("EventTypePR = %q, want %q", EventTypePR, "pr")
+	}
+}
+
+func TestFormatEventNotification(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    Event
+		contains []string
+	}{
+		{
+			name: "issue notification",
+			event: Event{
+				Type:   EventTypeIssue,
+				Number: 42,
+				Title:  "Bug report",
+				Author: "testuser",
+				URL:    "https://github.com/test/repo/issues/42",
+			},
+			contains: []string{"📝", "Issue #42", "Bug report", "@testuser"},
+		},
+		{
+			name: "PR notification",
+			event: Event{
+				Type:   EventTypePR,
+				Number: 123,
+				Title:  "New feature",
+				Author: "developer",
+				URL:    "https://github.com/test/repo/pull/123",
+			},
+			contains: []string{"🔀", "PR #123", "New feature", "@developer"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatEventNotification(tt.event)
+			for _, s := range tt.contains {
+				if !containsString(result, s) {
+					t.Errorf("FormatEventNotification() = %q, want to contain %q", result, s)
+				}
+			}
+		})
+	}
+}
+
+func TestMarkAsSeen(t *testing.T) {
+	client := &Client{
+		owner: "test",
+		repo:  "repo",
+	}
+
+	watcher := NewEventWatcher(client)
+
+	// Mark as seen
+	watcher.MarkAsSeen(EventTypeIssue, 42)
+
+	// Check internal state
+	watcher.mu.RLock()
+	seen := watcher.seenIDs["issue-42"]
+	watcher.mu.RUnlock()
+
+	if !seen {
+		t.Error("MarkAsSeen() should mark event as seen")
+	}
+}
+
+func TestReset(t *testing.T) {
+	client := &Client{
+		owner: "test",
+		repo:  "repo",
+	}
+
+	customTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	watcher := NewEventWatcherWithSince(client, customTime)
+
+	// Add some seen IDs
+	watcher.MarkAsSeen(EventTypeIssue, 1)
+	watcher.MarkAsSeen(EventTypePR, 2)
+
+	// Reset
+	watcher.Reset()
+
+	// Check seenIDs is cleared
+	watcher.mu.RLock()
+	count := len(watcher.seenIDs)
+	watcher.mu.RUnlock()
+
+	if count != 0 {
+		t.Errorf("Reset() seenIDs count = %d, want 0", count)
+	}
+
+	// Check lastCheck is updated
+	if time.Since(watcher.lastCheck) > time.Second {
+		t.Errorf("Reset() lastCheck should be updated to now")
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStringHelper(s, substr))
+}
+
+func containsStringHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- EventWatcher: Issue/PR新規作成を検知する機能
- `maxam watch owner/repo` コマンド追加
- `--interval` オプションでポーリング間隔設定可能（デフォルト1分）
- Ctrl+Cでgraceful shutdown

## Test plan
- [ ] `go test ./internal/github/...` → PASS
- [ ] `maxam watch ytnobody/MAXAM --interval 10s` で動作確認

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)