### PR TITLE
feat: auto mode stops when no open issues remain

### DIFF
--- a/internal/auto/runner.go
+++ b/internal/auto/runner.go
@@ -42,6 +42,13 @@ type TaskExecutor interface {
 	Execute(ctx context.Context, issueNumber int, title string) (prNumber int, err error)
 }
 
+// IssueChecker is the interface for checking open issues
+// Used to determine if auto mode should stop when no open issues remain
+type IssueChecker interface {
+	// CountOpenIssues returns the number of open issues
+	CountOpenIssues(ctx context.Context) (int, error)
+}
+
 // RunnerState represents the state of the runner
 type RunnerState string
 
@@ -60,14 +67,16 @@ const (
 type Runner struct {
 	mu sync.RWMutex
 
-	executor TaskExecutor
-	tasks    []*Task
-	state    RunnerState
+	executor     TaskExecutor
+	issueChecker IssueChecker
+	tasks        []*Task
+	state        RunnerState
 
 	// callbacks
 	onTaskStart    func(task *Task)
 	onTaskComplete func(task *Task)
 	onAllComplete  func(tasks []*Task)
+	onNoOpenIssues func() // Called when auto mode stops due to no open issues
 
 	// config
 	logger *log.Logger
@@ -117,6 +126,20 @@ func (r *Runner) SetOnAllComplete(fn func(tasks []*Task)) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.onAllComplete = fn
+}
+
+// SetOnNoOpenIssues sets the callback for when auto mode stops due to no open issues
+func (r *Runner) SetOnNoOpenIssues(fn func()) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.onNoOpenIssues = fn
+}
+
+// SetIssueChecker sets the issue checker for auto-stop functionality
+func (r *Runner) SetIssueChecker(checker IssueChecker) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.issueChecker = checker
 }
 
 // AddTask adds a task to be executed
@@ -245,7 +268,14 @@ func (r *Runner) Run(ctx context.Context) error {
 			break
 		}
 
-		r.executeTask(ctx, task)
+		shouldStop := r.executeTask(ctx, task)
+		if shouldStop {
+			// No open issues remaining, stop auto mode
+			r.mu.Lock()
+			r.state = RunnerStateCompleted
+			r.mu.Unlock()
+			break
+		}
 	}
 
 	// Call completion callback
@@ -279,7 +309,8 @@ func (r *Runner) nextPendingTask() *Task {
 }
 
 // executeTask executes a single task
