### PR TITLE
feat: maxam init でビルトインデフォルトチームを使用

### DIFF
--- a/cmd/maxam/init.go
+++ b/cmd/maxam/init.go
@@ -27,10 +27,12 @@ func runInit() {
 		os.Exit(1)
 	}
 
-	// 2. Load default team from ~/.maxam/default-team.yaml if exists
+	// 2. Load default team
+	// Priority: ~/.maxam/default-team.yaml > built-in default team
 	defaultTeam, err := loadDefaultTeam()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not load default team: %v\n", err)
+		// No user-defined default team, use built-in
+		defaultTeam = config.BuiltinDefaultTeam()
 	}
 
 	if defaultTeam != nil && len(defaultTeam.Agents) > 0 {
@@ -61,12 +63,8 @@ func runInit() {
 	fmt.Printf("  %s/CLAUDE.md\n", config.ProjectConfigDir(workDir))
 	fmt.Println()
 	fmt.Println("Next steps:")
-	if defaultTeam == nil || len(defaultTeam.Agents) == 0 {
-		fmt.Println("  1. Run 'maxam team init' to set up team members")
-		fmt.Println("  2. Or edit .maxam/config.yaml directly")
-	} else {
-		fmt.Println("  Team is ready! Run 'maxam' to start.")
-	}
+	fmt.Println("  Team is ready! Run 'maxam' to start.")
+	fmt.Println("  To customize the team, edit .maxam/config.yaml")
 }
 
 // loadDefaultTeam loads team configuration from ~/.maxam/default-team.yaml

--- a/cmd/maxam/init_test.go
+++ b/cmd/maxam/init_test.go
@@ -22,13 +22,34 @@ func TestLoadDefaultTeam(t *testing.T) {
 		t.Fatalf("failed to create .maxam dir: %v", err)
 	}
 
-	t.Run("no default-team.yaml", func(t *testing.T) {
+	t.Run("no default-team.yaml returns error", func(t *testing.T) {
 		cfg, err := loadDefaultTeam()
 		if err == nil {
 			t.Error("expected error when no default-team.yaml exists")
 		}
 		if cfg != nil {
 			t.Error("expected nil config when file doesn't exist")
+		}
+	})
+
+	t.Run("fallback to builtin when no default-team.yaml", func(t *testing.T) {
+		// This simulates the actual init behavior
+		cfg, err := loadDefaultTeam()
+		if err != nil {
+			// Expected: no user-defined default team, use built-in
+			cfg = config.BuiltinDefaultTeam()
+		}
+
+		if cfg == nil {
+			t.Fatal("expected builtin team config")
+		}
+
+		if len(cfg.Agents) != 6 {
+			t.Errorf("expected 6 agents from builtin team, got %d", len(cfg.Agents))
+		}
+
+		if cfg.TeamName != "MAXAM" {
+			t.Errorf("expected team name 'MAXAM', got '%s'", cfg.TeamName)
 		}
 	})
 
@@ -114,16 +135,16 @@ func TestInitProjectCreation(t *testing.T) {
 		}
 	})
 
-	t.Run("init with default team loads agents", func(t *testing.T) {
+	t.Run("init with user default-team.yaml takes priority", func(t *testing.T) {
 		tempProject2 := t.TempDir()
 
-		// Create default-team.yaml
+		// Create user-defined default-team.yaml
 		defaultTeam := &config.Config{
 			Version:  "1",
-			TeamName: "Default Team",
+			TeamName: "Custom Team",
 			Agents: []config.AgentConfig{
-				{Name: "mei", FullName: "Mei Chen", Role: "PM"},
-				{Name: "yuki", FullName: "Yuki Tanaka", Role: "Backend"},
+				{Name: "alice", FullName: "Alice Smith", Role: "Developer"},
+				{Name: "bob", FullName: "Bob Jones", Role: "Reviewer"},
 			},
 		}
 
@@ -141,10 +162,19 @@ func TestInitProjectCreation(t *testing.T) {
 			t.Fatalf("failed to initialize project: %v", err)
 		}
 
-		// Load default team and apply
+		// Load default team (should use user-defined, not built-in)
 		team, err := loadDefaultTeam()
 		if err != nil {
 			t.Fatalf("failed to load default team: %v", err)
+		}
+
+		// User-defined team should take priority
+		if team.TeamName != "Custom Team" {
+			t.Errorf("expected 'Custom Team' from user config, got '%s'", team.TeamName)
+		}
+
+		if len(team.Agents) != 2 {
+			t.Errorf("expected 2 agents from user config, got %d", len(team.Agents))
 		}
 
 		projectCfg, err := config.LoadProjectConfig(tempProject2)
@@ -159,7 +189,7 @@ func TestInitProjectCreation(t *testing.T) {
 			t.Fatalf("failed to save project config: %v", err)
 		}
 
-		// Verify agents are saved
+		// Verify user-defined agents are saved
 		savedCfg, err := config.LoadProjectConfig(tempProject2)
 		if err != nil {
 			t.Fatalf("failed to load saved config: %v", err)
@@ -169,8 +199,52 @@ func TestInitProjectCreation(t *testing.T) {
 			t.Errorf("expected 2 agents, got %d", len(savedCfg.Agents))
 		}
 
-		if savedCfg.TeamName != "Default Team" {
-			t.Errorf("expected team name 'Default Team', got '%s'", savedCfg.TeamName)
+		if savedCfg.TeamName != "Custom Team" {
+			t.Errorf("expected team name 'Custom Team', got '%s'", savedCfg.TeamName)
+		}
+	})
+
+	t.Run("init with builtin team when no user config", func(t *testing.T) {
+		tempProject3 := t.TempDir()
+
+		// Remove user-defined default-team.yaml
+		os.Remove(filepath.Join(maxamDir, "default-team.yaml"))
+
+		// Initialize project
+		if err := config.EnsureProjectInitialized(tempProject3); err != nil {
+			t.Fatalf("failed to initialize project: %v", err)
+		}
+
+		// Load default team (should fall back to built-in)
+		team, err := loadDefaultTeam()
+		if err != nil {
+			team = config.BuiltinDefaultTeam()
+		}
+
+		projectCfg, err := config.LoadProjectConfig(tempProject3)
+		if err != nil {
+			t.Fatalf("failed to load project config: %v", err)
+		}
+
+		projectCfg.Agents = team.Agents
+		projectCfg.TeamName = team.TeamName
+
+		if err := config.SaveToProject(tempProject3, projectCfg); err != nil {
+			t.Fatalf("failed to save project config: %v", err)
+		}
+
+		// Verify builtin agents are saved
+		savedCfg, err := config.LoadProjectConfig(tempProject3)
+		if err != nil {
+			t.Fatalf("failed to load saved config: %v", err)
+		}
+
+		if len(savedCfg.Agents) != 6 {
+			t.Errorf("expected 6 agents from builtin, got %d", len(savedCfg.Agents))
+		}
+
+		if savedCfg.TeamName != "MAXAM" {
+			t.Errorf("expected team name 'MAXAM' from builtin, got '%s'", savedCfg.TeamName)
 		}
 	})
 }

--- a/internal/config/builtin_team.go
+++ b/internal/config/builtin_team.go
@@ -1,0 +1,43 @@
+package config
+
+// BuiltinDefaultTeam returns the built-in default team configuration.
+// This is the only place where team members are hardcoded.
+// After maxam init, users customize the generated config.yaml.
+func BuiltinDefaultTeam() *Config {
+	return &Config{
+		Version:  "1",
+		TeamName: "MAXAM",
+		Agents: []AgentConfig{
+			{
+				Name:     "mei",
+				FullName: "Mei Chen",
+				Role:     "PM + Architect",
+			},
+			{
+				Name:     "yuki",
+				FullName: "Yuki Tanaka",
+				Role:     "Backend + Infrastructure",
+			},
+			{
+				Name:     "rin",
+				FullName: "Rin Sato",
+				Role:     "Frontend + Backend",
+			},
+			{
+				Name:     "shiori",
+				FullName: "Shiori Tanaka",
+				Role:     "Test + Documentation",
+			},
+			{
+				Name:     "priya",
+				FullName: "Priya Sharma",
+				Role:     "Review + Security + QA",
+			},
+			{
+				Name:     "amara",
+				FullName: "Amara Okonkwo",
+				Role:     "Analysis + Legal",
+			},
+		},
+	}
+}

--- a/internal/config/builtin_team_test.go
+++ b/internal/config/builtin_team_test.go
@@ -1,0 +1,58 @@
+package config
+
+import "testing"
+
+func TestBuiltinDefaultTeam(t *testing.T) {
+	team := BuiltinDefaultTeam()
+
+	if team == nil {
+		t.Fatal("BuiltinDefaultTeam returned nil")
+	}
+
+	if team.Version != "1" {
+		t.Errorf("expected version '1', got '%s'", team.Version)
+	}
+
+	if team.TeamName != "MAXAM" {
+		t.Errorf("expected team name 'MAXAM', got '%s'", team.TeamName)
+	}
+
+	// 6 agents expected
+	expectedAgents := []struct {
+		name     string
+		fullName string
+		role     string
+	}{
+		{"mei", "Mei Chen", "PM + Architect"},
+		{"yuki", "Yuki Tanaka", "Backend + Infrastructure"},
+		{"rin", "Rin Sato", "Frontend + Backend"},
+		{"shiori", "Shiori Tanaka", "Test + Documentation"},
+		{"priya", "Priya Sharma", "Review + Security + QA"},
+		{"amara", "Amara Okonkwo", "Analysis + Legal"},
+	}
+
+	if len(team.Agents) != len(expectedAgents) {
+		t.Fatalf("expected %d agents, got %d", len(expectedAgents), len(team.Agents))
+	}
+
+	for i, expected := range expectedAgents {
+		agent := team.Agents[i]
+		if agent.Name != expected.name {
+			t.Errorf("agent[%d].Name: expected '%s', got '%s'", i, expected.name, agent.Name)
+		}
+		if agent.FullName != expected.fullName {
+			t.Errorf("agent[%d].FullName: expected '%s', got '%s'", i, expected.fullName, agent.FullName)
+		}
+		if agent.Role != expected.role {
+			t.Errorf("agent[%d].Role: expected '%s', got '%s'", i, expected.role, agent.Role)
+		}
+	}
+}
+
+func TestBuiltinDefaultTeamHasAgents(t *testing.T) {
+	team := BuiltinDefaultTeam()
+
+	if !team.HasAgents() {
+		t.Error("BuiltinDefaultTeam should have agents")
+	}
+}


### PR DESCRIPTION
## Summary
- `maxam init` 実行時に `~/.maxam/default-team.yaml` がなくてもビルトインのデフォルトチーム（Mei, Yuki, Rin, Shiori, Priya, Amara の6人）を使用するようにした
- ユーザー定義の `default-team.yaml` がある場合はそちらを優先
- 生成された `.maxam/config.yaml` をユーザーがカスタマイズして使用する想定

## Test plan
- [x] `go test ./...` 全テスト通過
- [x] `gofmt -l .` フォーマット問題なし
- [x] `go vet ./...` 静的解析問題なし

## Changes
- `internal/config/builtin_team.go` - ビルトインデフォルトチーム定義を追加
- `cmd/maxam/init.go` - `default-team.yaml` がない場合にビルトインを使用
- テストケース追加

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)