### PR TITLE
refactor: move GitHub owner/repo to config

### DIFF
--- a/.maxam/config.yaml
+++ b/.maxam/config.yaml
@@ -1,5 +1,8 @@
 version: "1"
 default_agent: mei
+github:
+  owner: "ytnobody"
+  repo: "MAXAM"
 agents:
     - name: mei
       full_name: mei

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,18 @@ MAXAMは複数のAIエージェントが協調して開発業務を遂行する�
 
 > **Note:** `.env` は `.gitignore` に追加してください。
 
+### GitHub設定
+
+GitHubリポジトリ情報は`.maxam/config.yaml`に設定します。
+
+```yaml
+github:
+  owner: "ytnobody"
+  repo: "MAXAM"
+```
+
+この設定はPR監視、タスクステータス表示、プランモードなどで使用されます。
+
 ## コーディング規約
 
 ### 全般

--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -295,6 +295,15 @@ func initialTuiModel(workDir string) tuiModel {
 		}
 	}
 
+	// Setup ccusage client (silently disabled if not available)
+	ccClient := ccusage.NewClient()
+
+	// Load config first (needed for GitHub settings)
+	cfg, err := config.LoadWithProject(workDir)
+	if err != nil {
+		cfg = config.DefaultConfig()
+	}
+
 	// Setup PR watcher for worktree cleanup (silently fail if no GitHub access)
 	var prWatcher *gh.Watcher
 	var ghClient *gh.Client
@@ -303,25 +312,18 @@ func initialTuiModel(workDir string) tuiModel {
 	modeManager := mode.NewManager(config.ModeInteractive)
 
 	var taskStatusFetcher *taskstatus.Fetcher
-	if client, err := gh.NewClient("ytnobody", "MAXAM"); err == nil {
-		ghClient = client
-		prWatcher = gh.NewWatcher(ghClient)
+	if ghCfg := cfg.GetGitHubConfig(); ghCfg != nil && ghCfg.Owner != "" && ghCfg.Repo != "" {
+		if client, err := gh.NewClient(ghCfg.Owner, ghCfg.Repo); err == nil {
+			ghClient = client
+			prWatcher = gh.NewWatcher(ghClient)
 
-		// Setup plan mode components
-		planExecutor = mode.NewPlanExecutor(ghClient, nil)
-		approvalWatcher = approval.NewWatcher(ghClient)
+			// Setup plan mode components
+			planExecutor = mode.NewPlanExecutor(ghClient, nil)
+			approvalWatcher = approval.NewWatcher(ghClient)
 
-		// Setup task status fetcher (uses underlying github client)
-		taskStatusFetcher = taskstatus.NewFetcher(client.GetUnderlyingClient(), "ytnobody", "MAXAM")
-	}
-
-	// Setup ccusage client (silently disabled if not available)
-	ccClient := ccusage.NewClient()
-
-	// Setup agent router
-	cfg, err := config.LoadWithProject(workDir)
-	if err != nil {
-		cfg = config.DefaultConfig()
+			// Setup task status fetcher (uses underlying github client)
+			taskStatusFetcher = taskstatus.NewFetcher(client.GetUnderlyingClient(), ghCfg.Owner, ghCfg.Repo)
+		}
 	}
 	routerAgents := make([]router.AgentInfo, len(cfg.Agents))
 	agentNames := make([]string, len(cfg.Agents))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,12 @@ type HeartbeatConfig struct {
 	MaxRetries int    `yaml:"max_retries,omitempty"` // Max restart attempts
 }
 
+// GitHubConfig holds GitHub repository settings
+type GitHubConfig struct {
+	Owner string `yaml:"owner"` // Repository owner (e.g., "ytnobody")
+	Repo  string `yaml:"repo"`  // Repository name (e.g., "MAXAM")
+}
+
 // Config represents the MAXAM configuration
 type Config struct {
 	Version               string           `yaml:"version"`
@@ -65,6 +71,7 @@ type Config struct {
 	MentionCheckerEnabled *bool            `yaml:"mention_checker_enabled,omitempty"`
 	LogLevel              string           `yaml:"log_level,omitempty"`
 	Heartbeat             *HeartbeatConfig `yaml:"heartbeat,omitempty"`
+	GitHub                *GitHubConfig    `yaml:"github,omitempty"`
 }
 
 // AgentConfig represents an agent configuration
@@ -283,6 +290,11 @@ func mergeConfigs(base, override *Config) *Config {
 	// Override log level if set
 	if override.LogLevel != "" {
 		result.LogLevel = override.LogLevel
+	}
+
+	// Override GitHub config if set
+	if override.GitHub != nil {
+		result.GitHub = override.GitHub
 	}
 
 	return &result
@@ -513,4 +525,10 @@ func (c *Config) GetHeartbeatConfig() HeartbeatConfig {
 	}
 
 	return cfg
+}
+
+// GetGitHubConfig returns the GitHub configuration
+// Returns nil if not configured
+func (c *Config) GetGitHubConfig() *GitHubConfig {
+	return c.GitHub
 }


### PR DESCRIPTION
## Summary
- GitHubリポジトリ設定（owner/repo）をハードコードから設定ファイルへ移動
- PR #229 のFYIで指摘された改善点への対応

## Changes
- `internal/config/config.go`: `GitHubConfig`構造体を追加
- `cmd/maxam/tui.go`: `config.GetGitHubConfig()`から設定を取得
- `CLAUDE.md`: GitHub設定のドキュメント追加
- `.maxam/config.yaml`: GitHub設定を追加

## Test plan
- [x] go build ./...
- [x] go test ./...
- [x] 設定未設定時はGitHub機能が無効化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)