### PR TITLE
fix: mark chat processing as working state

### DIFF
--- a/internal/agent/worker/worker.go
+++ b/internal/agent/worker/worker.go
@@ -172,6 +172,14 @@ func (w *Worker) handleChat(req ChatRequest) {
 	}
 
 	// Available - process normally
+	// Mark as working during chat processing
+	desc := req.Input
+	if len(desc) > 30 {
+		desc = desc[:30] + "..."
+	}
+	w.state.StartTask(desc)
+	defer w.state.CompleteTask()
+
 	prompt := req.Input
 	if w.buildPrompt != nil {
 		prompt = w.buildPrompt(w.name, req.Input)


### PR DESCRIPTION
## Summary
- `handleChat`で`StartTask`/`CompleteTask`を呼び、チャット処理中も`IsWorking()`がtrueを返すようにした
- チャット処理中に別のリクエストが来た場合「今○○の作業中」と即座に返せるようになる
- チャット内容の先頭30文字をタスク説明として使用

## Test plan
- [x] 全テスト通過確認
- [x] gofmt, go vet 問題なし

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)