### PR TITLE
feat: WebSocket server infrastructure

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,12 @@ type GitHubConfig struct {
 	Repo  string `yaml:"repo"`  // Repository name (e.g., "MAXAM")
 }
 
+// WebSocketConfig holds WebSocket server settings
+type WebSocketConfig struct {
+	Enabled bool `yaml:"enabled"` // Whether WebSocket server is enabled (default: false)
+	Port    int  `yaml:"port"`    // WebSocket server port (default: 8080)
+}
+
 // Config represents the MAXAM configuration
 type Config struct {
 	Version               string           `yaml:"version"`
@@ -72,6 +78,7 @@ type Config struct {
 	LogLevel              string           `yaml:"log_level,omitempty"`
 	Heartbeat             *HeartbeatConfig `yaml:"heartbeat,omitempty"`
 	GitHub                *GitHubConfig    `yaml:"github,omitempty"`
+	WebSocket             *WebSocketConfig `yaml:"websocket,omitempty"`
 }
 
 // AgentConfig represents an agent configuration
@@ -295,6 +302,11 @@ func mergeConfigs(base, override *Config) *Config {
 	// Override GitHub config if set
 	if override.GitHub != nil {
 		result.GitHub = override.GitHub
+	}
+
+	// Override WebSocket config if set
+	if override.WebSocket != nil {
+		result.WebSocket = override.WebSocket
 	}
 
 	return &result
@@ -531,4 +543,33 @@ func (c *Config) GetHeartbeatConfig() HeartbeatConfig {
 // Returns nil if not configured
 func (c *Config) GetGitHubConfig() *GitHubConfig {
 	return c.GitHub
+}
+
+// DefaultWebSocketPort is the default WebSocket server port
+const DefaultWebSocketPort = 8080
+
+// GetWebSocketConfig returns the WebSocket configuration with defaults
+func (c *Config) GetWebSocketConfig() WebSocketConfig {
+	if c.WebSocket == nil {
+		return WebSocketConfig{
+			Enabled: false,
+			Port:    DefaultWebSocketPort,
+		}
+	}
+
+	cfg := *c.WebSocket
+
+	if cfg.Port <= 0 {
+		cfg.Port = DefaultWebSocketPort
+	}
+
+	return cfg
+}
+
+// IsWebSocketEnabled returns whether WebSocket server is enabled
+func (c *Config) IsWebSocketEnabled() bool {
+	if c.WebSocket == nil {
+		return false
+	}
+	return c.WebSocket.Enabled
 }

--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -1,0 +1,133 @@
+package ws
+
+import (
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	// Time allowed to write a message to the peer
+	writeWait = 10 * time.Second
+
+	// Time allowed to read the next pong message from the peer
+	pongWait = 60 * time.Second
+
+	// Send pings to peer with this period (must be less than pongWait)
+	pingPeriod = (pongWait * 9) / 10
+
+	// Maximum message size allowed from peer
+	maxMessageSize = 64 * 1024
+)
+
+// Client represents a WebSocket client connection
+type Client struct {
+	hub  *Hub
+	conn *websocket.Conn
+	send chan *Message
+	ID   string
+}
+
+// NewClient creates a new client
+func NewClient(hub *Hub, conn *websocket.Conn, id string) *Client {
+	return &Client{
+		hub:  hub,
+		conn: conn,
+		send: make(chan *Message, 256),
+		ID:   id,
+	}
+}
+
+// ReadPump pumps messages from the WebSocket connection to the hub
+func (c *Client) ReadPump() {
+	defer func() {
+		c.hub.Unregister(c)
+		c.conn.Close()
+	}()
+
+	c.conn.SetReadLimit(maxMessageSize)
+	c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	c.conn.SetPongHandler(func(string) error {
+		c.conn.SetReadDeadline(time.Now().Add(pongWait))
+		return nil
+	})
+
+	for {
+		_, data, err := c.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				// Log unexpected close errors if needed
+			}
+			break
+		}
+
+		message, err := ParseMessage(data)
+		if err != nil {
+			continue
+		}
+
+		// Set the sender to this client's ID
+		message.From = c.ID
+		if message.Timestamp.IsZero() {
+			message.Timestamp = time.Now()
+		}
+
+		c.hub.Broadcast(message)
+	}
+}
+
+// WritePump pumps messages from the hub to the WebSocket connection
+func (c *Client) WritePump() {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		c.conn.Close()
+	}()
+
+	for {
+		select {
+		case message, ok := <-c.send:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				// Hub closed the channel
+				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+
+			data, err := message.ToJSON()
+			if err != nil {
+				continue
+			}
+
+			if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+				return
+			}
+
+		case <-ticker.C:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// SendHistory sends the message history to this client
+func (c *Client) SendHistory(messages []*Message) error {
+	c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+	historyResp := NewHistoryResponse(messages)
+	data, err := historyResp.ToJSON()
+	if err != nil {
+		return err
+	}
+	return c.conn.WriteMessage(websocket.TextMessage, data)
+}
+
+// Send queues a message to be sent to this client
+func (c *Client) Send(message *Message) {
+	select {
+	case c.send <- message:
+	default:
+		// Buffer full, drop message
+	}
+}

--- a/internal/ws/hub.go
+++ b/internal/ws/hub.go
@@ -1,0 +1,124 @@
+package ws
+
+import (
+	"sync"
+)
+
+// Hub manages WebSocket client connections and message broadcasting
+type Hub struct {
+	clients    map[*Client]bool
+	broadcast  chan *Message
+	register   chan *Client
+	unregister chan *Client
+	mu         sync.RWMutex
+	history    []*Message
+	maxHistory int
+}
+
+// NewHub creates a new Hub
+func NewHub() *Hub {
+	return &Hub{
+		clients:    make(map[*Client]bool),
+		broadcast:  make(chan *Message, 256),
+		register:   make(chan *Client),
+		unregister: make(chan *Client),
+		history:    make([]*Message, 0, 100),
+		maxHistory: 100,
+	}
+}
+
+// Run starts the hub's main loop
+func (h *Hub) Run() {
+	for {
+		select {
+		case client := <-h.register:
+			h.mu.Lock()
+			h.clients[client] = true
+			h.mu.Unlock()
+
+			// Send join notification
+			joinMsg := NewJoinMessage(client.ID)
+			h.broadcastMessage(joinMsg)
+
+		case client := <-h.unregister:
+			h.mu.Lock()
+			if _, ok := h.clients[client]; ok {
+				delete(h.clients, client)
+				close(client.send)
+			}
+			h.mu.Unlock()
+
+			// Send leave notification
+			leaveMsg := NewLeaveMessage(client.ID)
+			h.broadcastMessage(leaveMsg)
+
+		case message := <-h.broadcast:
+			h.addToHistory(message)
+			h.broadcastMessage(message)
+		}
+	}
+}
+
+// broadcastMessage sends a message to all connected clients
+func (h *Hub) broadcastMessage(message *Message) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	for client := range h.clients {
+		select {
+		case client.send <- message:
+		default:
+			// Client send buffer full, skip
+		}
+	}
+}
+
+// addToHistory adds a message to the history buffer
+func (h *Hub) addToHistory(message *Message) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Only store chat messages in history
+	if message.Type != TypeChat {
+		return
+	}
+
+	h.history = append(h.history, message)
+
+	// Trim history if needed
+	if len(h.history) > h.maxHistory {
+		h.history = h.history[len(h.history)-h.maxHistory:]
+	}
+}
+
+// GetHistory returns a copy of the message history
+func (h *Hub) GetHistory() []*Message {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	result := make([]*Message, len(h.history))
+	copy(result, h.history)
+	return result
+}
+
+// ClientCount returns the number of connected clients
+func (h *Hub) ClientCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.clients)
+}
+
+// Broadcast sends a message to all connected clients
+func (h *Hub) Broadcast(message *Message) {
+	h.broadcast <- message
+}
+
+// Register adds a client to the hub
+func (h *Hub) Register(client *Client) {
+	h.register <- client
+}
+
+// Unregister removes a client from the hub
+func (h *Hub) Unregister(client *Client) {
+	h.unregister <- client
+}

