### PR TITLE
feat: add milestone branch auto-creation on /plan command

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ytnobody/MAXAM/internal/agent/control"
 	"github.com/ytnobody/MAXAM/internal/agent/worker"
 	"github.com/ytnobody/MAXAM/internal/approval"
+	"github.com/ytnobody/MAXAM/internal/branch"
 	"github.com/ytnobody/MAXAM/internal/ccusage"
 	"github.com/ytnobody/MAXAM/internal/config"
 	"github.com/ytnobody/MAXAM/internal/contextmon"
@@ -500,9 +501,12 @@ type ccusageTickMsg struct{}
 
 // planWorkflowMsg is sent when plan workflow completes or fails
 type planWorkflowMsg struct {
-	issueNumber int
-	issueURL    string
-	err         error
+	issueNumber   int
+	issueURL      string
+	branchName    string // milestone branch name if created
+	branchCreated bool   // true if branch was newly created
+	milestoneName string // human-readable milestone name
+	err           error
 }
 
 // planApprovalTickMsg is sent periodically to check for plan approval
@@ -958,10 +962,24 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// Plan issue created successfully
+		// Build success message with branch info
+		var statusMsg strings.Builder
+		statusMsg.WriteString(fmt.Sprintf("✅ 議論用Issueを作成しました: %s\n", msg.issueURL))
+
+		// Add branch creation status
+		if msg.branchName != "" {
+			if msg.branchCreated {
+				statusMsg.WriteString(fmt.Sprintf("🌿 マイルストーンブランチを作成しました: `%s`\n", msg.branchName))
+			} else {
+				statusMsg.WriteString(fmt.Sprintf("🌿 既存のマイルストーンブランチを使用: `%s`\n", msg.branchName))
+			}
+		}
+
+		statusMsg.WriteString("承認待ち中... (IssueにOK/LGTMとコメントしてください)")
+
 		m.messages = append(m.messages, tuiMessage{
 			role:    "system",
-			content: fmt.Sprintf("✅ 議論用Issueを作成しました: %s\n承認待ち中... (IssueにOK/LGTMとコメントしてください)", msg.issueURL),
+			content: statusMsg.String(),
 		})
 		m.updateViewport()
 
@@ -2147,7 +2165,7 @@ func (m *tuiModel) handleModeCommand(result mode.ParseResult) (tea.Model, tea.Cm
 }
 
 // startPlanWorkflow starts the plan workflow asynchronously
-// Analyzes project → Creates plan issue → Starts approval polling
+// Analyzes project → Creates milestone branch → Creates plan issue → Starts approval polling
 func (m *tuiModel) startPlanWorkflow() tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -2159,20 +2177,56 @@ func (m *tuiModel) startPlanWorkflow() tea.Cmd {
 			return planWorkflowMsg{err: fmt.Errorf("プロジェクト分析に失敗: %w", err)}
 		}
 
-		// Step 2: Generate proposal based on analysis
-		proposal := m.generatePlanProposal(analysis)
+		// Step 2: Generate milestone name and create branch
+		milestoneName := m.generateMilestoneName(analysis)
+		branchName, branchCreated, branchErr := branch.CreateMilestoneBranch(m.workDir, milestoneName)
+		// Branch creation is best-effort; don't fail the workflow if it fails
+		if branchErr != nil {
+			// Log the error but continue
+			branchName = ""
+			branchCreated = false
+		}
 
-		// Step 3: Create plan issue
+		// Step 3: Generate proposal based on analysis (include branch info)
+		proposal := m.generatePlanProposal(analysis)
+		if branchCreated && branchName != "" {
+			proposal += fmt.Sprintf("\n\n### マイルストーンブランチ\n- `%s` を作成しました\n", branchName)
+		} else if branchName != "" {
+			proposal += fmt.Sprintf("\n\n### マイルストーンブランチ\n- `%s` が既に存在します\n", branchName)
+		}
+
+		// Step 4: Create plan issue
 		planIssue, err := m.planExecutor.CreatePlanIssue(ctx, analysis, proposal)
 		if err != nil {
 			return planWorkflowMsg{err: fmt.Errorf("Issue作成に失敗: %w", err)}
 		}
 
 		return planWorkflowMsg{
-			issueNumber: planIssue.IssueNumber,
-			issueURL:    planIssue.URL,
+			issueNumber:   planIssue.IssueNumber,
+			issueURL:      planIssue.URL,
+			branchName:    branchName,
+			branchCreated: branchCreated,
+			milestoneName: milestoneName,
 		}
 	}
