### PR TITLE
feat: TUIをWebSocketクライアント化

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ytnobody/MAXAM/internal/router"
 	"github.com/ytnobody/MAXAM/internal/taskstatus"
 	"github.com/ytnobody/MAXAM/internal/worktree"
+	"github.com/ytnobody/MAXAM/internal/ws"
 )
 
 // Version is set by ldflags at build time
@@ -220,6 +221,10 @@ type tuiModel struct {
 	// Task status from GitHub PRs
 	taskStatusFetcher *taskstatus.Fetcher
 	taskStatusLine    string // Cached formatted status line
+
+	// WebSocket server and client for chat communication
+	wsServer *ws.Server
+	wsClient *ws.TUIClient
 }
 
 type agentResponseMsg struct {
@@ -427,6 +432,23 @@ func initialTuiModel(workDir string) tuiModel {
 		}
 	})
 
+	// Setup WebSocket server and client
+	var wsServer *ws.Server
+	var wsClient *ws.TUIClient
+	wsCfg := cfg.GetWebSocketConfig()
+	wsServer = ws.NewServer(wsCfg.Port)
+	if err := wsServer.Start(); err == nil {
+		// Connect TUI as a client
+		clientCfg := ws.DefaultTUIClientConfig(wsCfg.Port, "owner")
+		wsClient = ws.NewTUIClient(clientCfg)
+		// Connect in background (non-blocking)
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			wsClient.ConnectWithRetry(ctx)
+		}()
+	}
+
 	return tuiModel{
 		agents:              agents,
 		members:             members,
@@ -457,6 +479,8 @@ func initialTuiModel(workDir string) tuiModel {
 		recoveryHandler:     recHandler,
 		heartbeatMsgQueue:   heartbeatMsgQueue,
 		taskStatusFetcher:   taskStatusFetcher,
+		wsServer:            wsServer,
+		wsClient:            wsClient,
 	}
 }
 
@@ -658,6 +682,15 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.heartbeatMonitor != nil {
 				m.heartbeatMonitor.Stop()
 			}
+			// Stop WebSocket server and client
+			if m.wsClient != nil {
+				m.wsClient.Disconnect()
+			}
+			if m.wsServer != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				m.wsServer.Stop(ctx)
+				cancel()
+			}
 			return m, tea.Quit
 
 		case tea.KeyCtrlL:
@@ -675,6 +708,15 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.logMgr.Close()
 				if m.workerPool != nil {
 					m.workerPool.StopAll()
+				}
+				// Stop WebSocket server and client
+				if m.wsClient != nil {
+					m.wsClient.Disconnect()
+				}
+				if m.wsServer != nil {
+					ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+					m.wsServer.Stop(ctx)
+					cancel()
 				}
 				return m, tea.Quit
 			}
@@ -723,6 +765,11 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.messages = append(m.messages, tuiMessage{role: "user", content: input})
 			if m.history != nil {
 				m.history.Add("user", input)
+			}
+
+			// Broadcast user message via WebSocket
+			if m.wsServer != nil {
+				m.wsServer.Broadcast(ws.NewChatMessage("owner", "", input))
 			}
 
 			m.updateViewport()
@@ -1059,6 +1106,11 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			role:    msg.agent,
 			content: msg.content,
 		})
+
+		// Broadcast agent response via WebSocket
+		if m.wsServer != nil {
+			m.wsServer.Broadcast(ws.NewChatMessage(msg.agent, "", msg.content))
+		}
 
 		// Check for mention leaks in agent response and add to history
 		// Only enforce in Plan/Auto modes, not in Interactive mode

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/go-github/v60 v60.0.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/slack-go/slack v0.17.3
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/term v0.39.0
@@ -23,7 +23,6 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -546,7 +546,7 @@ func (c *Config) GetGitHubConfig() *GitHubConfig {
 }
 
 // DefaultWebSocketPort is the default WebSocket server port
