### PR TITLE
feat: add maxam init command for one-shot project setup

### DIFF
--- a/cmd/maxam/init.go
+++ b/cmd/maxam/init.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ytnobody/MAXAM/internal/config"
+)
+
+func runInit() {
+	workDir := getWorkDir()
+
+	// Check if already initialized
+	if config.IsProjectInitialized(workDir) {
+		fmt.Println("Project already initialized. Skipping.")
+		fmt.Printf("  Config: %s/config.yaml\n", config.ProjectConfigDir(workDir))
+		fmt.Printf("  CLAUDE.md: %s/CLAUDE.md\n", config.ProjectConfigDir(workDir))
+		return
+	}
+
+	fmt.Println("Initializing MAXAM project...")
+
+	// 1. Create .maxam/ directory and default files
+	if err := config.EnsureProjectInitialized(workDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// 2. Load default team from ~/.maxam/default-team.yaml if exists
+	defaultTeam, err := loadDefaultTeam()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not load default team: %v\n", err)
+	}
+
+	if defaultTeam != nil && len(defaultTeam.Agents) > 0 {
+		// Load project config and add agents
+		projectCfg, err := config.LoadProjectConfig(workDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading project config: %v\n", err)
+			os.Exit(1)
+		}
+
+		projectCfg.Agents = defaultTeam.Agents
+		if defaultTeam.TeamName != "" {
+			projectCfg.TeamName = defaultTeam.TeamName
+		}
+
+		if err := config.SaveToProject(workDir, projectCfg); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving project config: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Loaded default team (%d agents)\n", len(defaultTeam.Agents))
+	}
+
+	fmt.Println("Done!")
+	fmt.Println()
+	fmt.Printf("Created:\n")
+	fmt.Printf("  %s/config.yaml\n", config.ProjectConfigDir(workDir))
+	fmt.Printf("  %s/CLAUDE.md\n", config.ProjectConfigDir(workDir))
+	fmt.Println()
+	fmt.Println("Next steps:")
+	if defaultTeam == nil || len(defaultTeam.Agents) == 0 {
+		fmt.Println("  1. Run 'maxam team init' to set up team members")
+		fmt.Println("  2. Or edit .maxam/config.yaml directly")
+	} else {
+		fmt.Println("  Team is ready! Run 'maxam' to start.")
+	}
+}
+
+// loadDefaultTeam loads team configuration from ~/.maxam/default-team.yaml
+func loadDefaultTeam() (*config.Config, error) {
+	configDir, err := config.ConfigDir()
+	if err != nil {
+		return nil, err
+	}
+
+	defaultTeamPath := filepath.Join(configDir, "default-team.yaml")
+	return config.LoadFromPath(defaultTeamPath)
+}

