### PR TITLE
fix: prioritize config.yaml full_name over CLAUDE.md

### DIFF
--- a/internal/member/member.go
+++ b/internal/member/member.go
@@ -49,8 +49,8 @@ func NewMembers(workDir string) *Members {
 		for _, pm := range parsed {
 			key := strings.ToLower(pm.Name)
 			if existing, exists := m.members[key]; exists {
-				// If existing FullName looks like a short name, use FullName from CLAUDE.md
-				if existing.FullName == existing.Name || existing.FullName == key {
+				// Only use FullName from CLAUDE.md if config.yaml didn't provide one
+				if existing.FullName == "" {
 					existing.FullName = pm.FullName
 				}
 			} else {
@@ -66,8 +66,8 @@ func NewMembers(workDir string) *Members {
 		for _, pm := range parsed {
 			key := strings.ToLower(pm.Name)
 			if existing, exists := m.members[key]; exists {
-				// If existing FullName looks like a short name, use FullName from CLAUDE.md
-				if existing.FullName == existing.Name || existing.FullName == key {
+				// Only use FullName from CLAUDE.md if config.yaml didn't provide one
+				if existing.FullName == "" {
 					existing.FullName = pm.FullName
 				}
 			} else {


### PR DESCRIPTION
## Summary
- config.yamlの`full_name`が設定されている場合はそのまま使用
- `full_name`が空の場合のみCLAUDE.mdからフォールバック補完
- config.yamlを正として扱うよう修正

## Test plan
- [x] config.yamlにfull_name設定あり → config.yamlの値が使用される
- [x] config.yamlにfull_name設定なし → CLAUDE.mdから補完される
- [x] オーナーによる動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)