### PR TITLE
test: add skeleton tests for #277 process monitoring

### DIFF
--- a/internal/healthmgr/processinfo_test.go
+++ b/internal/healthmgr/processinfo_test.go
@@ -1,0 +1,338 @@
+package healthmgr
+
+import (
+	"sync"
+	"testing"
+)
+
+// =============================================================================
+// Test Data and Mocks
+// =============================================================================
+
+// TODO: #277 実装後に gopsutil のモックを追加
+// type MockProcess struct {
+// 	cpuPercent func() (float64, error)
+// 	memInfo    func() (*process.MemoryInfoStat, error)
+// 	children   func() ([]*process.Process, error)
+// }
+
+// =============================================================================
+// ProcessInfo 構造体テスト
+// =============================================================================
+
+func TestProcessInfo_StructDefinition(t *testing.T) {
+	// TODO: #277 実装後にテストを有効化
+	t.Skip("Waiting for #277 implementation: ProcessInfo struct not yet defined")
+
+	// ProcessInfo 構造体が正しく定義されているか確認
+	// Issue #277 で定義される予定の構造体:
+	// type ProcessInfo struct {
+	//     PID      int
+	//     CPUUsage float64
+	//     MemUsage uint64
+	//     Children []int
+	// }
+}
+
+// =============================================================================
+// 正常系テスト - プロセス情報の取得
+// =============================================================================
+
+func TestProcessInfo_GetProcessInfo_Success(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #1: プロセス情報の初回取得
+	// 期待: CPU使用率、メモリ使用量、子プロセス一覧が取得できる
+}
+
+func TestProcessInfo_PeriodicUpdate(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #2: 5秒間隔で定期取得
+	// 期待: heartbeat に同期して情報が更新される
+}
+
+// =============================================================================
+// 履歴管理テスト（リングバッファ）
+// =============================================================================
+
+func TestProcessInfo_History_Accumulation(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #3: 履歴の蓄積（リングバッファ）
+	// 期待: 直近5件が保持される
+}
+
+func TestProcessInfo_History_Overflow(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #4: 6件目以降の取得
+	// 期待: 最古の履歴が押し出され、5件を維持
+}
+
+func TestProcessInfo_MultipleAgents(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #5: 複数エージェントの並行監視
+	// 期待: 各エージェント独立して情報取得
+}
+
+// =============================================================================
+// 異常系・エッジケーステスト
+// =============================================================================
+
+func TestProcessInfo_Error_InvalidPID(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #6: プロセスが存在しない（PID不正）
+	// 期待: エラーハンドリング、ステータス反映
+}
+
+func TestProcessInfo_Error_ProcessTerminated(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #7: プロセスが監視中に終了
+	// 期待: 終了を検知、適切なステータス更新
+}
+
+func TestProcessInfo_ManyChildProcesses(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #8: 子プロセスが大量にある
+	// 期待: 性能影響なく取得できる
+}
+
+func TestProcessInfo_HighCPUUsage(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #9: CPU使用率が100%に張り付き
+	// 期待: 正しく取得（異常検知の入力として）
+}
+
+func TestProcessInfo_MemorySpike(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #10: メモリ使用量が急増
+	// 期待: 値の変化を正しく追跡
+}
+
+func TestProcessInfo_Error_GopsutilFailure(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #11: gopsutil がエラーを返す
+	// 期待: ベストエフォートで処理継続
+}
+
+func TestProcessInfo_Error_PermissionDenied(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #12: 権限不足でプロセス情報取得失敗
+	// 期待: 適切なエラーメッセージ
+}
+
+// =============================================================================
+// 境界値テスト
+// =============================================================================
+
+func TestProcessInfo_Boundary_EmptyHistory(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #13: 履歴0件の状態で取得リクエスト
+	// 期待: 空配列を返す（panicしない）
+}
+
+func TestProcessInfo_Boundary_ZeroCPU(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #14: CPU使用率 0%
+	// 期待: 正常に記録
+}
+
+func TestProcessInfo_Boundary_ZeroMemory(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #15: メモリ使用量 0 bytes
+	// 期待: 正常に記録
+}
+
+func TestProcessInfo_Boundary_NoChildren(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #16: 子プロセス 0件
+	// 期待: 空スライスを返す
+}
+
+// =============================================================================
+// 並行性テスト
+// =============================================================================
+
+func TestProcessInfo_Concurrent_MultipleReaders(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #17: 複数goroutineから同時読み取り
+	// 期待: race conditionなし
+
+	// テスト構造（実装後に有効化）:
+	// var wg sync.WaitGroup
+	// for i := 0; i < 10; i++ {
+	//     wg.Add(1)
+	//     go func() {
+	//         defer wg.Done()
+	//         // GetProcessInfo() を並行呼び出し
+	//     }()
+	// }
+	// wg.Wait()
+	_ = sync.WaitGroup{} // unused警告回避
+}
+
+func TestProcessInfo_Concurrent_ReadWhileWrite(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #18: 読み取り中に更新
+	// 期待: データ整合性が保たれる
+}
+
+func TestProcessInfo_Integration_WithManager(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #19: Manager と ProcessInfo の連携
+	// 期待: 既存のmutexパターンと整合
+}
+
+// =============================================================================
+// 統合テスト観点
+// =============================================================================
+
+func TestProcessInfo_Integration_HealthStructure(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #20: healthmgr との統合
+	// 期待: Health 構造体に ProcessInfo が含まれる
+}
+
+func TestProcessInfo_Integration_HeartbeatSync(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テストケース #21: heartbeat 5秒間隔との同期
+	// 期待: タイミングが正しく連携
+}
+
+// =============================================================================
+// テーブル駆動テスト（実装後に使用）
+// =============================================================================
+
+func TestProcessInfo_TableDriven_GetInfo(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// テーブル駆動テストの構造:
+	tests := []struct {
+		name        string
+		setupFn     func() // モックのセットアップ
+		wantCPU     float64
+		wantMem     uint64
+		wantChildN  int
+		wantErr     bool
+		description string
+	}{
+		{
+			name:        "normal process",
+			wantCPU:     25.5,
+			wantMem:     1024 * 1024 * 100, // 100MB
+			wantChildN:  3,
+			wantErr:     false,
+			description: "正常なプロセス情報の取得",
+		},
+		{
+			name:        "idle process",
+			wantCPU:     0.0,
+			wantMem:     1024 * 1024, // 1MB
+			wantChildN:  0,
+			wantErr:     false,
+			description: "アイドル状態のプロセス",
+		},
+		{
+			name:        "high load",
+			wantCPU:     99.9,
+			wantMem:     1024 * 1024 * 1024, // 1GB
+			wantChildN:  50,
+			wantErr:     false,
+			description: "高負荷状態のプロセス",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 実装後にテストロジックを追加
+			_ = tt.description // unused警告回避
+		})
+	}
+}
+
+func TestProcessInfo_TableDriven_History(t *testing.T) {
+	t.Skip("Waiting for #277 implementation")
+
+	// リングバッファのテーブル駆動テスト
+	tests := []struct {
+		name       string
+		addCount   int  // 追加する履歴の数
+		wantLen    int  // 期待する履歴の長さ
+		wantOldest int  // 期待する最古のインデックス
+	}{
+		{
+			name:       "empty",
+			addCount:   0,
+			wantLen:    0,
+			wantOldest: -1,
+		},
+		{
+			name:       "partial fill",
+			addCount:   3,
+			wantLen:    3,
+			wantOldest: 0,
+		},
+		{
+			name:       "exact fill",
+			addCount:   5,
+			wantLen:    5,
+			wantOldest: 0,
+		},
+		{
+			name:       "overflow once",
+			addCount:   6,
+			wantLen:    5,
+			wantOldest: 1, // 最初のエントリが押し出される
+		},
+		{
+			name:       "overflow multiple",
+			addCount:   10,
+			wantLen:    5,
+			wantOldest: 5, // 最初の5件が押し出される
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 実装後にテストロジックを追加
+			_ = tt.wantOldest // unused警告回避
+		})
+	}
+}
+
+// =============================================================================
+// ベンチマーク（オプション）
+// =============================================================================
+
+func BenchmarkProcessInfo_GetInfo(b *testing.B) {
+	b.Skip("Waiting for #277 implementation")
+
+	// gopsutil 呼び出しのパフォーマンス計測
+	// for i := 0; i < b.N; i++ {
+	//     // GetProcessInfo()
+	// }
+}
+
+func BenchmarkProcessInfo_HistoryWrite(b *testing.B) {
+	b.Skip("Waiting for #277 implementation")
+
+	// リングバッファへの書き込みパフォーマンス
+}


### PR DESCRIPTION
## Summary

- #277 プロセス監視機能の実装に先立ち、テストスケルトンを追加
- 全テストは `t.Skip()` でスキップ状態（実装待ち）
- 21件のテストケース + テーブル駆動テスト + ベンチマーク

## テストカバレッジ設計

### 正常系（5件）
- プロセス情報の初回取得
- 5秒間隔での定期取得
- リングバッファへの履歴蓄積
- オーバーフロー時の挙動（6件目以降）
- 複数エージェントの並行監視

### 異常系・エッジケース（7件）
- 無効なPID
- 監視中のプロセス終了
- 大量の子プロセス
- CPU 100%張り付き
- メモリ急増
- gopsutilエラー
- 権限不足

### 境界値（4件）
- 空の履歴
- CPU 0%
- メモリ 0bytes
- 子プロセス 0件

### 並行性（3件）
- 複数goroutineからの同時読み取り
- 読み取り中の更新
- Manager との連携

### 統合観点（2件）
- Health構造体との統合
- heartbeat 5秒間隔との同期

## Test plan

- [x] `go build ./internal/healthmgr/...` → ビルド成功
- [x] `go test ./internal/healthmgr/...` → 既存テストパス（新規テストはSkip）

## Related

- Related #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)