### PR TITLE
feat: add heartbeat monitoring and recovery system

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,19 +44,27 @@ func IsValidMode(m Mode) bool {
 	return false
 }
 
+// HeartbeatConfig holds heartbeat monitoring settings
+type HeartbeatConfig struct {
+	Interval   string `yaml:"interval,omitempty"`    // Monitoring interval (e.g., "10s")
+	Timeout    string `yaml:"timeout,omitempty"`     // Response timeout (e.g., "30s")
+	MaxRetries int    `yaml:"max_retries,omitempty"` // Max restart attempts
+}
+
 // Config represents the MAXAM configuration
 type Config struct {
-	Version               string        `yaml:"version"`
-	TeamName              string        `yaml:"team_name,omitempty"`
-	DefaultAgent          string        `yaml:"default_agent,omitempty"`
-	DefaultMode           Mode          `yaml:"default_mode,omitempty"`
-	Agents                []AgentConfig `yaml:"agents"`
-	AnalysisMinMessages   int           `yaml:"analysis_min_messages,omitempty"`
-	ContextMode           ContextMode   `yaml:"context_mode,omitempty"`
-	YOLOMode              bool          `yaml:"yolo_mode,omitempty"`
-	WorkersPerAgent       int           `yaml:"workers_per_agent,omitempty"`
-	MentionCheckerEnabled *bool         `yaml:"mention_checker_enabled,omitempty"`
-	LogLevel              string        `yaml:"log_level,omitempty"`
+	Version               string           `yaml:"version"`
+	TeamName              string           `yaml:"team_name,omitempty"`
+	DefaultAgent          string           `yaml:"default_agent,omitempty"`
+	DefaultMode           Mode             `yaml:"default_mode,omitempty"`
+	Agents                []AgentConfig    `yaml:"agents"`
+	AnalysisMinMessages   int              `yaml:"analysis_min_messages,omitempty"`
+	ContextMode           ContextMode      `yaml:"context_mode,omitempty"`
+	YOLOMode              bool             `yaml:"yolo_mode,omitempty"`
+	WorkersPerAgent       int              `yaml:"workers_per_agent,omitempty"`
+	MentionCheckerEnabled *bool            `yaml:"mention_checker_enabled,omitempty"`
+	LogLevel              string           `yaml:"log_level,omitempty"`
+	Heartbeat             *HeartbeatConfig `yaml:"heartbeat,omitempty"`
 }
 
 // AgentConfig represents an agent configuration
@@ -456,4 +464,38 @@ func (c *Config) GetLogLevel() string {
 		return "info"
 	}
 	return c.LogLevel
+}
+
+// DefaultHeartbeatInterval is the default heartbeat monitoring interval
+const DefaultHeartbeatInterval = "10s"
+
+// DefaultHeartbeatTimeout is the default heartbeat response timeout
+const DefaultHeartbeatTimeout = "30s"
+
+// DefaultHeartbeatMaxRetries is the default max restart attempts
+const DefaultHeartbeatMaxRetries = 3
+
+// GetHeartbeatConfig returns the heartbeat configuration with defaults
+func (c *Config) GetHeartbeatConfig() HeartbeatConfig {
+	if c.Heartbeat == nil {
+		return HeartbeatConfig{
+			Interval:   DefaultHeartbeatInterval,
+			Timeout:    DefaultHeartbeatTimeout,
+			MaxRetries: DefaultHeartbeatMaxRetries,
+		}
+	}
+
+	cfg := *c.Heartbeat
+
+	if cfg.Interval == "" {
+		cfg.Interval = DefaultHeartbeatInterval
+	}
+	if cfg.Timeout == "" {
+		cfg.Timeout = DefaultHeartbeatTimeout
+	}
+	if cfg.MaxRetries <= 0 {
+		cfg.MaxRetries = DefaultHeartbeatMaxRetries
+	}
+
+	return cfg
 }

