### PR TITLE
feat: add kill command for force-terminating runaway agents

### DIFF
--- a/internal/agent/control/handler.go
+++ b/internal/agent/control/handler.go
@@ -44,6 +44,8 @@ func (h *Handler) Handle(input string) *Result {
 		return h.handleStopAll()
 	case CommandResumeAll:
 		return h.handleResumeAll()
+	case CommandKill:
+		return h.handleKill(cmd.Target)
 	default:
 		return &Result{Success: false, Message: "不明なコマンドです"}
 	}
@@ -70,15 +72,24 @@ func (h *Handler) handleStop(target string) *Result {
 }
 
 // handleResume handles a resume command for a specific agent
+// If the agent was killed (context canceled), it will be restarted
 func (h *Handler) handleResume(target string) *Result {
 	// Case-insensitive agent name lookup
 	targetLower := strings.ToLower(target)
 	for _, name := range h.pool.All() {
 		if strings.ToLower(name) == targetLower {
+			// Try regular resume first
 			if h.pool.Resume(name) {
 				return &Result{
 					Success: true,
 					Message: fmt.Sprintf("%s を再開しました", name),
+				}
+			}
+			// If resume failed, try restart (for killed agents)
+			if h.pool.Restart(name) {
+				return &Result{
+					Success: true,
+					Message: fmt.Sprintf("%s を再起動しました", name),
 				}
 			}
 		}
@@ -104,6 +115,26 @@ func (h *Handler) handleResumeAll() *Result {
 	return &Result{
 		Success: true,
 		Message: "全エージェントを再開しました",
+	}
+}
+
+// handleKill handles a kill command for a specific agent
+func (h *Handler) handleKill(target string) *Result {
+	// Case-insensitive agent name lookup
+	targetLower := strings.ToLower(target)
+	for _, name := range h.pool.All() {
+		if strings.ToLower(name) == targetLower {
+			if h.pool.Kill(name) {
+				return &Result{
+					Success: true,
+					Message: fmt.Sprintf("⚠️ %s を強制終了しました。再起動するには @%s resume を実行してください。", name, name),
+				}
+			}
+		}
+	}
+	return &Result{
+		Success: false,
+		Message: fmt.Sprintf("エージェント '%s' が見つかりません", target),
 	}
 }
 

--- a/internal/agent/control/parser.go
+++ b/internal/agent/control/parser.go
@@ -19,6 +19,8 @@ const (
 	CommandStopAll
 	// CommandResumeAll represents a resume all command
 	CommandResumeAll
+	// CommandKill represents a force kill command
+	CommandKill
 )
 
 func (c CommandType) String() string {
@@ -31,6 +33,8 @@ func (c CommandType) String() string {
 		return "stop_all"
 	case CommandResumeAll:
 		return "resume_all"
+	case CommandKill:
+		return "kill"
 	default:
 		return "unknown"
 	}
@@ -53,8 +57,8 @@ type Parser struct {
 // NewParser creates a new control command parser
 func NewParser() *Parser {
 	return &Parser{
-		// Match @agentname stop or @agentname resume (case insensitive)
-		mentionPattern: regexp.MustCompile(`(?i)^@(\w+)\s+(stop|resume)\s*$`),
+		// Match @agentname stop, @agentname resume, or @agentname kill (case insensitive)
+		mentionPattern: regexp.MustCompile(`(?i)^@(\w+)\s+(stop|resume|kill)\s*$`),
 		// Match "stop all" or "resume all" (case insensitive)
 		globalPattern: regexp.MustCompile(`(?i)^(stop|resume)\s+all\s*$`),
 	}
@@ -73,14 +77,18 @@ func (p *Parser) Parse(input string) *Command {
 		return &Command{Type: CommandResumeAll}
 	}
 
-	// Check for mention commands (@agent stop, @agent resume)
+	// Check for mention commands (@agent stop, @agent resume, @agent kill)
 	if matches := p.mentionPattern.FindStringSubmatch(input); len(matches) == 3 {
 		target := matches[1]
 		action := strings.ToLower(matches[2])
-		if action == "stop" {
+		switch action {
+		case "stop":
 			return &Command{Type: CommandStop, Target: target}
+		case "resume":
+			return &Command{Type: CommandResume, Target: target}
+		case "kill":
+			return &Command{Type: CommandKill, Target: target}
 		}
-		return &Command{Type: CommandResume, Target: target}
 	}
 
 	return nil

--- a/internal/agent/control/parser_test.go
+++ b/internal/agent/control/parser_test.go
@@ -84,6 +84,25 @@ func TestParser_Parse(t *testing.T) {
 			wantType: CommandResumeAll,
 			wantTgt:  "",
 		},
+		// Individual kill commands
+		{
+			name:     "kill agent with @mention",
+			input:    "@yuki kill",
+			wantType: CommandKill,
+			wantTgt:  "yuki",
+		},
+		{
+			name:     "kill agent uppercase",
+			input:    "@PRIYA KILL",
+			wantType: CommandKill,
+			wantTgt:  "PRIYA",
+		},
+		{
+			name:     "kill agent mixed case",
+			input:    "@Mei Kill",
+			wantType: CommandKill,
+			wantTgt:  "Mei",
+		},
 		// Non-control commands (should return nil)
 		{
 			name:    "regular message",
@@ -163,6 +182,7 @@ func TestParser_IsControlCommand(t *testing.T) {
 	}{
 		{"@yuki stop", true},
 		{"@yuki resume", true},
+		{"@yuki kill", true},
 		{"stop all", true},
 		{"resume all", true},
 		{"hello world", false},
@@ -189,6 +209,7 @@ func TestCommandType_String(t *testing.T) {
 		{CommandResume, "resume"},
 		{CommandStopAll, "stop_all"},
 		{CommandResumeAll, "resume_all"},
+		{CommandKill, "kill"},
 		{CommandUnknown, "unknown"},
 		{CommandType(99), "unknown"},
 	}

--- a/internal/agent/worker/state.go
+++ b/internal/agent/worker/state.go
@@ -136,6 +136,16 @@ func (s *AgentState) Resume() {
 	}
 }
 
+// ForceStop immediately sets state to stopped regardless of current state
+func (s *AgentState) ForceStop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.state = StateStopped
+	s.stopRequested = false
+	s.currentTask = ""
+	s.startedAt = time.Time{}
+}
+
 // GetStatus returns a human-readable status message
 func (s *AgentState) GetStatus() string {
 	s.mu.RLock()

--- a/internal/agent/worker/worker.go
+++ b/internal/agent/worker/worker.go
@@ -112,6 +112,13 @@ func (w *Worker) IsStopped() bool {
 	return w.state.IsStopped()
 }
 
+// Kill forcefully terminates the worker by canceling its context
+// This immediately stops any ongoing work without waiting for completion
+func (w *Worker) Kill() {
+	w.cancel()
+	w.state.ForceStop()
+}
+
 // SendChat sends a chat request and returns immediately
 // The response will be sent to the provided channel
 func (w *Worker) SendChat(input string, response chan<- ChatResponse) {
@@ -376,4 +383,36 @@ func (p *Pool) GetStoppedWorkers() []string {
 		}
 	}
 	return stopped
+}
+
+// Kill forcefully terminates a specific worker by name
+// Returns true if the worker was found and killed
+func (p *Pool) Kill(name string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if w, ok := p.workers[name]; ok {
+		w.Kill()
+		return true
+	}
+	return false
+}
+
+// Restart restarts a killed worker by creating a new context
+func (p *Pool) Restart(name string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if w, ok := p.workers[name]; ok {
+		// Create new context and restart goroutines
+		ctx, cancel := context.WithCancel(context.Background())
+		w.ctx = ctx
+		w.cancel = cancel
+		w.chatChan = make(chan ChatRequest, 10)
+		w.taskChan = make(chan TaskRequest, 10)
+		w.state.Resume()
+		w.wg.Add(2)
+		go w.chatLoop()
+		go w.taskLoop()
+		return true
+	}
+	return false
 }

--- a/internal/agent/worker/worker_test.go
+++ b/internal/agent/worker/worker_test.go
@@ -255,6 +255,87 @@ func TestWorkerChatWhileStopped(t *testing.T) {
 	})
 }
 
+func TestAgentState_ForceStop(t *testing.T) {
+	t.Run("force stop while available", func(t *testing.T) {
+		state := NewAgentState()
+		state.ForceStop()
+
+		if !state.IsStopped() {
+			t.Error("expected state to be stopped after ForceStop")
+		}
+	})
+
+	t.Run("force stop while working immediately stops", func(t *testing.T) {
+		state := NewAgentState()
+		state.StartTask("doing work")
+		state.ForceStop()
+
+		if !state.IsStopped() {
+			t.Error("expected state to be stopped after ForceStop while working")
+		}
+		if state.GetCurrentTask() != "" {
+			t.Error("expected current task to be cleared after ForceStop")
+		}
+	})
+
+	t.Run("force stop clears task duration", func(t *testing.T) {
+		state := NewAgentState()
+		state.StartTask("doing work")
+		state.ForceStop()
+
+		if state.GetTaskDuration() != 0 {
+			t.Error("expected task duration to be 0 after ForceStop")
+		}
+	})
+}
+
+func TestPool_Kill(t *testing.T) {
+	t.Run("kill worker", func(t *testing.T) {
+		pool := NewPool()
+		w := NewWorker("yuki", nil)
+		w.Start()
+		pool.Add(w)
+
+		ok := pool.Kill("yuki")
+		if !ok {
+			t.Error("expected Kill to return true")
+		}
+		if !w.IsStopped() {
+			t.Error("expected worker to be stopped after Kill")
+		}
+	})
+
+	t.Run("kill non-existent worker returns false", func(t *testing.T) {
+		pool := NewPool()
+
+		if pool.Kill("nonexistent") {
+			t.Error("expected Kill to return false for non-existent worker")
+		}
+	})
+
+	t.Run("restart killed worker", func(t *testing.T) {
+		pool := NewPool()
+		w := NewWorker("yuki", nil)
+		w.Start()
+		pool.Add(w)
+
+		// Kill the worker
+		pool.Kill("yuki")
+		if !w.IsStopped() {
+			t.Error("precondition failed: worker should be stopped after kill")
+		}
+
+		// Restart it
+		ok := pool.Restart("yuki")
+		if !ok {
+			t.Error("expected Restart to return true")
+		}
+		if w.IsStopped() {
+			t.Error("expected worker to not be stopped after Restart")
+		}
+	})
+}
+
 func TestPool(t *testing.T) {
 	t.Run("add and get worker", func(t *testing.T) {
 		pool := NewPool()


### PR DESCRIPTION
## Summary
- `@agent kill` で暴走エージェントを強制終了
- `@agent resume` で強制終了したエージェントを再起動
- context cancelによる即時停止

## 変更ファイル
- `internal/agent/control/parser.go` - killコマンドのパース追加
- `internal/agent/control/handler.go` - killハンドラ追加
- `internal/agent/worker/state.go` - ForceStop追加
- `internal/agent/worker/worker.go` - Kill/Restart追加

## Test plan
- [x] `go test ./internal/agent/control/...` 通過
- [x] `go test ./internal/agent/worker/...` 通過
- [x] `go test ./...` 全テスト通過

## 使い方
```
@yuki kill    # yukiを強制終了
@yuki resume  # yukiを再起動
```

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)