### PR TITLE
feat: config caching for performance improvement

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,9 +5,28 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
+
+// Cache for global config (sync.Once pattern)
+var (
+	globalConfigOnce  sync.Once
+	globalConfig      *Config
+	globalConfigError error
+)
+
+// Cache for project configs (keyed by projectDir)
+var (
+	projectConfigMu    sync.RWMutex
+	projectConfigCache = make(map[string]*cachedConfig)
+)
+
+type cachedConfig struct {
+	config *Config
+	err    error
+}
 
 // ContextMode represents the context mode for system prompts
 type ContextMode string
@@ -191,7 +210,16 @@ func ProjectClaudeMD(projectDir string) string {
 }
 
 // Load reads configuration from ~/.maxam/config.yaml
+// Results are cached using sync.Once pattern for performance
 func Load() (*Config, error) {
+	globalConfigOnce.Do(func() {
+		globalConfig, globalConfigError = loadGlobal()
+	})
+	return globalConfig, globalConfigError
+}
+
+// loadGlobal performs the actual file read (called once)
+func loadGlobal() (*Config, error) {
 	configDir, err := ConfigDir()
 	if err != nil {
 		return nil, err
@@ -216,7 +244,28 @@ func Load() (*Config, error) {
 
 // LoadWithProject loads configuration with project-local overrides
 // Priority: project/.maxam/config.yaml > ~/.maxam/config.yaml > default
+// Results are cached per projectDir for performance
 func LoadWithProject(projectDir string) (*Config, error) {
+	// Check cache first
+	projectConfigMu.RLock()
+	if cached, ok := projectConfigCache[projectDir]; ok {
+		projectConfigMu.RUnlock()
+		return cached.config, cached.err
+	}
+	projectConfigMu.RUnlock()
+
+	// Cache miss - load and cache
+	config, err := loadWithProjectUncached(projectDir)
+
+	projectConfigMu.Lock()
+	projectConfigCache[projectDir] = &cachedConfig{config: config, err: err}
+	projectConfigMu.Unlock()
+
+	return config, err
+}
+
+// loadWithProjectUncached performs the actual load (called once per projectDir)
+func loadWithProjectUncached(projectDir string) (*Config, error) {
 	// 1. Start with global config
 	cfg, err := Load()
 	if err != nil {
@@ -572,4 +621,23 @@ func (c *Config) IsWebSocketEnabled() bool {
 		return false
 	}
 	return c.WebSocket.Enabled
+}
+
+// ResetCache clears all cached configurations
+// Intended for testing purposes only
+func ResetCache() {
+	globalConfigOnce = sync.Once{}
+	globalConfig = nil
+	globalConfigError = nil
+
+	projectConfigMu.Lock()
+	projectConfigCache = make(map[string]*cachedConfig)
+	projectConfigMu.Unlock()
+}
+
+// ResetProjectCache clears cached configuration for a specific project
+func ResetProjectCache(projectDir string) {
+	projectConfigMu.Lock()
+	delete(projectConfigCache, projectDir)
+	projectConfigMu.Unlock()
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -399,17 +399,26 @@ func TestProjectClaudeMD(t *testing.T) {
 }
 
 func TestLoadWithProject(t *testing.T) {
+	// Reset cache before test
+	ResetCache()
+
 	// Create temp dirs
 	tmpHome := t.TempDir()
 	projectDir := t.TempDir()
 
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpHome)
-	defer os.Setenv("HOME", originalHome)
+	defer func() {
+		os.Setenv("HOME", originalHome)
+		ResetCache()
+	}()
 
 	// Initialize global config
 	agents, _ := GetEmbeddedAgents()
 	EnsureInitialized(agents)
+
+	// Reset cache to clear initialization load
+	ResetCache()
 
 	// Test 1: No project config - should return global config
 	cfg, err := LoadWithProject(projectDir)
@@ -421,6 +430,9 @@ func TestLoadWithProject(t *testing.T) {
 	}
 
 	// Test 2: With project config - should override
+	// First reset project cache since we're adding a config file
+	ResetProjectCache(projectDir)
+
 	projectMaxamDir := filepath.Join(projectDir, ".maxam")
 	os.MkdirAll(projectMaxamDir, 0755)
 
@@ -1384,5 +1396,185 @@ func TestMergeConfigsMentionChecker(t *testing.T) {
 				t.Errorf("IsMentionCheckerEnabled() = %v, want %v", got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestLoadCaching(t *testing.T) {
+	// Reset cache before test
+	ResetCache()
+
+	tmpHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer func() {
+		os.Setenv("HOME", originalHome)
+		ResetCache()
+	}()
+
+	// Initialize
+	agents, _ := GetEmbeddedAgents()
+	EnsureInitialized(agents)
+
+	// Reset cache to clear initialization load
+	ResetCache()
+
+	// First load
+	cfg1, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	// Second load should return same pointer (cached)
+	cfg2, err := Load()
+	if err != nil {
+		t.Fatalf("Load() second call error: %v", err)
+	}
+
+	if cfg1 != cfg2 {
+		t.Error("Load() should return cached config (same pointer)")
+	}
+}
+
+func TestLoadWithProjectCaching(t *testing.T) {
+	// Reset cache before test
+	ResetCache()
+
+	tmpHome := t.TempDir()
+	projectDir := t.TempDir()
+
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer func() {
+		os.Setenv("HOME", originalHome)
+		ResetCache()
+	}()
+
+	// Initialize
+	agents, _ := GetEmbeddedAgents()
+	EnsureInitialized(agents)
+
+	// First load
+	cfg1, err := LoadWithProject(projectDir)
+	if err != nil {
+		t.Fatalf("LoadWithProject() error: %v", err)
+	}
+
+	// Second load should return same pointer (cached)
+	cfg2, err := LoadWithProject(projectDir)
+	if err != nil {
+		t.Fatalf("LoadWithProject() second call error: %v", err)
+	}
+
+	if cfg1 != cfg2 {
+		t.Error("LoadWithProject() should return cached config (same pointer)")
+	}
+}
+
+func TestResetCache(t *testing.T) {
+	// Reset cache before test
+	ResetCache()
+
+	tmpHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer func() {
+		os.Setenv("HOME", originalHome)
+		ResetCache()
+	}()
+
+	// Initialize
+	agents, _ := GetEmbeddedAgents()
+	EnsureInitialized(agents)
+
+	// Reset cache to clear initialization load
+	ResetCache()
+
+	// Load
+	cfg1, _ := Load()
+
+	// Reset cache
+	ResetCache()
+
+	// Load again - should be different pointer (fresh load)
+	cfg2, _ := Load()
+
+	if cfg1 == cfg2 {
+		t.Error("After ResetCache(), Load() should return different pointer")
+	}
+}
+
+func TestResetProjectCache(t *testing.T) {
+	// Reset cache before test
+	ResetCache()
+
+	tmpHome := t.TempDir()
+	projectDir := t.TempDir()
+
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer func() {
+		os.Setenv("HOME", originalHome)
+		ResetCache()
+	}()
+
+	// Initialize global config
+	agents, _ := GetEmbeddedAgents()
+	EnsureInitialized(agents)
+
+	// Reset cache to clear initialization load
+	ResetCache()
+
+	// Create a project config so we get merged configs
+	projectMaxamDir := filepath.Join(projectDir, ".maxam")
+	os.MkdirAll(projectMaxamDir, 0755)
+	projectConfigContent := `version: "2"`
+	os.WriteFile(filepath.Join(projectMaxamDir, "config.yaml"), []byte(projectConfigContent), 0644)
+
+	// Load project config
+	cfg1, _ := LoadWithProject(projectDir)
+
+	// Reset only project cache
+	ResetProjectCache(projectDir)
+
+	// Load again - should be different pointer (new merged config)
+	cfg2, _ := LoadWithProject(projectDir)
+
+	if cfg1 == cfg2 {
+		t.Error("After ResetProjectCache(), LoadWithProject() should return different pointer")
+	}
+}
+
+func TestCacheDifferentProjects(t *testing.T) {
+	// Reset cache before test
+	ResetCache()
+
+	tmpHome := t.TempDir()
+	projectDir1 := t.TempDir()
+	projectDir2 := t.TempDir()
+
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer func() {
+		os.Setenv("HOME", originalHome)
+		ResetCache()
+	}()
+
+	// Initialize
+	agents, _ := GetEmbeddedAgents()
+	EnsureInitialized(agents)
+
+	// Load for different projects
+	cfg1, _ := LoadWithProject(projectDir1)
+	cfg2, _ := LoadWithProject(projectDir2)
+
+	// Both should be cached independently
+	cfg1Again, _ := LoadWithProject(projectDir1)
+	cfg2Again, _ := LoadWithProject(projectDir2)
+
+	if cfg1 != cfg1Again {
+		t.Error("Project1 config should be cached")
+	}
+	if cfg2 != cfg2Again {
+		t.Error("Project2 config should be cached")
 	}
 }


### PR DESCRIPTION
## Summary
- Config読み込みをキャッシュ化してパフォーマンス改善
- グローバル設定は`sync.Once`パターンで1回のみ読み込み
- プロジェクト設定はprojectDir別にキャッシュ
- テスト用に`ResetCache()`, `ResetProjectCache()`を追加

## Test plan
- [x] `go test ./internal/config/...` パス
- [x] 全テストパス
- [x] キャッシュ動作の確認テスト追加済み

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)