--- a/internal/heartbeat/monitor.go
+++ b/internal/heartbeat/monitor.go
@@ -1,0 +1,281 @@
+// Package heartbeat provides agent health monitoring.
+package heartbeat
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Config holds heartbeat monitoring configuration.
+type Config struct {
+	Interval   time.Duration // Monitoring interval (default: 10s)
+	Timeout    time.Duration // Response timeout (default: 30s)
+	MaxRetries int           // Max restart attempts (default: 3)
+}
+
+// DefaultConfig returns the default heartbeat configuration.
+func DefaultConfig() Config {
+	return Config{
+		Interval:   10 * time.Second,
+		Timeout:    30 * time.Second,
+		MaxRetries: 3,
+	}
+}
+
+// Status represents the health status of a worker.
+type Status int
+
+const (
+	StatusUnknown Status = iota
+	StatusHealthy
+	StatusUnresponsive
+	StatusDead
+)
+
+func (s Status) String() string {
+	switch s {
+	case StatusHealthy:
+		return "healthy"
+	case StatusUnresponsive:
+		return "unresponsive"
+	case StatusDead:
+		return "dead"
+	default:
+		return "unknown"
+	}
+}
+
+// WorkerHealth tracks the health state of a worker.
+type WorkerHealth struct {
+	Name         string
+	Status       Status
+	LastPing     time.Time
+	LastResponse time.Time
+	FailCount    int
+}
+
+// PingFunc is called to send a ping to a worker.
+// It should return nil if the worker responds, error otherwise.
+type PingFunc func(ctx context.Context, workerName string) error
+
+// UnresponsiveCallback is called when a worker becomes unresponsive.
+type UnresponsiveCallback func(workerName string, failCount int)
+
+// Monitor watches worker health using heartbeat pings.
+type Monitor struct {
+	cfg       Config
+	workers   map[string]*WorkerHealth
+	mu        sync.RWMutex
+	pingFn    PingFunc
+	onUnresp  UnresponsiveCallback
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	running   bool
+	runningMu sync.Mutex
+}
+
+// NewMonitor creates a new heartbeat monitor.
+func NewMonitor(cfg Config, pingFn PingFunc) *Monitor {
+	if cfg.Interval <= 0 {
+		cfg.Interval = DefaultConfig().Interval
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = DefaultConfig().Timeout
+	}
+	if cfg.MaxRetries <= 0 {
+		cfg.MaxRetries = DefaultConfig().MaxRetries
+	}
+
+	return &Monitor{
+		cfg:     cfg,
+		workers: make(map[string]*WorkerHealth),
+		pingFn:  pingFn,
+	}
+}
+
+// SetUnresponsiveCallback sets the callback for unresponsive workers.
+func (m *Monitor) SetUnresponsiveCallback(fn UnresponsiveCallback) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onUnresp = fn
+}
+
+// RegisterWorker adds a worker to monitoring.
+func (m *Monitor) RegisterWorker(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.workers[name] = &WorkerHealth{
+		Name:   name,
+		Status: StatusUnknown,
+	}
+}
+
+// UnregisterWorker removes a worker from monitoring.
+func (m *Monitor) UnregisterWorker(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.workers, name)
+}
+
+// Start begins the monitoring loop.
+func (m *Monitor) Start() {
+	m.runningMu.Lock()
+	if m.running {
+		m.runningMu.Unlock()
+		return
+	}
+	m.running = true
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+	m.runningMu.Unlock()
+
+	m.wg.Add(1)
+	go m.monitorLoop()
+}
+
+// Stop stops the monitoring loop.
+func (m *Monitor) Stop() {
+	m.runningMu.Lock()
+	if !m.running {
+		m.runningMu.Unlock()
+		return
+	}
+	m.running = false
+	m.cancel()
+	m.runningMu.Unlock()
+	m.wg.Wait()
+}
+
+// monitorLoop runs periodic health checks.
+func (m *Monitor) monitorLoop() {
+	defer m.wg.Done()
+
+	ticker := time.NewTicker(m.cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.checkAll()
+		}
+	}
+}
+
+// checkAll pings all registered workers.
+func (m *Monitor) checkAll() {
+	m.mu.RLock()
+	names := make([]string, 0, len(m.workers))
+	for name := range m.workers {
+		names = append(names, name)
+	}
+	m.mu.RUnlock()
+
+	for _, name := range names {
+		m.checkWorker(name)
+	}
+}
+
+// checkWorker pings a single worker and updates its health.
+func (m *Monitor) checkWorker(name string) {
+	m.mu.RLock()
+	health, exists := m.workers[name]
+	m.mu.RUnlock()
+	if !exists {
+		return
+	}
+
+	// Use background context if monitor not started
+	parentCtx := m.ctx
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, m.cfg.Timeout)
+	defer cancel()
+
+	now := time.Now()
+
+	m.mu.Lock()
+	health.LastPing = now
+	m.mu.Unlock()
+
+	err := m.pingFn(ctx, name)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err != nil {
+		health.FailCount++
+		if health.FailCount >= m.cfg.MaxRetries {
+			health.Status = StatusDead
+		} else {
+			health.Status = StatusUnresponsive
+		}
+
+		// Trigger callback
+		if m.onUnresp != nil {
+			go m.onUnresp(name, health.FailCount)
+		}
+	} else {
+		health.Status = StatusHealthy
+		health.LastResponse = time.Now()
+		health.FailCount = 0
+	}
+}
+
+// GetHealth returns the current health of a worker.
+func (m *Monitor) GetHealth(name string) (WorkerHealth, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	health, exists := m.workers[name]
+	if !exists {
+		return WorkerHealth{}, false
+	}
+	return *health, true
+}
+
+// GetAllHealth returns health status of all workers.
+func (m *Monitor) GetAllHealth() map[string]WorkerHealth {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make(map[string]WorkerHealth, len(m.workers))
+	for name, health := range m.workers {
+		result[name] = *health
+	}
+	return result
+}
+
+// ResetFailCount resets the failure count for a worker.
+func (m *Monitor) ResetFailCount(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if health, exists := m.workers[name]; exists {
+		health.FailCount = 0
+		health.Status = StatusUnknown
+	}
+}
+
+// IsHealthy returns true if the worker is healthy.
+func (m *Monitor) IsHealthy(name string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if health, exists := m.workers[name]; exists {
+		return health.Status == StatusHealthy
+	}
+	return false
+}
+
+// GetUnresponsiveWorkers returns names of unresponsive or dead workers.
+func (m *Monitor) GetUnresponsiveWorkers() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []string
+	for name, health := range m.workers {
+		if health.Status == StatusUnresponsive || health.Status == StatusDead {
+			result = append(result, name)
+		}
+	}
+	return result
+}

