### PR TITLE
feat: smart history trimming for context overflow prevention

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -1675,13 +1675,69 @@ func (m *tuiModel) buildPrompt(agentName, input string) string {
 
 	prompt := sb.String()
 
-	// Check context size and update warning
+	// Smart truncation: contextMonitor.ShouldTruncate() を使用
+	// コンテキストが95%以上に達した場合、履歴を再度圧縮
 	if m.contextMonitor != nil {
 		status := m.contextMonitor.Check(len(prompt))
 		if status.Level >= contextmon.LevelWarning {
 			m.contextWarning = status.FormatWarning()
 		} else {
 			m.contextWarning = ""
+		}
+
+		// 95% 超過時は履歴を4件に削減して再構築
+		if m.contextMonitor.ShouldTruncate(len(prompt)) && len(m.messages) > 0 {
+			sb.Reset()
+			// ヘッダーを再構築
+			sb.WriteString("これはチームチャットです。オーナーやチームメンバーと自然に会話してください。\n\n")
+			sb.WriteString("チームメンバー:\n")
+			for i, agentCfg := range m.config.Agents {
+				marker := ""
+				if m.config.DefaultAgent == agentCfg.Name || (m.config.DefaultAgent == "" && i == 0) {
+					marker = "（デフォルト応答者）"
+				}
+				sb.WriteString(fmt.Sprintf("- %s: %s%s\n", m.members.GetFullName(agentCfg.Name), agentCfg.Role, marker))
+			}
+			sb.WriteString("\n重要:\n")
+			sb.WriteString("- 情報が不足していたら質問してください\n")
+			sb.WriteString("- 曖昧な指示には確認を取ってください\n")
+			sb.WriteString("- 作業前に計画を説明し、OKをもらってから進めてください\n")
+			sb.WriteString("- 短く自然な会話で返答してください\n")
+			sb.WriteString("- 他のメンバーに作業を依頼するときは「@名前」で呼びかけてください\n")
+			sb.WriteString("- 呼びかけられたら、その依頼に応答してください\n")
+			sb.WriteString("- 自分自身にはメンションしない（例: 自分がMeiなら @Mei は使わない）\n\n")
+
+			if m.projectContext != "" && !m.projectContextSent {
+				sb.WriteString(m.projectContext)
+				sb.WriteString("\n")
+			} else if m.projectContext != "" {
+				sb.WriteString(fmt.Sprintf("## プロジェクト情報\n\n作業ディレクトリ: %s\n\n", m.workDir))
+			}
+
+			sb.WriteString("## 会話履歴（圧縮）\n\n")
+			// 履歴を4件に削減
+			compressedMessages := m.selectHistoryMessagesWithLimit(4)
+			for _, msg := range compressedMessages {
+				if msg.role == "user" {
+					sb.WriteString(fmt.Sprintf("オーナー: %s\n\n", msg.content))
+				} else {
+					sb.WriteString(fmt.Sprintf("%s: %s\n\n", m.getFullName(msg.role), msg.content))
+				}
+			}
+
+			// Trim persisted history to prevent future overflows
+			if m.history != nil {
+				_ = m.history.TrimToSize(len(compressedMessages) * 2) // Keep slightly more than displayed
+			}
+
+			sb.WriteString("## 今のメッセージ\n\n")
+			if lastRole != "user" {
+				sb.WriteString(fmt.Sprintf("%s からあなたへ: %s\n", m.getFullName(lastRole), input))
+			} else {
+				sb.WriteString(fmt.Sprintf("オーナー: %s\n", input))
+			}
+
+			prompt = sb.String()
 		}
 	}
 
@@ -1690,13 +1746,22 @@ func (m *tuiModel) buildPrompt(agentName, input string) string {
 
 // selectHistoryMessages は履歴メッセージを動的に選択
 // メッセージ長に応じて数を調整し、雑談は除外
+// maxCount を 0 以下にすると自動判定（8件またはコンテキストサイズベース）
 func (m *tuiModel) selectHistoryMessages() []tuiMessage {
+	return m.selectHistoryMessagesWithLimit(0)
+}
+
+// selectHistoryMessagesWithLimit は履歴メッセージを指定数まで選択
+func (m *tuiModel) selectHistoryMessagesWithLimit(maxCount int) []tuiMessage {
 	if len(m.messages) == 0 {
 		return nil
 	}
 
-	// 基本は8件、メッセージ長によって調整
+	// 基本は8件、maxCount が指定されていればそちらを使用
 	baseCount := 8
+	if maxCount > 0 {
+		baseCount = maxCount
+	}
 	totalChars := 0
 	const maxChars = 8000 // 目安の上限
 

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -130,3 +130,19 @@ func (h *History) save() error {
 func (h *History) Path() string {
 	return h.filePath
 }
+
+// TrimToSize trims the message history to the specified count
+// Keeps the most recent `count` messages
+func (h *History) TrimToSize(count int) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if count <= 0 {
+		h.Messages = make([]Message, 0)
+	} else if len(h.Messages) > count {
+		h.Messages = h.Messages[len(h.Messages)-count:]
+	}
+
+	h.UpdatedAt = time.Now()
+	return h.save()
+}

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -159,3 +159,80 @@ func TestDefaultPath(t *testing.T) {
 		t.Errorf("Path() = %s, want %s", h.Path(), expected)
 	}
 }
+
+func TestTrimToSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test_history.json")
+
+	h, err := New(path)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	// Add 10 messages
+	for i := 0; i < 10; i++ {
+		h.Add("user", "message "+string(rune('0'+i)))
+	}
+
+	// Trim to 4 messages
+	if err := h.TrimToSize(4); err != nil {
+		t.Fatalf("TrimToSize() error: %v", err)
+	}
+
+	msgs := h.GetAll()
+	if len(msgs) != 4 {
+		t.Errorf("After TrimToSize(4), len = %d, want 4", len(msgs))
+	}
+
+	// Verify persistence
+	h2, err := New(path)
+	if err != nil {
+		t.Fatalf("New() reload error: %v", err)
+	}
+
+	msgs2 := h2.GetAll()
+	if len(msgs2) != 4 {
+		t.Errorf("After reload, len = %d, want 4", len(msgs2))
+	}
+
+	// Verify it kept the most recent messages
+	if msgs2[3].Content != "message 9" {
+		t.Errorf("Last message = %s, want 'message 9'", msgs2[3].Content)
+	}
+}
+
+func TestTrimToSizeEdgeCases(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test_history.json")
+
+	h, err := New(path)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	h.Add("user", "msg1")
+	h.Add("user", "msg2")
+
+	// Trim with count=0 (clear all)
+	if err := h.TrimToSize(0); err != nil {
+		t.Fatalf("TrimToSize(0) error: %v", err)
+	}
+
+	msgs := h.GetAll()
+	if len(msgs) != 0 {
+		t.Errorf("After TrimToSize(0), len = %d, want 0", len(msgs))
+	}
+
+	h.Add("user", "msg1")
+	h.Add("user", "msg2")
+
+	// Trim with count > current size (no change)
+	if err := h.TrimToSize(100); err != nil {
+		t.Fatalf("TrimToSize(100) error: %v", err)
+	}
+
+	msgs = h.GetAll()
+	if len(msgs) != 2 {
+		t.Errorf("After TrimToSize(100), len = %d, want 2", len(msgs))
+	}
+}


### PR DESCRIPTION
## Summary

- コンテキストサイズが95%閾値超過時に履歴を自動圧縮
- 永続化履歴もトリミングして将来のオーバーフローを防止
- ユーザーに警告を表示

## Changes

1. `tui.go` - buildPrompt()でShouldTruncate()チェック追加
2. `history.go` - TrimToSize()メソッド追加
3. `history_test.go` - テストケース追加

## Test plan

- [x] `go test ./internal/history/...` - PASS
- [x] `go test ./internal/contextmon/...` - PASS
- [x] `go vet ./cmd/maxam/...` - OK

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)