### PR TITLE
feat: ゼロコンフィグでエージェント分身を自動生成

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -448,13 +448,43 @@ func (c *Config) GetAgentByInstanceKey(key string) *AgentConfig {
 }
 
 // GetAgentInstances returns all instances of the specified agent name
+// If no explicit instance_id is configured, automatically generates DefaultMaxInstances instances
 func (c *Config) GetAgentInstances(name string) []AgentConfig {
 	var result []AgentConfig
+	hasExplicitInstance := false
+
 	for _, agent := range c.Agents {
 		if agent.Name == name {
 			result = append(result, agent)
+			if agent.InstanceID != "" {
+				hasExplicitInstance = true
+			}
 		}
 	}
+
+	// If no instances found, return empty
+	if len(result) == 0 {
+		return result
+	}
+
+	// If explicit instance_ids are configured, use as-is
+	if hasExplicitInstance {
+		return result
+	}
+
+	// Auto-generate instances based on DefaultMaxInstances
+	// Take the first (and only) agent as base
+	base := result[0]
+	result = nil // reset
+
+	for i := 0; i < DefaultMaxInstances; i++ {
+		instance := base
+		if i > 0 {
+			instance.InstanceID = fmt.Sprintf("%d", i)
+		}
+		result = append(result, instance)
+	}
+
 	return result
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1089,9 +1089,9 @@ func TestGetAgentInstances(t *testing.T) {
 			expectedCount: 3,
 		},
 		{
-			name:          "meiは1インスタンス",
+			name:          "meiは自動で3インスタンス",
 			agentName:     "mei",
-			expectedCount: 1,
+			expectedCount: DefaultMaxInstances, // 明示的instance_idがなければ自動生成
 		},
 		{
 			name:          "存在しないエージェントは0",
@@ -1108,6 +1108,18 @@ func TestGetAgentInstances(t *testing.T) {
 			}
 		})
 	}
+
+	// 自動生成されたインスタンスのキー確認
+	t.Run("自動生成インスタンスのキー", func(t *testing.T) {
+		instances := cfg.GetAgentInstances("mei")
+		expectedKeys := []string{"mei", "mei-1", "mei-2"}
+		for i, inst := range instances {
+			key := inst.GetInstanceKey()
+			if key != expectedKeys[i] {
+				t.Errorf("instance[%d] key = %q, want %q", i, key, expectedKeys[i])
+			}
+		}
+	})
 }
 
 func TestGetAllInstanceKeys(t *testing.T) {


### PR DESCRIPTION
## Summary
- エージェント定義に明示的な`instance_id`がない場合、`DefaultMaxInstances`（3）分のインスタンスを自動生成
- 設定なしで分身が義務化される

## Changes
- `GetAgentInstances()`: 明示的設定がない場合に自動でインスタンス生成
- 最初のインスタンスは元のキー（例: `yuki`）
- 2番目以降は `yuki-1`, `yuki-2` と自動付与

## Test plan
- [x] `go test ./internal/config/...` 全件パス
- [x] 自動生成インスタンスのキー確認テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)