--- a/internal/heartbeat/monitor_test.go
+++ b/internal/heartbeat/monitor_test.go
@@ -1,0 +1,409 @@
+package heartbeat
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Interval != 10*time.Second {
+		t.Errorf("expected Interval 10s, got %v", cfg.Interval)
+	}
+	if cfg.Timeout != 30*time.Second {
+		t.Errorf("expected Timeout 30s, got %v", cfg.Timeout)
+	}
+	if cfg.MaxRetries != 3 {
+		t.Errorf("expected MaxRetries 3, got %d", cfg.MaxRetries)
+	}
+}
+
+func TestStatus_String(t *testing.T) {
+	tests := []struct {
+		status Status
+		want   string
+	}{
+		{StatusUnknown, "unknown"},
+		{StatusHealthy, "healthy"},
+		{StatusUnresponsive, "unresponsive"},
+		{StatusDead, "dead"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.status.String(); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMonitor_RegisterUnregister(t *testing.T) {
+	m := NewMonitor(DefaultConfig(), nil)
+
+	m.RegisterWorker("worker1")
+	m.RegisterWorker("worker2")
+
+	health, exists := m.GetHealth("worker1")
+	if !exists {
+		t.Error("worker1 should exist")
+	}
+	if health.Name != "worker1" {
+		t.Errorf("expected name worker1, got %s", health.Name)
+	}
+
+	m.UnregisterWorker("worker1")
+	_, exists = m.GetHealth("worker1")
+	if exists {
+		t.Error("worker1 should not exist after unregister")
+	}
+
+	_, exists = m.GetHealth("worker2")
+	if !exists {
+		t.Error("worker2 should still exist")
+	}
+}
+
+func TestMonitor_GetAllHealth(t *testing.T) {
+	m := NewMonitor(DefaultConfig(), nil)
+	m.RegisterWorker("a")
+	m.RegisterWorker("b")
+	m.RegisterWorker("c")
+
+	all := m.GetAllHealth()
+	if len(all) != 3 {
+		t.Errorf("expected 3 workers, got %d", len(all))
+	}
+
+	for _, name := range []string{"a", "b", "c"} {
+		if _, ok := all[name]; !ok {
+			t.Errorf("worker %s not found", name)
+		}
+	}
+}
+
+func TestMonitor_CheckWorker_Healthy(t *testing.T) {
+	pingFn := func(ctx context.Context, name string) error {
+		return nil // Always healthy
+	}
+
+	cfg := Config{
+		Interval:   100 * time.Millisecond,
+		Timeout:    1 * time.Second,
+		MaxRetries: 3,
+	}
+	m := NewMonitor(cfg, pingFn)
+	m.RegisterWorker("test")
+
+	m.checkWorker("test")
+
+	health, _ := m.GetHealth("test")
+	if health.Status != StatusHealthy {
+		t.Errorf("expected healthy, got %v", health.Status)
+	}
+	if health.FailCount != 0 {
+		t.Errorf("expected 0 failures, got %d", health.FailCount)
+	}
+}
+
+func TestMonitor_CheckWorker_Unresponsive(t *testing.T) {
+	pingFn := func(ctx context.Context, name string) error {
+		return errors.New("timeout")
+	}
+
+	cfg := Config{
+		Interval:   100 * time.Millisecond,
+		Timeout:    1 * time.Second,
+		MaxRetries: 3,
+	}
+	m := NewMonitor(cfg, pingFn)
+	m.RegisterWorker("test")
+
+	// First failure
+	m.checkWorker("test")
+	health, _ := m.GetHealth("test")
+	if health.Status != StatusUnresponsive {
+		t.Errorf("expected unresponsive, got %v", health.Status)
+	}
+	if health.FailCount != 1 {
+		t.Errorf("expected 1 failure, got %d", health.FailCount)
+	}
+
+	// Second failure
+	m.checkWorker("test")
+	health, _ = m.GetHealth("test")
+	if health.FailCount != 2 {
+		t.Errorf("expected 2 failures, got %d", health.FailCount)
+	}
+}
+
+func TestMonitor_CheckWorker_Dead(t *testing.T) {
+	pingFn := func(ctx context.Context, name string) error {
+		return errors.New("timeout")
+	}
+
+	cfg := Config{
+		Interval:   100 * time.Millisecond,
+		Timeout:    1 * time.Second,
+		MaxRetries: 2,
+	}
+	m := NewMonitor(cfg, pingFn)
+	m.RegisterWorker("test")
+
+	// Exceed max retries
+	m.checkWorker("test")
+	m.checkWorker("test")
+
+	health, _ := m.GetHealth("test")
+	if health.Status != StatusDead {
+		t.Errorf("expected dead, got %v", health.Status)
+	}
+}
+
+func TestMonitor_UnresponsiveCallback(t *testing.T) {
+	pingFn := func(ctx context.Context, name string) error {
+		return errors.New("timeout")
+	}
+
+	cfg := Config{
+		Interval:   100 * time.Millisecond,
+		Timeout:    1 * time.Second,
+		MaxRetries: 3,
+	}
+	m := NewMonitor(cfg, pingFn)
+
+	var callbackCalled atomic.Int32
+	var callbackName string
+	var callbackFailCount int
+	var mu sync.Mutex
+
+	m.SetUnresponsiveCallback(func(name string, failCount int) {
+		callbackCalled.Add(1)
+		mu.Lock()
+		callbackName = name
+		callbackFailCount = failCount
+		mu.Unlock()
+	})
+
+	m.RegisterWorker("test")
+	m.checkWorker("test")
+
+	// Wait for callback
+	time.Sleep(50 * time.Millisecond)
+
+	if callbackCalled.Load() != 1 {
+		t.Errorf("expected callback called once, got %d", callbackCalled.Load())
+	}
+	mu.Lock()
+	if callbackName != "test" {
+		t.Errorf("expected name 'test', got %s", callbackName)
+	}
+	if callbackFailCount != 1 {
+		t.Errorf("expected failCount 1, got %d", callbackFailCount)
+	}
+	mu.Unlock()
+}
+
+func TestMonitor_ResetFailCount(t *testing.T) {
+	pingFn := func(ctx context.Context, name string) error {
+		return errors.New("timeout")
+	}
+
+	cfg := Config{
+		Interval:   100 * time.Millisecond,
+		Timeout:    1 * time.Second,
+		MaxRetries: 3,
+	}
+	m := NewMonitor(cfg, pingFn)
+	m.RegisterWorker("test")
+
+	m.checkWorker("test")
+	m.checkWorker("test")
+
+	health, _ := m.GetHealth("test")
+	if health.FailCount != 2 {
+		t.Errorf("expected 2 failures, got %d", health.FailCount)
+	}
+
+	m.ResetFailCount("test")
+
+	health, _ = m.GetHealth("test")
+	if health.FailCount != 0 {
+		t.Errorf("expected 0 failures after reset, got %d", health.FailCount)
+	}
+	if health.Status != StatusUnknown {
+		t.Errorf("expected unknown status after reset, got %v", health.Status)
+	}
+}
+
+func TestMonitor_IsHealthy(t *testing.T) {
+	var healthy bool
+	pingFn := func(ctx context.Context, name string) error {
+		if healthy {
+			return nil
+		}
+		return errors.New("error")
+	}
+
+	m := NewMonitor(DefaultConfig(), pingFn)
+	m.RegisterWorker("test")
+
+	if m.IsHealthy("test") {
+		t.Error("should not be healthy initially")
+	}
+
+	healthy = true
+	m.checkWorker("test")
+
+	if !m.IsHealthy("test") {
+		t.Error("should be healthy after successful ping")
+	}
+
+	if m.IsHealthy("nonexistent") {
+		t.Error("nonexistent worker should not be healthy")
+	}
+}
+
+func TestMonitor_GetUnresponsiveWorkers(t *testing.T) {
+	callCount := make(map[string]int)
+	var mu sync.Mutex
+	pingFn := func(ctx context.Context, name string) error {
+		mu.Lock()
+		callCount[name]++
+		mu.Unlock()
+		if name == "healthy" {
+			return nil
+		}
+		return errors.New("error")
+	}
+
+	cfg := Config{
+		Interval:   100 * time.Millisecond,
+		Timeout:    1 * time.Second,
+		MaxRetries: 3,
+	}
+	m := NewMonitor(cfg, pingFn)
+	m.RegisterWorker("healthy")
+	m.RegisterWorker("sick")
+
+	m.checkWorker("healthy")
+	m.checkWorker("sick")
+
+	unresponsive := m.GetUnresponsiveWorkers()
+	if len(unresponsive) != 1 {
+		t.Errorf("expected 1 unresponsive, got %d", len(unresponsive))
+	}
+	if len(unresponsive) > 0 && unresponsive[0] != "sick" {
+		t.Errorf("expected 'sick', got %s", unresponsive[0])
+	}
+}
+
+func TestMonitor_StartStop(t *testing.T) {
+	var pingCount atomic.Int32
+	pingFn := func(ctx context.Context, name string) error {
+		pingCount.Add(1)
+		return nil
+	}
+
+	cfg := Config{
+		Interval:   50 * time.Millisecond,
+		Timeout:    100 * time.Millisecond,
+		MaxRetries: 3,
+	}
+	m := NewMonitor(cfg, pingFn)
+	m.RegisterWorker("test")
+
+	m.Start()
+
+	// Wait for some pings
+	time.Sleep(150 * time.Millisecond)
+
+	m.Stop()
+
+	count := pingCount.Load()
+	if count < 1 {
+		t.Errorf("expected at least 1 ping, got %d", count)
+	}
+
+	// Verify stopped
+	countAfterStop := pingCount.Load()
+	time.Sleep(100 * time.Millisecond)
+	if pingCount.Load() != countAfterStop {
+		t.Error("monitor should be stopped")
+	}
+}
+
+func TestMonitor_StartStop_Idempotent(t *testing.T) {
+	m := NewMonitor(DefaultConfig(), nil)
+
+	// Multiple starts should be safe
+	m.Start()
+	m.Start()
+	m.Start()
+
+	// Multiple stops should be safe
+	m.Stop()
+	m.Stop()
+	m.Stop()
+}
+
+func TestMonitor_ConfigDefaults(t *testing.T) {
+	// Zero config should use defaults
+	cfg := Config{}
+	m := NewMonitor(cfg, nil)
+
+	if m.cfg.Interval != DefaultConfig().Interval {
+		t.Errorf("expected default interval, got %v", m.cfg.Interval)
+	}
+	if m.cfg.Timeout != DefaultConfig().Timeout {
+		t.Errorf("expected default timeout, got %v", m.cfg.Timeout)
+	}
+	if m.cfg.MaxRetries != DefaultConfig().MaxRetries {
+		t.Errorf("expected default max retries, got %d", m.cfg.MaxRetries)
+	}
+}
+
+func TestMonitor_Recovery(t *testing.T) {
+	// Simulate worker that recovers
+	failCount := 0
+	pingFn := func(ctx context.Context, name string) error {
+		failCount++
+		if failCount <= 2 {
+			return errors.New("error")
+		}
+		return nil // Recovers on 3rd attempt
+	}
+
+	cfg := Config{
+		Interval:   100 * time.Millisecond,
+		Timeout:    1 * time.Second,
+		MaxRetries: 5,
+	}
+	m := NewMonitor(cfg, pingFn)
+	m.RegisterWorker("test")
+
+	// Fail twice
+	m.checkWorker("test")
+	m.checkWorker("test")
+
+	health, _ := m.GetHealth("test")
+	if health.Status != StatusUnresponsive {
+		t.Errorf("expected unresponsive, got %v", health.Status)
+	}
+
+	// Third check - should recover
+	m.checkWorker("test")
+
+	health, _ = m.GetHealth("test")
+	if health.Status != StatusHealthy {
+		t.Errorf("expected healthy after recovery, got %v", health.Status)
+	}
+	if health.FailCount != 0 {
+		t.Errorf("expected fail count reset to 0, got %d", health.FailCount)
+	}
+}

--- a/internal/recovery/handler.go
+++ b/internal/recovery/handler.go
@@ -1,0 +1,211 @@
+// Package recovery provides agent recovery and fallback mechanisms.
+package recovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ErrMaxRetriesExceeded is returned when max restart attempts are exhausted.
+var ErrMaxRetriesExceeded = errors.New("max retries exceeded")
+
+// ErrPMNotificationFailed is returned when PM notification fails.
+var ErrPMNotificationFailed = errors.New("PM notification failed")
+
+// RestartFunc is called to restart a worker.
+type RestartFunc func(ctx context.Context, workerName string) error
+
+// NotifyFunc is called to send notifications.
+type NotifyFunc func(ctx context.Context, target, message string) error
+
+// Config holds recovery configuration.
+type Config struct {
+	MaxRetries    int           // Max restart attempts per worker
+	RetryDelay    time.Duration // Delay between retries
+	NotifyTimeout time.Duration // Timeout for notifications
+	PMAgent       string        // PM agent name for notifications
+	OwnerChannel  string        // Owner notification channel (fallback)
+}
+
+// DefaultConfig returns the default recovery configuration.
+func DefaultConfig() Config {
+	return Config{
+		MaxRetries:    3,
+		RetryDelay:    5 * time.Second,
+		NotifyTimeout: 10 * time.Second,
+		PMAgent:       "mei",
+		OwnerChannel:  "owner",
+	}
+}
+
+// RecoveryState tracks recovery attempts for a worker.
+type RecoveryState struct {
+	WorkerName  string
+	Attempts    int
+	LastAttempt time.Time
+	LastError   error
+	Recovered   bool
+}
+
+// Handler manages worker recovery.
+type Handler struct {
+	cfg       Config
+	restartFn RestartFunc
+	notifyFn  NotifyFunc
+	states    map[string]*RecoveryState
+	mu        sync.RWMutex
+}
+
+// NewHandler creates a new recovery handler.
+func NewHandler(cfg Config, restartFn RestartFunc, notifyFn NotifyFunc) *Handler {
+	if cfg.MaxRetries <= 0 {
+		cfg.MaxRetries = DefaultConfig().MaxRetries
+	}
+	if cfg.RetryDelay <= 0 {
+		cfg.RetryDelay = DefaultConfig().RetryDelay
+	}
+	if cfg.NotifyTimeout <= 0 {
+		cfg.NotifyTimeout = DefaultConfig().NotifyTimeout
+	}
+	if cfg.PMAgent == "" {
+		cfg.PMAgent = DefaultConfig().PMAgent
+	}
+	if cfg.OwnerChannel == "" {
+		cfg.OwnerChannel = DefaultConfig().OwnerChannel
+	}
+
+	return &Handler{
+		cfg:       cfg,
+		restartFn: restartFn,
+		notifyFn:  notifyFn,
+		states:    make(map[string]*RecoveryState),
+	}
+}
+
+// HandleUnresponsive handles an unresponsive worker.
+// Returns true if recovery was successful.
+func (h *Handler) HandleUnresponsive(ctx context.Context, workerName string, failCount int) bool {
+	h.mu.Lock()
+	state, exists := h.states[workerName]
+	if !exists {
+		state = &RecoveryState{WorkerName: workerName}
+		h.states[workerName] = state
+	}
+	state.Attempts = failCount
+	state.LastAttempt = time.Now()
+	h.mu.Unlock()
+
+	// Try restart
+	if failCount <= h.cfg.MaxRetries {
+		if err := h.attemptRestart(ctx, workerName); err == nil {
+			h.mu.Lock()
+			state.Recovered = true
+			state.LastError = nil
+			h.mu.Unlock()
+			return true
+		} else {
+			h.mu.Lock()
+			state.LastError = err
+			h.mu.Unlock()
+		}
+	}
+
+	// Restart failed or max retries exceeded - notify PM
+	if failCount >= h.cfg.MaxRetries {
+		h.notifyPM(ctx, workerName, failCount)
+	}
+
+	return false
+}
+
+// attemptRestart tries to restart a worker.
+func (h *Handler) attemptRestart(ctx context.Context, workerName string) error {
+	if h.restartFn == nil {
+		return errors.New("restart function not set")
+	}
+
+	// Wait before retry
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(h.cfg.RetryDelay):
+	}
+
+	return h.restartFn(ctx, workerName)
+}
+
+// notifyPM sends a notification to PM, with owner fallback.
+func (h *Handler) notifyPM(ctx context.Context, workerName string, failCount int) {
+	if h.notifyFn == nil {
+		return
+	}
+
+	message := fmt.Sprintf("エージェント %s が応答不能 (失敗回数: %d)。自動復帰に失敗しました。", workerName, failCount)
+
+	notifyCtx, cancel := context.WithTimeout(ctx, h.cfg.NotifyTimeout)
+	defer cancel()
+
+	// Try PM notification
+	err := h.notifyFn(notifyCtx, h.cfg.PMAgent, message)
+	if err != nil {
+		// PM notification failed - fallback to owner
+		h.notifyOwner(ctx, workerName, failCount, err)
+	}
+}
+
+// notifyOwner sends notification directly to owner (fallback).
+func (h *Handler) notifyOwner(ctx context.Context, workerName string, failCount int, pmError error) {
+	if h.notifyFn == nil {
+		return
+	}
+
+	message := fmt.Sprintf(
+		"[FALLBACK] エージェント %s が応答不能 (失敗回数: %d)。PM通知失敗: %v",
+		workerName, failCount, pmError,
+	)
+
+	notifyCtx, cancel := context.WithTimeout(ctx, h.cfg.NotifyTimeout)
+	defer cancel()
+
+	// Best effort - ignore error
+	_ = h.notifyFn(notifyCtx, h.cfg.OwnerChannel, message)
+}
+
+// GetState returns the recovery state for a worker.
+func (h *Handler) GetState(workerName string) (RecoveryState, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	state, exists := h.states[workerName]
+	if !exists {
+		return RecoveryState{}, false
+	}
+	return *state, true
+}
+
+// ResetState resets the recovery state for a worker.
+func (h *Handler) ResetState(workerName string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.states, workerName)
+}
+
+// ResetAll resets all recovery states.
+func (h *Handler) ResetAll() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.states = make(map[string]*RecoveryState)
+}
+
+// GetAllStates returns all recovery states.
+func (h *Handler) GetAllStates() map[string]RecoveryState {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	result := make(map[string]RecoveryState, len(h.states))
+	for name, state := range h.states {
+		result[name] = *state
+	}
+	return result
+}