-const DefaultWebSocketPort = 8080
+const DefaultWebSocketPort = 8765
 
 // GetWebSocketConfig returns the WebSocket configuration with defaults
 func (c *Config) GetWebSocketConfig() WebSocketConfig {

--- a/internal/ws/tuiclient.go
+++ b/internal/ws/tuiclient.go
@@ -1,0 +1,358 @@
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// TUIClient represents a WebSocket client for the TUI
+type TUIClient struct {
+	serverURL     string
+	clientID      string
+	conn          *websocket.Conn
+	mu            sync.RWMutex
+	connected     atomic.Bool
+	incoming      chan *Message
+	outgoing      chan *Message
+	done          chan struct{}
+	reconnectWait time.Duration
+	maxReconnect  int
+	onMessage     func(*Message)
+	onConnect     func()
+	onDisconnect  func(error)
+}
+
+// TUIClientConfig holds configuration for the TUI client
+type TUIClientConfig struct {
+	ServerURL     string
+	ClientID      string
+	ReconnectWait time.Duration
+	MaxReconnect  int
+}
+
+// DefaultTUIClientConfig returns default configuration
+func DefaultTUIClientConfig(port int, clientID string) TUIClientConfig {
+	return TUIClientConfig{
+		ServerURL:     fmt.Sprintf("ws://localhost:%d/ws", port),
+		ClientID:      clientID,
+		ReconnectWait: 2 * time.Second,
+		MaxReconnect:  10,
+	}
+}
+
+// NewTUIClient creates a new TUI WebSocket client
+func NewTUIClient(cfg TUIClientConfig) *TUIClient {
+	return &TUIClient{
+		serverURL:     cfg.ServerURL,
+		clientID:      cfg.ClientID,
+		incoming:      make(chan *Message, 256),
+		outgoing:      make(chan *Message, 256),
+		done:          make(chan struct{}),
+		reconnectWait: cfg.ReconnectWait,
+		maxReconnect:  cfg.MaxReconnect,
+	}
+}
+
+// SetMessageHandler sets the callback for incoming messages
+func (c *TUIClient) SetMessageHandler(handler func(*Message)) {
+	c.onMessage = handler
+}
+
+// SetConnectHandler sets the callback for successful connection
+func (c *TUIClient) SetConnectHandler(handler func()) {
+	c.onConnect = handler
+}
+
+// SetDisconnectHandler sets the callback for disconnection
+func (c *TUIClient) SetDisconnectHandler(handler func(error)) {
+	c.onDisconnect = handler
+}
+
+// Connect establishes a WebSocket connection to the server
+func (c *TUIClient) Connect(ctx context.Context) error {
+	u, err := url.Parse(c.serverURL)
+	if err != nil {
+		return fmt.Errorf("invalid server URL: %w", err)
+	}
+
+	// Add client ID and history request to query
+	q := u.Query()
+	q.Set("id", c.clientID)
+	q.Set("history", "true")
+	u.RawQuery = q.Encode()
+
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to connect: %w", err)
+	}
+
+	c.mu.Lock()
+	c.conn = conn
+	c.mu.Unlock()
+	c.connected.Store(true)
+
+	if c.onConnect != nil {
+		c.onConnect()
+	}
+
+	// Start read/write pumps
+	go c.readPump()
+	go c.writePump()
+
+	return nil
+}
+
+// ConnectWithRetry connects with automatic retry on failure
+func (c *TUIClient) ConnectWithRetry(ctx context.Context) error {
+	var lastErr error
+	for i := 0; i < c.maxReconnect; i++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err := c.Connect(ctx); err != nil {
+			lastErr = err
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(c.reconnectWait):
+				continue
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("max reconnect attempts reached: %w", lastErr)
+}
+
+// Disconnect closes the WebSocket connection
+func (c *TUIClient) Disconnect() error {
+	if !c.connected.Load() {
+		return nil
+	}
+
+	c.connected.Store(false)
+
+	// Close done channel (only once)
+	select {
+	case <-c.done:
+		// Already closed
+	default:
+		close(c.done)
+	}
+
+	c.mu.Lock()
+	conn := c.conn
+	c.conn = nil
+	c.mu.Unlock()
+
+	var err error
+	if conn != nil {
+		// Send close message
+		deadline := time.Now().Add(time.Second)
+		conn.SetWriteDeadline(deadline)
+		conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		err = conn.Close()
+	}
+
+	// Call disconnect handler
+	if c.onDisconnect != nil {
+		c.onDisconnect(nil)
+	}
+
+	return err
+}
+
+// IsConnected returns true if the client is connected
+func (c *TUIClient) IsConnected() bool {
+	return c.connected.Load()
+}
+
+// Send sends a message to the server
+func (c *TUIClient) Send(msg *Message) error {
+	if !c.connected.Load() {
+		return fmt.Errorf("not connected")
+	}
+
+	select {
+	case c.outgoing <- msg:
+		return nil
+	default:
+		return fmt.Errorf("send buffer full")
+	}
+}
+
+// SendChat sends a chat message
+func (c *TUIClient) SendChat(to, content string) error {
+	msg := NewChatMessage(c.clientID, to, content)
+	return c.Send(msg)
+}
+
+// Incoming returns the channel for incoming messages
+func (c *TUIClient) Incoming() <-chan *Message {
+	return c.incoming
+}
+
+// readPump reads messages from the WebSocket connection
+func (c *TUIClient) readPump() {
+	defer func() {
+		c.handleDisconnect(nil)
+	}()
+
+	c.mu.RLock()
+	conn := c.conn
+	c.mu.RUnlock()
+
+	if conn == nil {
+		return
+	}
+
+	conn.SetReadLimit(maxMessageSize)
+	conn.SetReadDeadline(time.Now().Add(pongWait))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(pongWait))
+		return nil
+	})
+
+	for {
+		select {
+		case <-c.done:
+			return
+		default:
+		}
+
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				c.handleDisconnect(err)
+			}
+			return
+		}
+
+		// Try to parse as history response first
+		if histResp, err := tryParseHistoryResponse(data); err == nil {
+			for _, msg := range histResp.Messages {
+				c.deliverMessage(msg)
+			}
+			continue
+		}
+
+		// Parse as regular message
+		msg, err := ParseMessage(data)
+		if err != nil {
+			continue
+		}
+
+		c.deliverMessage(msg)
+	}
+}
+
+// writePump writes messages to the WebSocket connection
+func (c *TUIClient) writePump() {
+	ticker := time.NewTicker(pingPeriod)
+	defer ticker.Stop()
+
+	c.mu.RLock()
+	conn := c.conn
+	c.mu.RUnlock()
+
+	if conn == nil {
+		return
+	}
+
+	for {
+		select {
+		case <-c.done:
+			return
+
+		case msg := <-c.outgoing:
+			conn.SetWriteDeadline(time.Now().Add(writeWait))
+			data, err := msg.ToJSON()
+			if err != nil {
+				continue
+			}
+			if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+				c.handleDisconnect(err)
+				return
+			}
+
+		case <-ticker.C:
+			conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				c.handleDisconnect(err)
+				return
+			}
+		}
+	}
+}
+
+// deliverMessage delivers a message to handlers
+func (c *TUIClient) deliverMessage(msg *Message) {
+	// Deliver to handler if set
+	if c.onMessage != nil {
+		c.onMessage(msg)
+	}
+
+	// Also send to channel for polling
+	select {
+	case c.incoming <- msg:
+	default:
+		// Buffer full, drop oldest
+		select {
+		case <-c.incoming:
+		default:
+		}
+		select {
+		case c.incoming <- msg:
+		default:
+		}
+	}
+}
+
+// handleDisconnect handles disconnection
+func (c *TUIClient) handleDisconnect(err error) {
+	if !c.connected.Load() {
+		return
+	}
+
+	c.connected.Store(false)
+
+	// Close done channel (only once)
+	select {
+	case <-c.done:
+		// Already closed
+	default:
+		close(c.done)
+	}
+
+	c.mu.Lock()
+	if c.conn != nil {
+		c.conn.Close()
+		c.conn = nil
+	}
+	c.mu.Unlock()
+
+	if c.onDisconnect != nil {
+		c.onDisconnect(err)
+	}
+}
+
+// tryParseHistoryResponse attempts to parse data as a HistoryResponse
+func tryParseHistoryResponse(data []byte) (*HistoryResponse, error) {
+	var resp HistoryResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Type != TypeHistory {
+		return nil, fmt.Errorf("not a history response")
+	}
+	return &resp, nil
+}