--- a/cmd/maxam/init_test.go
+++ b/cmd/maxam/init_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ytnobody/MAXAM/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+func TestLoadDefaultTeam(t *testing.T) {
+	// Create temp home directory
+	tempHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempHome)
+	defer os.Setenv("HOME", originalHome)
+
+	// Create ~/.maxam directory
+	maxamDir := filepath.Join(tempHome, ".maxam")
+	if err := os.MkdirAll(maxamDir, 0755); err != nil {
+		t.Fatalf("failed to create .maxam dir: %v", err)
+	}
+
+	t.Run("no default-team.yaml", func(t *testing.T) {
+		cfg, err := loadDefaultTeam()
+		if err == nil {
+			t.Error("expected error when no default-team.yaml exists")
+		}
+		if cfg != nil {
+			t.Error("expected nil config when file doesn't exist")
+		}
+	})
+
+	t.Run("with default-team.yaml", func(t *testing.T) {
+		// Create default-team.yaml
+		defaultTeam := &config.Config{
+			Version:  "1",
+			TeamName: "Test Team",
+			Agents: []config.AgentConfig{
+				{Name: "alice", FullName: "Alice Smith", Role: "Developer"},
+				{Name: "bob", FullName: "Bob Jones", Role: "Reviewer"},
+			},
+		}
+
+		data, err := yaml.Marshal(defaultTeam)
+		if err != nil {
+			t.Fatalf("failed to marshal config: %v", err)
+		}
+
+		if err := os.WriteFile(filepath.Join(maxamDir, "default-team.yaml"), data, 0644); err != nil {
+			t.Fatalf("failed to write default-team.yaml: %v", err)
+		}
+
+		cfg, err := loadDefaultTeam()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cfg.TeamName != "Test Team" {
+			t.Errorf("expected team name 'Test Team', got '%s'", cfg.TeamName)
+		}
+
+		if len(cfg.Agents) != 2 {
+			t.Errorf("expected 2 agents, got %d", len(cfg.Agents))
+		}
+
+		if cfg.Agents[0].Name != "alice" {
+			t.Errorf("expected first agent 'alice', got '%s'", cfg.Agents[0].Name)
+		}
+	})
+}
+
+func TestInitProjectCreation(t *testing.T) {
+	// Create temp directories
+	tempHome := t.TempDir()
+	tempProject := t.TempDir()
+
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempHome)
+	defer os.Setenv("HOME", originalHome)
+
+	// Create ~/.maxam directory
+	maxamDir := filepath.Join(tempHome, ".maxam")
+	if err := os.MkdirAll(maxamDir, 0755); err != nil {
+		t.Fatalf("failed to create .maxam dir: %v", err)
+	}
+
+	t.Run("init creates .maxam directory", func(t *testing.T) {
+		// Ensure project is not initialized
+		if config.IsProjectInitialized(tempProject) {
+			t.Error("project should not be initialized")
+		}
+
+		// Initialize
+		if err := config.EnsureProjectInitialized(tempProject); err != nil {
+			t.Fatalf("failed to initialize project: %v", err)
+		}
+
+		// Check files created
+		configPath := filepath.Join(tempProject, ".maxam", "config.yaml")
+		if _, err := os.Stat(configPath); os.IsNotExist(err) {
+			t.Error("config.yaml not created")
+		}
+
+		claudeMDPath := filepath.Join(tempProject, ".maxam", "CLAUDE.md")
+		if _, err := os.Stat(claudeMDPath); os.IsNotExist(err) {
+			t.Error("CLAUDE.md not created")
+		}
+
+		// Check IsProjectInitialized returns true
+		if !config.IsProjectInitialized(tempProject) {
+			t.Error("project should be initialized")
+		}
+	})
+
+	t.Run("init with default team loads agents", func(t *testing.T) {
+		tempProject2 := t.TempDir()
+
+		// Create default-team.yaml
+		defaultTeam := &config.Config{
+			Version:  "1",
+			TeamName: "Default Team",
+			Agents: []config.AgentConfig{
+				{Name: "mei", FullName: "Mei Chen", Role: "PM"},
+				{Name: "yuki", FullName: "Yuki Tanaka", Role: "Backend"},
+			},
+		}
+
+		data, err := yaml.Marshal(defaultTeam)
+		if err != nil {
+			t.Fatalf("failed to marshal config: %v", err)
+		}
+
+		if err := os.WriteFile(filepath.Join(maxamDir, "default-team.yaml"), data, 0644); err != nil {
+			t.Fatalf("failed to write default-team.yaml: %v", err)
+		}
+
+		// Initialize project
+		if err := config.EnsureProjectInitialized(tempProject2); err != nil {
+			t.Fatalf("failed to initialize project: %v", err)
+		}
+
+		// Load default team and apply
+		team, err := loadDefaultTeam()
+		if err != nil {
+			t.Fatalf("failed to load default team: %v", err)
+		}
+
+		projectCfg, err := config.LoadProjectConfig(tempProject2)
+		if err != nil {
+			t.Fatalf("failed to load project config: %v", err)
+		}
+
+		projectCfg.Agents = team.Agents
+		projectCfg.TeamName = team.TeamName
+
+		if err := config.SaveToProject(tempProject2, projectCfg); err != nil {
+			t.Fatalf("failed to save project config: %v", err)
+		}
+
+		// Verify agents are saved
+		savedCfg, err := config.LoadProjectConfig(tempProject2)
+		if err != nil {
+			t.Fatalf("failed to load saved config: %v", err)
+		}
+
+		if len(savedCfg.Agents) != 2 {
+			t.Errorf("expected 2 agents, got %d", len(savedCfg.Agents))
+		}
+
+		if savedCfg.TeamName != "Default Team" {
+			t.Errorf("expected team name 'Default Team', got '%s'", savedCfg.TeamName)
+		}
+	})
+}
+
+func TestInitIdempotent(t *testing.T) {
+	tempProject := t.TempDir()
+
+	// First init
+	if err := config.EnsureProjectInitialized(tempProject); err != nil {
+		t.Fatalf("first init failed: %v", err)
+	}
+
+	// Modify config
+	cfg, err := config.LoadProjectConfig(tempProject)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	cfg.TeamName = "Modified Team"
+	if err := config.SaveToProject(tempProject, cfg); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	// Second init should not overwrite
+	if err := config.EnsureProjectInitialized(tempProject); err != nil {
+		t.Fatalf("second init failed: %v", err)
+	}
+
+	// Verify modification preserved
+	cfg2, err := config.LoadProjectConfig(tempProject)
+	if err != nil {
+		t.Fatalf("failed to load config after second init: %v", err)
+	}
+
+	if cfg2.TeamName != "Modified Team" {
+		t.Errorf("expected team name 'Modified Team', got '%s'", cfg2.TeamName)
+	}
+}

--- a/cmd/maxam/main.go
+++ b/cmd/maxam/main.go
@@ -30,6 +30,8 @@ func main() {
 	cmd := os.Args[1]
 
 	switch cmd {
+	case "init":
+		runInit()
 	case "task":
 		runTaskLegacy()
 	case "team":
@@ -63,6 +65,7 @@ Usage:
   maxam <command> [arguments]
 
 Commands:
+  init                 Initialize MAXAM in current project
   (none)               Launch team chat TUI (default)
   chat <agent>         Interactive chat with an agent (mei/yuki/rin/shiori/priya/amara/team)
   chat team --daemon   Daemon mode: wait for input continuously (for external integration)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -466,6 +466,21 @@ func (c *Config) GetLogLevel() string {
 	return c.LogLevel
 }
 
+// LoadFromPath loads configuration from a specific file path
+func LoadFromPath(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
 // DefaultHeartbeatInterval is the default heartbeat monitoring interval
 const DefaultHeartbeatInterval = "10s"
 


### PR DESCRIPTION
## Summary

- `maxam init` コマンドで新規プロジェクトの初期セットアップを一発で完了
- `~/.maxam/default-team.yaml` からデフォルトチーム設定をロード
- 既存の `.maxam/` がある場合はスキップ（上書きしない）

## 動作確認

```bash
# 新規プロジェクトで
maxam init
# -> .maxam/config.yaml と .maxam/CLAUDE.md が作成される

# デフォルトチームを使う場合
# ~/.maxam/default-team.yaml にチーム設定を記載しておく
```

## Test plan

- [x] `go test ./cmd/maxam/... -run TestInit`
- [x] `go test ./cmd/maxam/... -run TestLoadDefaultTeam`
- [x] `go test ./...`

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)