### PR TITLE
feat: integrate WebSocket broadcast into chat daemon mode

### DIFF
--- a/cmd/maxam/chat.go
+++ b/cmd/maxam/chat.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/ytnobody/MAXAM/internal/logger"
 	"github.com/ytnobody/MAXAM/internal/member"
 	"github.com/ytnobody/MAXAM/internal/mention"
+	"github.com/ytnobody/MAXAM/internal/ws"
 )
 
 // chatFlags holds parsed command line flags for chat command
@@ -22,6 +24,8 @@ type chatFlags struct {
 	agentName    string
 	daemon       bool
 	mentionCheck bool
+	websocket    bool
+	wsPort       int
 }
 
 // ChatSession manages an interactive conversation with an agent
@@ -33,6 +37,7 @@ type ChatSession struct {
 	history      []chatMessage
 	mentionCheck bool
 	daemon       bool
+	wsServer     *ws.Server
 }
 
 type chatMessage struct {
@@ -68,6 +73,13 @@ func parseChatFlags(args []string) chatFlags {
 			flags.mentionCheck = false
 		case arg == "--no-mention-check":
 			flags.mentionCheck = false
+		case arg == "--websocket", arg == "--ws":
+			flags.websocket = true
+		case strings.HasPrefix(arg, "--ws-port="):
+			if port, err := strconv.Atoi(strings.TrimPrefix(arg, "--ws-port=")); err == nil {
+				flags.wsPort = port
+				flags.websocket = true
+			}
 		}
 	}
 
@@ -79,9 +91,11 @@ func runChat() {
 		fmt.Fprintln(os.Stderr, "Usage: maxam chat <agent> [flags]")
 		fmt.Fprintln(os.Stderr, "Agents: (run 'maxam team list' to see configured agents)")
 		fmt.Fprintln(os.Stderr, "Flags:")
-		fmt.Fprintln(os.Stderr, "  --daemon          Run in daemon mode (wait for input continuously)")
-		fmt.Fprintln(os.Stderr, "  --mention-check   Enable mention checker (default: on, off in daemon mode)")
+		fmt.Fprintln(os.Stderr, "  --daemon            Run in daemon mode (wait for input continuously)")
+		fmt.Fprintln(os.Stderr, "  --mention-check     Enable mention checker (default: on, off in daemon mode)")
 		fmt.Fprintln(os.Stderr, "  --no-mention-check  Disable mention checker")
+		fmt.Fprintln(os.Stderr, "  --websocket, --ws   Enable WebSocket broadcast (daemon mode only)")
+		fmt.Fprintln(os.Stderr, "  --ws-port=PORT      WebSocket server port (default: 8080)")
 		os.Exit(1)
 	}
 
@@ -121,6 +135,25 @@ func runChat() {
 		daemon:       flags.daemon,
 	}
 	defer session.logMgr.Close()