--- a/internal/ws/message.go
+++ b/internal/ws/message.go
@@ -1,0 +1,106 @@
+// Package ws provides WebSocket server and client functionality for MAXAM chat
+package ws
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// MessageType represents the type of WebSocket message
+type MessageType string
+
+const (
+	// TypeChat is a regular chat message
+	TypeChat MessageType = "chat"
+	// TypeSystem is a system notification
+	TypeSystem MessageType = "system"
+	// TypeHistory is a batch of historical messages
+	TypeHistory MessageType = "history"
+	// TypeJoin is sent when a client joins
+	TypeJoin MessageType = "join"
+	// TypeLeave is sent when a client leaves
+	TypeLeave MessageType = "leave"
+)
+
+// Message represents a WebSocket message
+type Message struct {
+	Type      MessageType `json:"type"`
+	From      string      `json:"from"`
+	To        string      `json:"to,omitempty"`
+	Content   string      `json:"content"`
+	Timestamp time.Time   `json:"timestamp"`
+}
+
+// NewChatMessage creates a new chat message
+func NewChatMessage(from, to, content string) *Message {
+	return &Message{
+		Type:      TypeChat,
+		From:      from,
+		To:        to,
+		Content:   content,
+		Timestamp: time.Now(),
+	}
+}
+
+// NewSystemMessage creates a new system message
+func NewSystemMessage(content string) *Message {
+	return &Message{
+		Type:      TypeSystem,
+		From:      "system",
+		Content:   content,
+		Timestamp: time.Now(),
+	}
+}
+
+// NewJoinMessage creates a new join notification
+func NewJoinMessage(clientID string) *Message {
+	return &Message{
+		Type:      TypeJoin,
+		From:      clientID,
+		Content:   clientID + " joined",
+		Timestamp: time.Now(),
+	}
+}
+
+// NewLeaveMessage creates a new leave notification
+func NewLeaveMessage(clientID string) *Message {
+	return &Message{
+		Type:      TypeLeave,
+		From:      clientID,
+		Content:   clientID + " left",
+		Timestamp: time.Now(),
+	}
+}
+
+// ToJSON serializes the message to JSON
+func (m *Message) ToJSON() ([]byte, error) {
+	return json.Marshal(m)
+}
+
+// ParseMessage deserializes a message from JSON
+func ParseMessage(data []byte) (*Message, error) {
+	var msg Message
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+// HistoryResponse wraps multiple messages for history delivery
+type HistoryResponse struct {
+	Type     MessageType `json:"type"`
+	Messages []*Message  `json:"messages"`
+}
+
+// NewHistoryResponse creates a new history response
+func NewHistoryResponse(messages []*Message) *HistoryResponse {
+	return &HistoryResponse{
+		Type:     TypeHistory,
+		Messages: messages,
+	}
+}
+
+// ToJSON serializes the history response to JSON
+func (h *HistoryResponse) ToJSON() ([]byte, error) {
+	return json.Marshal(h)
+}

--- a/internal/ws/server.go
+++ b/internal/ws/server.go
@@ -1,0 +1,154 @@
+package ws
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	// Allow all origins for local development
+	// TODO: Add proper origin validation for production
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+// Server represents a WebSocket server
+type Server struct {
+	hub        *Hub
+	httpServer *http.Server
+	port       int
+	running    atomic.Bool
+	mu         sync.Mutex
+	clientID   int64 // For generating unique client IDs
+}
+
+// NewServer creates a new WebSocket server
+func NewServer(port int) *Server {
+	return &Server{
+		hub:  NewHub(),
+		port: port,
+	}
+}
+
+// Start starts the WebSocket server
+func (s *Server) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.running.Load() {
+		return fmt.Errorf("server already running")
+	}
+
+	// Start the hub
+	go s.hub.Run()
+
+	// Set up HTTP routes
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws", s.handleWebSocket)
+	mux.HandleFunc("/health", s.handleHealth)
+
+	s.httpServer = &http.Server{
+		Addr:    fmt.Sprintf(":%d", s.port),
+		Handler: mux,
+	}
+
+	s.running.Store(true)
+
+	// Start HTTP server in background
+	go func() {
+		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			s.running.Store(false)
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the WebSocket server
+func (s *Server) Stop(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.running.Load() {
+		return nil
+	}
+
+	s.running.Store(false)
+
+	if s.httpServer != nil {
+		return s.httpServer.Shutdown(ctx)
+	}
+
+	return nil
+}
+
+// handleWebSocket handles WebSocket connection requests
+func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+
+	// Generate a unique client ID or use query param
+	clientID := r.URL.Query().Get("id")
+	if clientID == "" {
+		clientID = fmt.Sprintf("client-%d", atomic.AddInt64(&s.clientID, 1))
+	}
+
+	client := NewClient(s.hub, conn, clientID)
+
+	// Register the client
+	s.hub.Register(client)
+
+	// Send history if requested
+	if r.URL.Query().Get("history") == "true" {
+		history := s.hub.GetHistory()
+		if len(history) > 0 {
+			client.SendHistory(history)
+		}
+	}
+
+	// Start client pumps
+	go client.WritePump()
+	client.ReadPump()
+}
+
+// handleHealth returns server health status
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, `{"status":"ok","clients":%d}`, s.hub.ClientCount())
+}
+
+// IsRunning returns whether the server is running
+func (s *Server) IsRunning() bool {
+	return s.running.Load()
+}
+
+// GetHub returns the hub instance
+func (s *Server) GetHub() *Hub {
+	return s.hub
+}
+
+// Port returns the server port
+func (s *Server) Port() int {
+	return s.port
+}
+
+// Broadcast sends a message to all connected clients
+func (s *Server) Broadcast(message *Message) {
+	s.hub.Broadcast(message)
+}
+
+// ClientCount returns the number of connected clients
+func (s *Server) ClientCount() int {
+	return s.hub.ClientCount()
+}