--- a/internal/ws/tuiclient_test.go
+++ b/internal/ws/tuiclient_test.go
@@ -1,0 +1,247 @@
+package ws
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTUIClient_ConnectToServer(t *testing.T) {
+	// Start a test server on a specific port
+	testPort := 18765
+	server := NewServer(testPort)
+	if err := server.Start(); err != nil {
+		t.Fatalf("Failed to start server: %v", err)
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		server.Stop(ctx)
+	}()
+
+	// Wait for server to be ready
+	time.Sleep(100 * time.Millisecond)
+
+	// Create client
+	cfg := DefaultTUIClientConfig(testPort, "test-tui")
+	client := NewTUIClient(cfg)
+
+	// Test connection
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+
+	if !client.IsConnected() {
+		t.Error("Client should be connected")
+	}
+
+	// Wait for join notification to propagate
+	time.Sleep(100 * time.Millisecond)
+
+	if server.ClientCount() != 1 {
+		t.Errorf("Expected 1 client, got %d", server.ClientCount())
+	}
+
+	// Disconnect
+	if err := client.Disconnect(); err != nil {
+		t.Errorf("Failed to disconnect: %v", err)
+	}
+
+	if client.IsConnected() {
+		t.Error("Client should be disconnected")
+	}
+}
+
+func TestTUIClient_SendAndReceive(t *testing.T) {
+	// Start server on a specific port
+	testPort := 18766
+	server := NewServer(testPort)
+	if err := server.Start(); err != nil {
+		t.Fatalf("Failed to start server: %v", err)
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		server.Stop(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Create two clients
+	cfg1 := DefaultTUIClientConfig(testPort, "client1")
+	client1 := NewTUIClient(cfg1)
+
+	cfg2 := DefaultTUIClientConfig(testPort, "client2")
+	client2 := NewTUIClient(cfg2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Connect both clients
+	if err := client1.Connect(ctx); err != nil {
+		t.Fatalf("Client1 failed to connect: %v", err)
+	}
+	defer client1.Disconnect()
+
+	if err := client2.Connect(ctx); err != nil {
+		t.Fatalf("Client2 failed to connect: %v", err)
+	}
+	defer client2.Disconnect()
+
+	// Wait for connections
+	time.Sleep(200 * time.Millisecond)
+
+	// Set up message receiver for client2
+	var received *Message
+	var mu sync.Mutex
+	done := make(chan struct{})
+
+	client2.SetMessageHandler(func(msg *Message) {
+		mu.Lock()
+		defer mu.Unlock()
+		if msg.Type == TypeChat && msg.From == "client1" {
+			received = msg
+			close(done)
+		}
+	})
+
+	// Send message from client1
+	if err := client1.SendChat("client2", "Hello from client1"); err != nil {
+		t.Fatalf("Failed to send message: %v", err)
+	}
+
+	// Wait for message
+	select {
+	case <-done:
+		mu.Lock()
+		if received == nil {
+			t.Error("Expected to receive message")
+		} else if received.Content != "Hello from client1" {
+			t.Errorf("Unexpected content: %s", received.Content)
+		}
+		mu.Unlock()
+	case <-time.After(2 * time.Second):
+		t.Error("Timeout waiting for message")
+	}
+}
+
+func TestTUIClient_ConnectWithRetry(t *testing.T) {
+	// Start server on a specific port
+	testPort := 18767
+	server := NewServer(testPort)
+	if err := server.Start(); err != nil {
+		t.Fatalf("Failed to start server: %v", err)
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		server.Stop(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Create client with retry config
+	cfg := TUIClientConfig{
+		ServerURL:     DefaultTUIClientConfig(testPort, "").ServerURL,
+		ClientID:      "retry-test",
+		ReconnectWait: 100 * time.Millisecond,
+		MaxReconnect:  3,
+	}
+	client := NewTUIClient(cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Test ConnectWithRetry succeeds
+	if err := client.ConnectWithRetry(ctx); err != nil {
+		t.Errorf("Failed to connect with retry: %v", err)
+	}
+
+	if !client.IsConnected() {
+		t.Error("Client should be connected")
+	}
+
+	client.Disconnect()
+}
+
+func TestTUIClient_ConnectWithRetry_Fails(t *testing.T) {
+	// No server running - should fail after max retries
+	cfg := TUIClientConfig{
+		ServerURL:     "ws://localhost:19999/ws",
+		ClientID:      "retry-fail-test",
+		ReconnectWait: 50 * time.Millisecond,
+		MaxReconnect:  2,
+	}
+	client := NewTUIClient(cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Should fail after retries
+	err := client.ConnectWithRetry(ctx)
+	if err == nil {
+		t.Error("Expected error when server not available")
+	}
+}
+
+func TestTUIClient_ConnectHandlers(t *testing.T) {
+	// Start server on a specific port
+	testPort := 18769
+	server := NewServer(testPort)
+	if err := server.Start(); err != nil {
+		t.Fatalf("Failed to start server: %v", err)
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		server.Stop(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	cfg := DefaultTUIClientConfig(testPort, "handler-test")
+	client := NewTUIClient(cfg)
+
+	// Track handlers called
+	connected := make(chan struct{})
+	disconnected := make(chan struct{})
+
+	client.SetConnectHandler(func() {
+		close(connected)
+	})
+
+	client.SetDisconnectHandler(func(err error) {
+		close(disconnected)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Connect
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+
+	// Wait for connect handler
+	select {
+	case <-connected:
+		// OK
+	case <-time.After(time.Second):
+		t.Error("Connect handler not called")
+	}
+
+	// Disconnect
+	client.Disconnect()
+
+	// Wait for disconnect handler
+	select {
+	case <-disconnected:
+		// OK
+	case <-time.After(time.Second):
+		t.Error("Disconnect handler not called")
+	}
+}


### PR DESCRIPTION
## Summary
- TUI起動時にWebSocketサーバーを起動し、自己接続
- ユーザー入力とエージェント応答をWebSocket経由でブロードキャスト
- デフォルトポートを8765に変更
- TUIClient実装（internal/ws/tuiclient.go）

## Test plan
- [ ] go test ./... が全PASS
- [ ] TUI起動時にWebSocketサーバーが起動することを確認
- [ ] メッセージがブロードキャストされることを確認

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)