--- a/internal/recovery/handler_test.go
+++ b/internal/recovery/handler_test.go
@@ -1,0 +1,345 @@
+package recovery
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.MaxRetries != 3 {
+		t.Errorf("expected MaxRetries 3, got %d", cfg.MaxRetries)
+	}
+	if cfg.RetryDelay != 5*time.Second {
+		t.Errorf("expected RetryDelay 5s, got %v", cfg.RetryDelay)
+	}
+	if cfg.NotifyTimeout != 10*time.Second {
+		t.Errorf("expected NotifyTimeout 10s, got %v", cfg.NotifyTimeout)
+	}
+	if cfg.PMAgent != "mei" {
+		t.Errorf("expected PMAgent 'mei', got %s", cfg.PMAgent)
+	}
+	if cfg.OwnerChannel != "owner" {
+		t.Errorf("expected OwnerChannel 'owner', got %s", cfg.OwnerChannel)
+	}
+}
+
+func TestHandler_HandleUnresponsive_RestartSuccess(t *testing.T) {
+	restartCalled := false
+	restartFn := func(ctx context.Context, name string) error {
+		restartCalled = true
+		return nil
+	}
+
+	cfg := Config{
+		MaxRetries:    3,
+		RetryDelay:    10 * time.Millisecond,
+		NotifyTimeout: 100 * time.Millisecond,
+	}
+	h := NewHandler(cfg, restartFn, nil)
+
+	ctx := context.Background()
+	result := h.HandleUnresponsive(ctx, "worker1", 1)
+
+	if !restartCalled {
+		t.Error("restart should be called")
+	}
+	if !result {
+		t.Error("should return true on successful restart")
+	}
+
+	state, exists := h.GetState("worker1")
+	if !exists {
+		t.Error("state should exist")
+	}
+	if !state.Recovered {
+		t.Error("state should be marked as recovered")
+	}
+}
+
+func TestHandler_HandleUnresponsive_RestartFail(t *testing.T) {
+	restartFn := func(ctx context.Context, name string) error {
+		return errors.New("restart failed")
+	}
+
+	var notifiedTarget string
+	var mu sync.Mutex
+	notifyFn := func(ctx context.Context, target, message string) error {
+		mu.Lock()
+		notifiedTarget = target
+		mu.Unlock()
+		return nil
+	}
+
+	cfg := Config{
+		MaxRetries:    3,
+		RetryDelay:    10 * time.Millisecond,
+		NotifyTimeout: 100 * time.Millisecond,
+		PMAgent:       "mei",
+	}
+	h := NewHandler(cfg, restartFn, notifyFn)
+
+	ctx := context.Background()
+	result := h.HandleUnresponsive(ctx, "worker1", 3) // At max retries
+
+	if result {
+		t.Error("should return false when restart fails")
+	}
+
+	// Wait for notification goroutine
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	if notifiedTarget != "mei" {
+		t.Errorf("expected PM 'mei' to be notified, got %s", notifiedTarget)
+	}
+	mu.Unlock()
+}
+
+func TestHandler_HandleUnresponsive_PMNotifyFail_OwnerFallback(t *testing.T) {
+	restartFn := func(ctx context.Context, name string) error {
+		return errors.New("restart failed")
+	}
+
+	var notifications []string
+	var mu sync.Mutex
+	notifyFn := func(ctx context.Context, target, message string) error {
+		mu.Lock()
+		notifications = append(notifications, target)
+		mu.Unlock()
+		if target == "mei" {
+			return errors.New("PM unreachable")
+		}
+		return nil
+	}
+
+	cfg := Config{
+		MaxRetries:    3,
+		RetryDelay:    10 * time.Millisecond,
+		NotifyTimeout: 100 * time.Millisecond,
+		PMAgent:       "mei",
+		OwnerChannel:  "owner",
+	}
+	h := NewHandler(cfg, restartFn, notifyFn)
+
+	ctx := context.Background()
+	h.HandleUnresponsive(ctx, "worker1", 3)
+
+	// Wait for notification goroutines
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(notifications) != 2 {
+		t.Errorf("expected 2 notifications (PM then owner), got %d: %v", len(notifications), notifications)
+	}
+	if len(notifications) >= 2 {
+		if notifications[0] != "mei" {
+			t.Errorf("expected first notification to mei, got %s", notifications[0])
+		}
+		if notifications[1] != "owner" {
+			t.Errorf("expected second notification to owner, got %s", notifications[1])
+		}
+	}
+}
+
+func TestHandler_HandleUnresponsive_NoRestartBeyondMaxRetries(t *testing.T) {
+	var restartCount atomic.Int32
+	restartFn := func(ctx context.Context, name string) error {
+		restartCount.Add(1)
+		return errors.New("always fail")
+	}
+
+	cfg := Config{
+		MaxRetries:    2,
+		RetryDelay:    10 * time.Millisecond,
+		NotifyTimeout: 100 * time.Millisecond,
+	}
+	h := NewHandler(cfg, restartFn, nil)
+
+	ctx := context.Background()
+
+	// Within retry limit
+	h.HandleUnresponsive(ctx, "worker1", 1)
+	h.HandleUnresponsive(ctx, "worker1", 2)
+
+	// Beyond retry limit
+	h.HandleUnresponsive(ctx, "worker1", 3)
+	h.HandleUnresponsive(ctx, "worker1", 4)
+
+	// Should only have tried restart twice (for failCount <= MaxRetries)
+	if restartCount.Load() != 2 {
+		t.Errorf("expected 2 restart attempts, got %d", restartCount.Load())
+	}
+}
+
+// fastTestConfig returns a config with short timeouts for testing
+func fastTestConfig() Config {
+	return Config{
+		MaxRetries:    3,
+		RetryDelay:    10 * time.Millisecond,
+		NotifyTimeout: 100 * time.Millisecond,
+		PMAgent:       "mei",
+		OwnerChannel:  "owner",
+	}
+}
+
+func TestHandler_GetState(t *testing.T) {
+	h := NewHandler(fastTestConfig(), nil, nil)
+
+	_, exists := h.GetState("unknown")
+	if exists {
+		t.Error("unknown worker should not exist")
+	}
+
+	ctx := context.Background()
+	h.HandleUnresponsive(ctx, "worker1", 2)
+
+	state, exists := h.GetState("worker1")
+	if !exists {
+		t.Error("worker1 should exist after handling")
+	}
+	if state.WorkerName != "worker1" {
+		t.Errorf("expected name worker1, got %s", state.WorkerName)
+	}
+	if state.Attempts != 2 {
+		t.Errorf("expected 2 attempts, got %d", state.Attempts)
+	}
+}
+
+func TestHandler_ResetState(t *testing.T) {
+	restartFn := func(ctx context.Context, name string) error {
+		return nil
+	}
+
+	h := NewHandler(fastTestConfig(), restartFn, nil)
+
+	ctx := context.Background()
+	h.HandleUnresponsive(ctx, "worker1", 1)
+
+	_, exists := h.GetState("worker1")
+	if !exists {
+		t.Error("worker1 should exist")
+	}
+
+	h.ResetState("worker1")
+
+	_, exists = h.GetState("worker1")
+	if exists {
+		t.Error("worker1 should not exist after reset")
+	}
+}
+
+func TestHandler_ResetAll(t *testing.T) {
+	restartFn := func(ctx context.Context, name string) error {
+		return nil
+	}
+
+	h := NewHandler(fastTestConfig(), restartFn, nil)
+
+	ctx := context.Background()
+	h.HandleUnresponsive(ctx, "worker1", 1)
+	h.HandleUnresponsive(ctx, "worker2", 1)
+	h.HandleUnresponsive(ctx, "worker3", 1)
+
+	states := h.GetAllStates()
+	if len(states) != 3 {
+		t.Errorf("expected 3 states, got %d", len(states))
+	}
+
+	h.ResetAll()
+
+	states = h.GetAllStates()
+	if len(states) != 0 {
+		t.Errorf("expected 0 states after reset, got %d", len(states))
+	}
+}
+
+func TestHandler_GetAllStates(t *testing.T) {
+	restartFn := func(ctx context.Context, name string) error {
+		return nil
+	}
+
+	h := NewHandler(fastTestConfig(), restartFn, nil)
+
+	ctx := context.Background()
+	h.HandleUnresponsive(ctx, "a", 1)
+	h.HandleUnresponsive(ctx, "b", 2)
+
+	states := h.GetAllStates()
+
+	if len(states) != 2 {
+		t.Errorf("expected 2 states, got %d", len(states))
+	}
+	if _, ok := states["a"]; !ok {
+		t.Error("state 'a' should exist")
+	}
+	if _, ok := states["b"]; !ok {
+		t.Error("state 'b' should exist")
+	}
+}
+
+func TestHandler_ConfigDefaults(t *testing.T) {
+	cfg := Config{}
+	h := NewHandler(cfg, nil, nil)
+
+	if h.cfg.MaxRetries != DefaultConfig().MaxRetries {
+		t.Errorf("expected default max retries, got %d", h.cfg.MaxRetries)
+	}
+	if h.cfg.RetryDelay != DefaultConfig().RetryDelay {
+		t.Errorf("expected default retry delay, got %v", h.cfg.RetryDelay)
+	}
+	if h.cfg.NotifyTimeout != DefaultConfig().NotifyTimeout {
+		t.Errorf("expected default notify timeout, got %v", h.cfg.NotifyTimeout)
+	}
+	if h.cfg.PMAgent != DefaultConfig().PMAgent {
+		t.Errorf("expected default PM agent, got %s", h.cfg.PMAgent)
+	}
+	if h.cfg.OwnerChannel != DefaultConfig().OwnerChannel {
+		t.Errorf("expected default owner channel, got %s", h.cfg.OwnerChannel)
+	}
+}
+
+func TestHandler_NilRestartFn(t *testing.T) {
+	h := NewHandler(DefaultConfig(), nil, nil)
+
+	ctx := context.Background()
+	result := h.HandleUnresponsive(ctx, "worker1", 1)
+
+	if result {
+		t.Error("should return false when restart fn is nil")
+	}
+}
+
+func TestHandler_ContextCancellation(t *testing.T) {
+	restartFn := func(ctx context.Context, name string) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+			return nil
+		}
+	}
+
+	cfg := Config{
+		MaxRetries:    3,
+		RetryDelay:    100 * time.Millisecond,
+		NotifyTimeout: 100 * time.Millisecond,
+	}
+	h := NewHandler(cfg, restartFn, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	result := h.HandleUnresponsive(ctx, "worker1", 1)
+
+	if result {
+		t.Error("should return false when context is cancelled")
+	}
+}


### PR DESCRIPTION
## Summary
- ハートビート監視機能（`internal/heartbeat/monitor.go`）を追加
- 復旧ハンドラ（`internal/recovery/handler.go`）を追加
- PM通知失敗時にオーナーへフォールバック通知
- config.yamlにheartbeat設定を追加

## 設定例
```yaml
heartbeat:
  interval: 10s      # 監視間隔
  timeout: 30s       # 応答タイムアウト
  max_retries: 3     # リスタート試行回数
```

## Test plan
- [x] heartbeat/monitor_test.go: 16パターン
- [x] recovery/handler_test.go: 12パターン
- [x] 全テスト通過

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)