--- a/internal/ws/server_test.go
+++ b/internal/ws/server_test.go
@@ -1,0 +1,254 @@
+package ws
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestMessage(t *testing.T) {
+	t.Run("NewChatMessage", func(t *testing.T) {
+		msg := NewChatMessage("alice", "bob", "hello")
+		if msg.Type != TypeChat {
+			t.Errorf("expected type %s, got %s", TypeChat, msg.Type)
+		}
+		if msg.From != "alice" {
+			t.Errorf("expected from alice, got %s", msg.From)
+		}
+		if msg.To != "bob" {
+			t.Errorf("expected to bob, got %s", msg.To)
+		}
+		if msg.Content != "hello" {
+			t.Errorf("expected content hello, got %s", msg.Content)
+		}
+	})
+
+	t.Run("NewSystemMessage", func(t *testing.T) {
+		msg := NewSystemMessage("system alert")
+		if msg.Type != TypeSystem {
+			t.Errorf("expected type %s, got %s", TypeSystem, msg.Type)
+		}
+		if msg.From != "system" {
+			t.Errorf("expected from system, got %s", msg.From)
+		}
+	})
+
+	t.Run("JSON serialization", func(t *testing.T) {
+		msg := NewChatMessage("alice", "bob", "hello")
+		data, err := msg.ToJSON()
+		if err != nil {
+			t.Fatalf("failed to serialize: %v", err)
+		}
+
+		parsed, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("failed to parse: %v", err)
+		}
+
+		if parsed.Type != msg.Type {
+			t.Errorf("type mismatch: expected %s, got %s", msg.Type, parsed.Type)
+		}
+		if parsed.From != msg.From {
+			t.Errorf("from mismatch: expected %s, got %s", msg.From, parsed.From)
+		}
+		if parsed.Content != msg.Content {
+			t.Errorf("content mismatch: expected %s, got %s", msg.Content, parsed.Content)
+		}
+	})
+}
+
+func TestHub(t *testing.T) {
+	t.Run("ClientCount", func(t *testing.T) {
+		hub := NewHub()
+		go hub.Run()
+
+		if hub.ClientCount() != 0 {
+			t.Errorf("expected 0 clients, got %d", hub.ClientCount())
+		}
+	})
+
+	t.Run("GetHistory empty", func(t *testing.T) {
+		hub := NewHub()
+		history := hub.GetHistory()
+		if len(history) != 0 {
+			t.Errorf("expected empty history, got %d messages", len(history))
+		}
+	})
+}
+
+func TestServer(t *testing.T) {
+	t.Run("NewServer", func(t *testing.T) {
+		server := NewServer(8080)
+		if server.Port() != 8080 {
+			t.Errorf("expected port 8080, got %d", server.Port())
+		}
+		if server.IsRunning() {
+			t.Error("server should not be running initially")
+		}
+	})
+
+	t.Run("Start and Stop", func(t *testing.T) {
+		server := NewServer(0) // Use port 0 for random available port
+		if err := server.Start(); err != nil {
+			t.Fatalf("failed to start server: %v", err)
+		}
+
+		if !server.IsRunning() {
+			t.Error("server should be running after start")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := server.Stop(ctx); err != nil {
+			t.Fatalf("failed to stop server: %v", err)
+		}
+
+		if server.IsRunning() {
+			t.Error("server should not be running after stop")
+		}
+	})
+
+	t.Run("Double start returns error", func(t *testing.T) {
+		server := NewServer(0)
+		if err := server.Start(); err != nil {
+			t.Fatalf("failed to start server: %v", err)
+		}
+		defer server.Stop(context.Background())
+
+		if err := server.Start(); err == nil {
+			t.Error("expected error on double start")
+		}
+	})
+}
+
+func TestServerWebSocket(t *testing.T) {
+	// Create test server
+	hub := NewHub()
+	go hub.Run()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+
+		clientID := r.URL.Query().Get("id")
+		if clientID == "" {
+			clientID = "test-client"
+		}
+
+		client := NewClient(hub, conn, clientID)
+		hub.Register(client)
+
+		go client.WritePump()
+		client.ReadPump()
+	}))
+	defer server.Close()
+
+	// Convert http URL to ws URL
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "?id=test"
+
+	t.Run("Connect and receive join message", func(t *testing.T) {
+		conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		if err != nil {
+			t.Fatalf("failed to connect: %v", err)
+		}
+		defer conn.Close()
+
+		// Wait for join message
+		conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("failed to read message: %v", err)
+		}
+
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("failed to parse message: %v", err)
+		}
+
+		if msg.Type != TypeJoin {
+			t.Errorf("expected join message, got %s", msg.Type)
+		}
+	})
+
+	t.Run("Send and receive chat message", func(t *testing.T) {
+		// Connect two clients
+		conn1, _, err := websocket.DefaultDialer.Dial(wsURL+"1", nil)
+		if err != nil {
+			t.Fatalf("failed to connect client 1: %v", err)
+		}
+		defer conn1.Close()
+
+		// Give time for connection to be established
+		time.Sleep(100 * time.Millisecond)
+
+		conn2, _, err := websocket.DefaultDialer.Dial(wsURL+"2", nil)
+		if err != nil {
+			t.Fatalf("failed to connect client 2: %v", err)
+		}
+		defer conn2.Close()
+
+		// Give time for both connections to be established
+		time.Sleep(100 * time.Millisecond)
+
+		// Send a chat message from client 1
+		chatMsg := NewChatMessage("", "", "hello world")
+		data, _ := chatMsg.ToJSON()
+		if err := conn1.WriteMessage(websocket.TextMessage, data); err != nil {
+			t.Fatalf("failed to send message: %v", err)
+		}
+
+		// Read messages on client 2, looking for the chat message
+		conn2.SetReadDeadline(time.Now().Add(5 * time.Second))
+		for {
+			_, received, err := conn2.ReadMessage()
+			if err != nil {
+				t.Fatalf("failed to receive message: %v", err)
+			}
+
+			msg, err := ParseMessage(received)
+			if err != nil {
+				t.Fatalf("failed to parse received message: %v", err)
+			}
+
+			// Skip join/leave messages, look for chat
+			if msg.Type == TypeChat {
+				if msg.Content != "hello world" {
+					t.Errorf("expected 'hello world', got '%s'", msg.Content)
+				}
+				break
+			}
+		}
+	})
+}
+
+func TestHistoryResponse(t *testing.T) {
+	messages := []*Message{
+		NewChatMessage("alice", "bob", "hello"),
+		NewChatMessage("bob", "alice", "hi"),
+	}
+
+	resp := NewHistoryResponse(messages)
+	if resp.Type != TypeHistory {
+		t.Errorf("expected type %s, got %s", TypeHistory, resp.Type)
+	}
+	if len(resp.Messages) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(resp.Messages))
+	}
+
+	data, err := resp.ToJSON()
+	if err != nil {
+		t.Fatalf("failed to serialize history response: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Error("expected non-empty JSON")
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/ws` パッケージ追加（server, hub, client, message）
- Config に `websocket.enabled` / `websocket.port` 設定追加
- 複数クライアント接続、メッセージブロードキャスト対応
- 履歴管理、join/leave通知

## Test plan
- [x] `go test ./internal/ws/...` - 全テスト通過
- [x] `go vet ./...` - エラーなし
- [x] `go build ./...` - ビルド成功

## 設定例
```yaml
websocket:
  enabled: true
  port: 8080
```

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)