+}
+
+// generateMilestoneName generates a milestone name based on project analysis
+// Uses the oldest open issue or current date as the milestone identifier
+func (m *tuiModel) generateMilestoneName(analysis *mode.ProjectAnalysis) string {
+	// If there's a priority issue, use its info
+	if analysis.OldestOpenIssue != nil {
+		// Use format like "issue-123-fix-bug"
+		title := analysis.OldestOpenIssue.Title
+		// Truncate long titles
+		if len(title) > 30 {
+			title = title[:30]
+		}
+		return fmt.Sprintf("issue-%d-%s", analysis.OldestOpenIssue.Number, title)
+	}
+
+	// Fallback to date-based milestone
+	return time.Now().Format("2006-01-02")
 }
 
 // generatePlanProposal generates a plan proposal based on project analysis

--- a/internal/branch/branch.go
+++ b/internal/branch/branch.go
@@ -1,0 +1,165 @@
+// Package branch provides git branch management utilities
+package branch
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// SanitizeBranchName converts a milestone name to a valid git branch name
+// Rules:
+// - Spaces → hyphens
+// - Special characters (except / and -) → removed or converted to hyphens
+// - Consecutive hyphens → single hyphen
+// - Leading/trailing hyphens → removed
+// - Lowercase conversion
+func SanitizeBranchName(name string) string {
+	// Convert to lowercase
+	result := strings.ToLower(name)
+
+	// Replace spaces with hyphens
+	result = strings.ReplaceAll(result, " ", "-")
+
+	// Replace underscores with hyphens
+	result = strings.ReplaceAll(result, "_", "-")
+
+	// Remove or replace special characters (keep alphanumeric, /, -, .)
+	// Git branch names can contain / for hierarchy but not at start/end
+	re := regexp.MustCompile(`[^a-z0-9/.\-]`)
+	result = re.ReplaceAllString(result, "-")
+
+	// Collapse consecutive hyphens
+	re = regexp.MustCompile(`-+`)
+	result = re.ReplaceAllString(result, "-")
+
+	// Remove leading/trailing hyphens and dots
+	result = strings.Trim(result, "-.")
+
+	// Remove consecutive slashes
+	re = regexp.MustCompile(`/+`)
+	result = re.ReplaceAllString(result, "/")
+
+	// Remove leading/trailing slashes
+	result = strings.Trim(result, "/")
+
+	return result
+}
+
+// MilestoneBranchName creates a branch name for a milestone
+// Format: milestone/{sanitized-name}
+func MilestoneBranchName(milestoneName string) string {
+	sanitized := SanitizeBranchName(milestoneName)
+	if sanitized == "" {
+		return "milestone/default"
+	}
+	return "milestone/" + sanitized
+}
+
+// BranchExists checks if a branch exists in the repository
+func BranchExists(repoPath, branchName string) (bool, error) {
+	cmd := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+branchName)
+	cmd.Dir = repoPath
+	err := cmd.Run()
+	if err != nil {
+		// Exit code 1 means branch doesn't exist
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, fmt.Errorf("check branch exists: %w", err)
+	}
+	return true, nil
+}
+
+// CreateBranch creates a new branch from the current HEAD
+func CreateBranch(repoPath, branchName string) error {
+	cmd := exec.Command("git", "branch", branchName)
+	cmd.Dir = repoPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("create branch %q: %s: %w", branchName, strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+// CreateBranchFromBase creates a new branch from a specified base branch
+func CreateBranchFromBase(repoPath, branchName, baseBranch string) error {
+	cmd := exec.Command("git", "branch", branchName, baseBranch)
+	cmd.Dir = repoPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("create branch %q from %q: %s: %w", branchName, baseBranch, strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+// CreateMilestoneBranch creates a milestone branch if it doesn't exist
+// Returns (branchName, created, error)
+// - branchName: the actual branch name created
+// - created: true if branch was newly created, false if already existed
+func CreateMilestoneBranch(repoPath, milestoneName string) (string, bool, error) {
+	branchName := MilestoneBranchName(milestoneName)
+
+	// Check if branch already exists
+	exists, err := BranchExists(repoPath, branchName)
+	if err != nil {
+		return "", false, fmt.Errorf("check existing branch: %w", err)
+	}
+
+	if exists {
+		return branchName, false, nil
+	}
+
+	// Create new branch
+	if err := CreateBranch(repoPath, branchName); err != nil {
+		return "", false, err
+	}
+
+	return branchName, true, nil
+}
+
+// CreateMilestoneBranchFromBase creates a milestone branch from a specified base
+// Returns (branchName, created, error)
+func CreateMilestoneBranchFromBase(repoPath, milestoneName, baseBranch string) (string, bool, error) {
+	branchName := MilestoneBranchName(milestoneName)
+
+	// Check if branch already exists
+	exists, err := BranchExists(repoPath, branchName)
+	if err != nil {
+		return "", false, fmt.Errorf("check existing branch: %w", err)
+	}
+
+	if exists {
+		return branchName, false, nil
+	}
+
+	// Create new branch from base
+	if err := CreateBranchFromBase(repoPath, branchName, baseBranch); err != nil {
+		return "", false, err
+	}
+
+	return branchName, true, nil
+}
+
+// CheckoutBranch switches to the specified branch
+func CheckoutBranch(repoPath, branchName string) error {
+	cmd := exec.Command("git", "checkout", branchName)
+	cmd.Dir = repoPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("checkout branch %q: %s: %w", branchName, strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+// GetCurrentBranch returns the current branch name
+func GetCurrentBranch(repoPath string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = repoPath
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("get current branch: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/internal/branch/branch_test.go
+++ b/internal/branch/branch_test.go
@@ -1,0 +1,444 @@
+package branch
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestSanitizeBranchName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple name",
+			input:    "feature",
+			expected: "feature",
+		},
+		{
+			name:     "spaces to hyphens",
+			input:    "my feature",
+			expected: "my-feature",
+		},
+		{
+			name:     "uppercase to lowercase",
+			input:    "MyFeature",
+			expected: "myfeature",
+		},
+		{
+			name:     "underscores to hyphens",
+			input:    "my_feature",
+			expected: "my-feature",
+		},
+		{
+			name:     "special characters removed",
+			input:    "feature!@#$%test",
+			expected: "feature-test",
+		},
+		{
+			name:     "consecutive hyphens collapsed",
+			input:    "feature---test",
+			expected: "feature-test",
+		},
+		{
+			name:     "leading trailing hyphens removed",
+			input:    "-feature-",
+			expected: "feature",
+		},
+		{
+			name:     "slashes preserved for hierarchy",
+			input:    "feature/sub",
+			expected: "feature/sub",
+		},
+		{
+			name:     "dots preserved",
+			input:    "v1.0.0",
+			expected: "v1.0.0",
+		},
+		{
+			name:     "complex milestone name",
+			input:    "Sprint 2024-Q1: UI Improvements",
+			expected: "sprint-2024-q1-ui-improvements",
+		},
+		{
+			name:     "Japanese characters removed",
+			input:    "機能追加",
+			expected: "",
+		},
+		{
+			name:     "mixed Japanese and English",
+			input:    "feature-機能",
+			expected: "feature",
+		},
+		{
+			name:     "consecutive slashes collapsed",
+			input:    "feature//sub",
+			expected: "feature/sub",
+		},
+		{
+			name:     "leading trailing slashes removed",
+			input:    "/feature/",
+			expected: "feature",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only special characters",
+			input:    "!@#$%",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeBranchName(tt.input)
+			if result != tt.expected {
+				t.Errorf("SanitizeBranchName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMilestoneBranchName(t *testing.T) {
+	tests := []struct {
+		name          string
+		milestoneName string
+		expected      string
+	}{
+		{
+			name:          "simple milestone",
+			milestoneName: "v1.0",
+			expected:      "milestone/v1.0",
+		},
+		{
+			name:          "milestone with spaces",
+			milestoneName: "Sprint 1",
+			expected:      "milestone/sprint-1",
+		},
+		{
+			name:          "empty milestone defaults",
+			milestoneName: "",
+			expected:      "milestone/default",
+		},
+		{
+			name:          "only special chars defaults",
+			milestoneName: "!!!",
+			expected:      "milestone/default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MilestoneBranchName(tt.milestoneName)
+			if result != tt.expected {
+				t.Errorf("MilestoneBranchName(%q) = %q, want %q", tt.milestoneName, result, tt.expected)
+			}
+		})
+	}
+}
+
+// setupTestRepo creates a temporary git repository for testing
+func setupTestRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	// Initialize git repo
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git init failed: %v", err)
+	}
+
+	// Configure git user (required for commits)
+	cmd = exec.Command("git", "config", "user.email", "test@test.com")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git config email failed: %v", err)
+	}
+
+	cmd = exec.Command("git", "config", "user.name", "Test User")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git config name failed: %v", err)
+	}
+
+	// Create initial commit
+	dummyFile := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(dummyFile, []byte("# Test\n"), 0644); err != nil {
+		t.Fatalf("write dummy file failed: %v", err)
+	}
+
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git add failed: %v", err)
+	}
+
+	cmd = exec.Command("git", "commit", "-m", "Initial commit")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git commit failed: %v", err)
+	}
+
+	return dir
+}
+
+func TestBranchExists(t *testing.T) {
+	// Skip if git is not available
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repoPath := setupTestRepo(t)
+
+	tests := []struct {
+		name       string
+		branchName string
+		setup      func()
+		expected   bool
+	}{
+		{
+			name:       "existing default branch",
+			branchName: "master",
+			setup:      func() {},
+			expected:   true,
+		},
+		{
+			name:       "non-existing branch",
+			branchName: "feature/nonexistent",
+			setup:      func() {},
+			expected:   false,
+		},
+		{
+			name:       "created branch exists",
+			branchName: "feature/test",
+			setup: func() {
+				cmd := exec.Command("git", "branch", "feature/test")
+				cmd.Dir = repoPath
+				_ = cmd.Run()
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			exists, err := BranchExists(repoPath, tt.branchName)
+			if err != nil {
+				t.Fatalf("BranchExists() error = %v", err)
+			}
+			if exists != tt.expected {
+				t.Errorf("BranchExists(%q) = %v, want %v", tt.branchName, exists, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCreateBranch(t *testing.T) {
+	// Skip if git is not available
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repoPath := setupTestRepo(t)
+
+	// Test creating a new branch
+	branchName := "feature/new-branch"
+	err := CreateBranch(repoPath, branchName)
+	if err != nil {
+		t.Fatalf("CreateBranch() error = %v", err)
+	}
+
+	// Verify branch exists
+	exists, err := BranchExists(repoPath, branchName)
+	if err != nil {
+		t.Fatalf("BranchExists() error = %v", err)
+	}
+	if !exists {
+		t.Error("Created branch should exist")
+	}
+
+	// Test creating duplicate branch (should fail)
+	err = CreateBranch(repoPath, branchName)
+	if err == nil {
+		t.Error("CreateBranch() should fail for duplicate branch")
+	}
+}
+
+func TestCreateMilestoneBranch(t *testing.T) {
+	// Skip if git is not available
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	t.Run("creates new milestone branch", func(t *testing.T) {
+		repoPath := setupTestRepo(t)
+
+		branchName, created, err := CreateMilestoneBranch(repoPath, "Sprint 1")
+		if err != nil {
+			t.Fatalf("CreateMilestoneBranch() error = %v", err)
+		}
+		if !created {
+			t.Error("Branch should be newly created")
+		}
+		if branchName != "milestone/sprint-1" {
+			t.Errorf("branchName = %q, want %q", branchName, "milestone/sprint-1")
+		}
+
+		// Verify branch exists
+		exists, _ := BranchExists(repoPath, branchName)
+		if !exists {
+			t.Error("Created milestone branch should exist")
+		}
+	})
+
+	t.Run("returns existing branch without creating", func(t *testing.T) {
+		repoPath := setupTestRepo(t)
+
+		// Create first time
+		branchName1, created1, err := CreateMilestoneBranch(repoPath, "v1.0")
+		if err != nil {
+			t.Fatalf("First CreateMilestoneBranch() error = %v", err)
+		}
+		if !created1 {
+			t.Error("First call should create branch")
+		}
+
+		// Try to create again
+		branchName2, created2, err := CreateMilestoneBranch(repoPath, "v1.0")
+		if err != nil {
+			t.Fatalf("Second CreateMilestoneBranch() error = %v", err)
+		}
+		if created2 {
+			t.Error("Second call should not create branch")
+		}
+		if branchName1 != branchName2 {
+			t.Errorf("Branch names should match: %q vs %q", branchName1, branchName2)
+		}
+	})
+}
+
+func TestCreateMilestoneBranchFromBase(t *testing.T) {
+	// Skip if git is not available
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repoPath := setupTestRepo(t)
+
+	// Create a base branch with a commit
+	cmd := exec.Command("git", "checkout", "-b", "develop")
+	cmd.Dir = repoPath
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("create develop branch failed: %v", err)
+	}
+
+	// Add a commit to develop
+	dummyFile := filepath.Join(repoPath, "develop.txt")
+	if err := os.WriteFile(dummyFile, []byte("develop content\n"), 0644); err != nil {
+		t.Fatalf("write dummy file failed: %v", err)
+	}
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = repoPath
+	_ = cmd.Run()
+	cmd = exec.Command("git", "commit", "-m", "Develop commit")
+	cmd.Dir = repoPath
+	_ = cmd.Run()
+
+	// Create milestone branch from develop
+	branchName, created, err := CreateMilestoneBranchFromBase(repoPath, "Feature Sprint", "develop")
+	if err != nil {
+		t.Fatalf("CreateMilestoneBranchFromBase() error = %v", err)
+	}
+	if !created {
+		t.Error("Branch should be newly created")
+	}
+	if branchName != "milestone/feature-sprint" {
+		t.Errorf("branchName = %q, want %q", branchName, "milestone/feature-sprint")
+	}
+
+	// Verify the new branch has the develop commit
+	cmd = exec.Command("git", "checkout", branchName)
+	cmd.Dir = repoPath
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("checkout milestone branch failed: %v", err)
+	}
+
+	// Check if develop.txt exists (inherited from develop)
+	if _, err := os.Stat(dummyFile); os.IsNotExist(err) {
+		t.Error("Milestone branch should have develop.txt from base branch")
+	}
+}
+
+func TestGetCurrentBranch(t *testing.T) {
+	// Skip if git is not available
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repoPath := setupTestRepo(t)
+
+	// Get current branch (should be master or main depending on git version)
+	branch, err := GetCurrentBranch(repoPath)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch() error = %v", err)
+	}
+	if branch != "master" && branch != "main" {
+		t.Errorf("GetCurrentBranch() = %q, want 'master' or 'main'", branch)
+	}
+
+	// Create and checkout a new branch
+	newBranch := "feature/test"
+	cmd := exec.Command("git", "checkout", "-b", newBranch)
+	cmd.Dir = repoPath
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("checkout new branch failed: %v", err)
+	}
+
+	branch, err = GetCurrentBranch(repoPath)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch() error = %v", err)
+	}
+	if branch != newBranch {
+		t.Errorf("GetCurrentBranch() = %q, want %q", branch, newBranch)
+	}
+}
+
+func TestCheckoutBranch(t *testing.T) {
+	// Skip if git is not available
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repoPath := setupTestRepo(t)
+
+	// Create a test branch
+	testBranch := "feature/checkout-test"
+	if err := CreateBranch(repoPath, testBranch); err != nil {
+		t.Fatalf("CreateBranch() error = %v", err)
+	}
+
+	// Checkout the new branch
+	if err := CheckoutBranch(repoPath, testBranch); err != nil {
+		t.Fatalf("CheckoutBranch() error = %v", err)
+	}
+
+	// Verify we're on the new branch
+	current, _ := GetCurrentBranch(repoPath)
+	if current != testBranch {
+		t.Errorf("Current branch = %q, want %q", current, testBranch)
+	}
+
+	// Try to checkout non-existent branch
+	if err := CheckoutBranch(repoPath, "nonexistent"); err == nil {
+		t.Error("CheckoutBranch() should fail for non-existent branch")
+	}
+}


### PR DESCRIPTION
## Summary

- `/plan` コマンド実行時にマイルストーンブランチを自動作成する機能を追加
- 新規 `internal/branch` パッケージを追加
  - `SanitizeBranchName`: マイルストーン名をgitブランチ名に変換（スペース→ハイフン、特殊文字除去など）
  - `CreateMilestoneBranch`: `milestone/{name}` 形式でブランチを作成
  - 既存ブランチがあれば新規作成をスキップ
- TUIの `/plan` ワークフローに統合
  - 優先Issueからマイルストーン名を生成
  - ブランチ作成結果をシステムメッセージに表示
  - ベストエフォート: ブランチ作成失敗でもワークフローは継続

## Test plan

- [x] `go test ./internal/branch/...` - 全テスト通過（16パターン）
- [x] `go test ./...` - 全体テスト通過
- [x] `go build ./cmd/maxam/...` - ビルド成功
- [x] `gofmt` / `go vet` - 問題なし

## 動作確認

```
/plan コマンド実行時:
✅ 議論用Issueを作成しました: https://github.com/...
🌿 マイルストーンブランチを作成しました: `milestone/issue-123-fix-something`
承認待ち中... (IssueにOK/LGTMとコメントしてください)
```

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)