### PR TITLE
fix: 自己メンション禁止ルールをプロンプトに追加

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -1633,7 +1633,8 @@ func (m *tuiModel) buildPrompt(agentName, input string) string {
 	sb.WriteString("- 作業前に計画を説明し、OKをもらってから進めてください\n")
 	sb.WriteString("- 短く自然な会話で返答してください\n")
 	sb.WriteString("- 他のメンバーに作業を依頼するときは「@名前」で呼びかけてください\n")
-	sb.WriteString("- 呼びかけられたら、その依頼に応答してください\n\n")
+	sb.WriteString("- 呼びかけられたら、その依頼に応答してください\n")
+	sb.WriteString("- 自分自身にはメンションしない（例: 自分がMeiなら @Mei は使わない）\n\n")
 
 	// Add project context (初回のみフル、以降は要約)
 	if m.projectContext != "" {


### PR DESCRIPTION
## Summary
- プロンプト生成部分に「自分自身にはメンションしない」ルールを追加
- 例: 自分がMeiなら @Mei は使わない

## Changes
- `cmd/maxam/tui.go`: `buildPrompt`関数の「重要:」セクションに1行追加

## Test plan
- [x] `go test ./cmd/maxam/...` → PASS

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)