-func (r *Runner) executeTask(ctx context.Context, task *Task) {
+// Returns true if auto mode should stop (no open issues remaining)
+func (r *Runner) executeTask(ctx context.Context, task *Task) bool {
 	// Mark as running
 	r.mu.Lock()
 	task.State = TaskStateRunning
@@ -309,11 +340,32 @@ func (r *Runner) executeTask(ctx context.Context, task *Task) {
 		r.logger.Printf("[auto] Task completed: #%d -> PR #%d", task.IssueNumber, prNumber)
 	}
 	onTaskComplete := r.onTaskComplete
+	issueChecker := r.issueChecker
+	onNoOpenIssues := r.onNoOpenIssues
 	r.mu.Unlock()
 
 	if onTaskComplete != nil {
 		onTaskComplete(task)
 	}
+
+	// Check if there are no open issues remaining
+	if task.State == TaskStateCompleted && issueChecker != nil {
+		checkCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		count, err := issueChecker.CountOpenIssues(checkCtx)
+		if err != nil {
+			r.logger.Printf("[auto] Failed to check open issues: %v", err)
+		} else if count == 0 {
+			r.logger.Printf("[auto] No open issues remaining. Stopping auto mode.")
+			if onNoOpenIssues != nil {
+				onNoOpenIssues()
+			}
+			return true // Signal to stop
+		}
+	}
+
+	return false
 }
 
 // Stop stops the runner

--- a/internal/auto/runner_test.go
+++ b/internal/auto/runner_test.go
@@ -322,3 +322,200 @@ func TestStubExecutor_WithFailure(t *testing.T) {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }
+
+// StubIssueChecker is a test implementation of IssueChecker
+type StubIssueChecker struct {
+	OpenCount int
+	Err       error
+}
+
+func (s *StubIssueChecker) CountOpenIssues(ctx context.Context) (int, error) {
+	return s.OpenCount, s.Err
+}
+
+func TestRunner_AutoStopWhenNoOpenIssues(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	executor := NewStubExecutor()
+	executor.SimulatedDuration = 10 * time.Millisecond
+	executor.NextPRNumber = 100
+	executor.Logger = logger
+
+	issueChecker := &StubIssueChecker{OpenCount: 0} // No open issues
+
+	runner := NewRunner(executor, Config{Logger: logger})
+	runner.SetIssueChecker(issueChecker)
+
+	var noOpenIssuesCalled bool
+	runner.SetOnNoOpenIssues(func() {
+		noOpenIssuesCalled = true
+	})
+
+	runner.AddTask(1, "Task 1")
+	runner.AddTask(2, "Task 2")
+
+	ctx := context.Background()
+	err := runner.Run(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only first task should be completed because auto mode stopped
+	if runner.CompletedCount() != 1 {
+		t.Errorf("expected 1 completed (auto stopped after first), got %d", runner.CompletedCount())
+	}
+
+	if runner.PendingCount() != 1 {
+		t.Errorf("expected 1 pending, got %d", runner.PendingCount())
+	}
+
+	if !noOpenIssuesCalled {
+		t.Error("expected onNoOpenIssues callback to be called")
+	}
+
+	if runner.State() != RunnerStateCompleted {
+		t.Errorf("expected completed state, got %s", runner.State())
+	}
+
+	// Check log message
+	if !strings.Contains(buf.String(), "No open issues remaining") {
+		t.Errorf("expected log message about no open issues: %s", buf.String())
+	}
+}
+
+func TestRunner_ContinuesWithOpenIssues(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	executor := NewStubExecutor()
+	executor.SimulatedDuration = 10 * time.Millisecond
+	executor.NextPRNumber = 100
+
+	issueChecker := &StubIssueChecker{OpenCount: 5} // Still has open issues
+
+	runner := NewRunner(executor, Config{Logger: logger})
+	runner.SetIssueChecker(issueChecker)
+
+	var noOpenIssuesCalled bool
+	runner.SetOnNoOpenIssues(func() {
+		noOpenIssuesCalled = true
+	})
+
+	runner.AddTask(1, "Task 1")
+	runner.AddTask(2, "Task 2")
+
+	ctx := context.Background()
+	err := runner.Run(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both tasks should be completed
+	if runner.CompletedCount() != 2 {
+		t.Errorf("expected 2 completed, got %d", runner.CompletedCount())
+	}
+
+	if noOpenIssuesCalled {
+		t.Error("onNoOpenIssues should not be called when issues remain")
+	}
+}
+
+func TestRunner_IssueCheckerError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	executor := NewStubExecutor()
+	executor.SimulatedDuration = 10 * time.Millisecond
+	executor.NextPRNumber = 100
+
+	issueChecker := &StubIssueChecker{Err: errors.New("API error")}
+
+	runner := NewRunner(executor, Config{Logger: logger})
+	runner.SetIssueChecker(issueChecker)
+
+	runner.AddTask(1, "Task 1")
+	runner.AddTask(2, "Task 2")
+
+	ctx := context.Background()
+	err := runner.Run(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should continue even if issue check fails
+	if runner.CompletedCount() != 2 {
+		t.Errorf("expected 2 completed, got %d", runner.CompletedCount())
+	}
+
+	// Check log message about error
+	if !strings.Contains(buf.String(), "Failed to check open issues") {
+		t.Errorf("expected log message about check failure: %s", buf.String())
+	}
+}
+
+func TestRunner_NoIssueCheckerSet(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	executor := NewStubExecutor()
+	executor.SimulatedDuration = 10 * time.Millisecond
+	executor.NextPRNumber = 100
+
+	// No issue checker set - should behave normally
+	runner := NewRunner(executor, Config{Logger: logger})
+
+	runner.AddTask(1, "Task 1")
+	runner.AddTask(2, "Task 2")
+
+	ctx := context.Background()
+	err := runner.Run(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both tasks should be completed
+	if runner.CompletedCount() != 2 {
+		t.Errorf("expected 2 completed, got %d", runner.CompletedCount())
+	}
+}
+
+func TestRunner_FailedTaskDoesNotTriggerCheck(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	executor := NewStubExecutor()
+	executor.SimulatedDuration = 10 * time.Millisecond
+	executor.SetFailure(1, errors.New("task failed"))
+
+	issueChecker := &StubIssueChecker{OpenCount: 0}
+
+	runner := NewRunner(executor, Config{Logger: logger})
+	runner.SetIssueChecker(issueChecker)
+
+	var noOpenIssuesCalled bool
+	runner.SetOnNoOpenIssues(func() {
+		noOpenIssuesCalled = true
+	})
+
+	runner.AddTask(1, "Task 1 (will fail)")
+	runner.AddTask(2, "Task 2")
+
+	ctx := context.Background()
+	err := runner.Run(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// First task failed, second task completed and triggered stop
+	if runner.FailedCount() != 1 {
+		t.Errorf("expected 1 failed, got %d", runner.FailedCount())
+	}
+	if runner.CompletedCount() != 1 {
+		t.Errorf("expected 1 completed, got %d", runner.CompletedCount())
+	}
+
+	if !noOpenIssuesCalled {
+		t.Error("expected onNoOpenIssues to be called after second task completed")
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -158,6 +158,16 @@ func (c *Client) CloseIssue(ctx context.Context, number int) error {
 	return nil
 }
 
+// CountOpenIssues returns the number of open issues
+// Implements the auto.IssueChecker interface
+func (c *Client) CountOpenIssues(ctx context.Context) (int, error) {
+	issues, err := c.ListIssues(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	return len(issues), nil
+}
+
 // EditIssue updates an issue's title and/or body
 func (c *Client) EditIssue(ctx context.Context, number int, title, body *string) (*github.Issue, error) {
 	req := &github.IssueRequest{}


### PR DESCRIPTION
## Summary
- autoモードでタスク完了後にOpen Issue数をチェック
- 0件になったらautoモードを自動停止
- `IssueChecker`インターフェースで抽象化し、テスト容易に

## Test plan
- [ ] `go test ./internal/auto/...` - 新規テスト6件含む全テストパス
- [ ] `go test ./internal/github/...` - client.goの変更確認
- [ ] autoモード起動 → Issue対応 → 全Issue完了で停止確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)