+
+	// Start WebSocket server if enabled (daemon mode only)
+	if flags.websocket && flags.daemon {
+		port := flags.wsPort
+		if port == 0 {
+			port = 8080
+		}
+		session.wsServer = ws.NewServer(port)
+		if err := session.wsServer.Start(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to start WebSocket server: %v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "WebSocket server started on port %d\n", port)
+			defer func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				session.wsServer.Stop(ctx)
+			}()
+		}
+	}
 
 	if flags.agentName == "team" {
 		if flags.daemon {
@@ -329,6 +362,12 @@ func (s *ChatSession) processTeamMessage(input string) {
 
 	s.history = append(s.history, chatMessage{role: "user", content: input})
 
+	// Broadcast user input via WebSocket if server is running
+	if s.wsServer != nil && s.wsServer.IsRunning() {
+		userMsg := ws.NewChatMessage("owner", "", input)
+		s.wsServer.Broadcast(userMsg)
+	}
+
 	// Detect all mentioned agents
 	mentioned := s.members.DetectMentions(input)
 	if len(mentioned) == 0 {
@@ -343,6 +382,7 @@ func (s *ChatSession) processTeamMessage(input string) {
 			continue
 		}
 
+		fullName := s.members.GetFullName(agentName)
 		prompt := s.buildPrompt(agentName, input)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -356,6 +396,12 @@ func (s *ChatSession) processTeamMessage(input string) {
 
 		result = strings.TrimSpace(result)
 		fmt.Println(result)
+
+		// Broadcast agent response via WebSocket if server is running
+		if s.wsServer != nil && s.wsServer.IsRunning() {
+			agentMsg := ws.NewChatMessage(fullName, "", result)
+			s.wsServer.Broadcast(agentMsg)
+		}
 
 		// Check for mention leaks in agent response
 		if s.mentionCheck {

--- a/cmd/maxam/chat_test.go
+++ b/cmd/maxam/chat_test.go
@@ -9,6 +9,8 @@ func TestParseChatFlags(t *testing.T) {
 		wantAgent   string
 		wantDaemon  bool
 		wantMention bool
+		wantWS      bool
+		wantWSPort  int
 	}{
 		{
 			name:        "agent only",
@@ -16,6 +18,8 @@ func TestParseChatFlags(t *testing.T) {
 			wantAgent:   "yuki",
 			wantDaemon:  false,
 			wantMention: true,
+			wantWS:      false,
+			wantWSPort:  0,
 		},
 		{
 			name:        "agent with daemon",
@@ -23,6 +27,8 @@ func TestParseChatFlags(t *testing.T) {
 			wantAgent:   "team",
 			wantDaemon:  true,
 			wantMention: false, // daemon mode: default off
+			wantWS:      false,
+			wantWSPort:  0,
 		},
 		{
 			name:        "daemon with mention-check explicitly enabled",
@@ -30,6 +36,8 @@ func TestParseChatFlags(t *testing.T) {
 			wantAgent:   "team",
 			wantDaemon:  true,
 			wantMention: true,
+			wantWS:      false,
+			wantWSPort:  0,
 		},
 		{
 			name:        "daemon with mention-check=true",
@@ -37,6 +45,8 @@ func TestParseChatFlags(t *testing.T) {
 			wantAgent:   "team",
 			wantDaemon:  true,
 			wantMention: true,
+			wantWS:      false,
+			wantWSPort:  0,
 		},
 		{
 			name:        "daemon with mention-check=false",
@@ -44,6 +54,8 @@ func TestParseChatFlags(t *testing.T) {
 			wantAgent:   "team",
 			wantDaemon:  true,
 			wantMention: false,
+			wantWS:      false,
+			wantWSPort:  0,
 		},
 		{
 			name:        "non-daemon with no-mention-check",
@@ -51,6 +63,8 @@ func TestParseChatFlags(t *testing.T) {
 			wantAgent:   "yuki",
 			wantDaemon:  false,
 			wantMention: false,
+			wantWS:      false,
+			wantWSPort:  0,
 		},
 		{
 			name:        "uppercase agent name normalized",
@@ -58,6 +72,8 @@ func TestParseChatFlags(t *testing.T) {
 			wantAgent:   "yuki",
 			wantDaemon:  false,
 			wantMention: true,
+			wantWS:      false,
+			wantWSPort:  0,
 		},
 		{
 			name:        "empty args",
@@ -65,6 +81,35 @@ func TestParseChatFlags(t *testing.T) {
 			wantAgent:   "",
 			wantDaemon:  false,
 			wantMention: true,
+			wantWS:      false,
+			wantWSPort:  0,
+		},
+		{
+			name:        "daemon with websocket flag",
+			args:        []string{"maxam", "chat", "team", "--daemon", "--websocket"},
+			wantAgent:   "team",
+			wantDaemon:  true,
+			wantMention: false,
+			wantWS:      true,
+			wantWSPort:  0,
+		},
+		{
+			name:        "daemon with ws short flag",
+			args:        []string{"maxam", "chat", "team", "--daemon", "--ws"},
+			wantAgent:   "team",
+			wantDaemon:  true,
+			wantMention: false,
+			wantWS:      true,
+			wantWSPort:  0,
+		},
+		{
+			name:        "daemon with ws-port",
+			args:        []string{"maxam", "chat", "team", "--daemon", "--ws-port=9090"},
+			wantAgent:   "team",
+			wantDaemon:  true,
+			wantMention: false,
+			wantWS:      true,
+			wantWSPort:  9090,
 		},
 	}
 
@@ -80,6 +125,12 @@ func TestParseChatFlags(t *testing.T) {
 			}
 			if flags.mentionCheck != tt.wantMention {
 				t.Errorf("mentionCheck = %v, want %v", flags.mentionCheck, tt.wantMention)
+			}
+			if flags.websocket != tt.wantWS {
+				t.Errorf("websocket = %v, want %v", flags.websocket, tt.wantWS)
+			}
+			if flags.wsPort != tt.wantWSPort {
+				t.Errorf("wsPort = %d, want %d", flags.wsPort, tt.wantWSPort)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- daemonモードでWebSocketサーバーを起動するオプション（`--websocket`/`--ws`）を追加
- ユーザー入力とエージェント応答をWebSocket経由でブロードキャスト
- ポート指定オプション（`--ws-port=PORT`）追加（デフォルト: 8080）

## 変更内容
- `chatFlags`に`websocket`, `wsPort`フィールド追加
- `ChatSession`に`wsServer *ws.Server`フィールド追加
- `processTeamMessage()`でBroadcast処理追加
- フラグパーステスト追加

## Test plan
- [x] `go test ./cmd/maxam/... -v -run Chat` 全テスト通過
- [x] `go test ./...` 全テスト通過
- [x] `gofmt -l .` 警告なし
- [x] `go vet ./...` 警告なし

## 使い方
```bash
maxam chat team --daemon --websocket
maxam chat team --daemon --ws --ws-port=9090
```

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)