### PR TITLE
fix: race condition in TUIClient and procmgr

### DIFF
--- a/internal/procmgr/procmgr.go
+++ b/internal/procmgr/procmgr.go
@@ -90,6 +90,9 @@ type ManagedProcess struct {
 	cancel       context.CancelFunc
 	onExit       func(name string, err error)
 	restartDelay time.Duration
+	waitOnce     sync.Once
+	waitErr      error
+	waitDone     chan struct{}
 }
 
 // Start starts a new process with the given configuration.
@@ -135,6 +138,7 @@ func (m *Manager) startProcess(cfg ProcessConfig) (*ManagedProcess, error) {
 		ctx:          ctx,
 		cancel:       cancel,
 		restartDelay: 5 * time.Second, // Default delay between restarts
+		waitDone:     make(chan struct{}),
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -156,15 +160,19 @@ func (m *Manager) startProcess(cfg ProcessConfig) (*ManagedProcess, error) {
 
 // monitor watches the process and handles exit.
 func (p *ManagedProcess) monitor() {
-	err := p.cmd.Wait()
+	p.waitOnce.Do(func() {
+		p.waitErr = p.cmd.Wait()
+		close(p.waitDone)
+	})
 
 	p.mu.Lock()
 	p.info.State = StateStopped
-	p.info.LastError = err
+	p.info.LastError = p.waitErr
+	handler := p.onExit
 	p.mu.Unlock()
 
-	if p.onExit != nil {
-		p.onExit(p.config.Name, err)
+	if handler != nil {
+		handler(p.config.Name, p.waitErr)
 	}
 }
 
@@ -184,9 +192,9 @@ func (m *Manager) Stop(name string) error {
 // stop stops the process gracefully.
 func (p *ManagedProcess) stop() error {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 
 	if p.info.State != StateRunning {
+		p.mu.Unlock()
 		return nil
 	}
 
@@ -195,28 +203,31 @@ func (p *ManagedProcess) stop() error {
 		if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil {
 			// Process might already be dead
 			if !errors.Is(err, os.ErrProcessDone) {
+				p.mu.Unlock()
 				return fmt.Errorf("failed to send SIGTERM: %w", err)
 			}
 		}
 	}
 
-	// Wait a bit for graceful shutdown
-	done := make(chan struct{})
-	go func() {
-		p.cmd.Wait()
-		close(done)
-	}()
+	// Release lock before waiting to avoid blocking
+	waitDone := p.waitDone
+	p.mu.Unlock()
 
+	// Wait for process to exit (monitor goroutine will close waitDone)
 	select {
-	case <-done:
+	case <-waitDone:
+		p.mu.Lock()
 		p.info.State = StateStopped
+		p.mu.Unlock()
 		return nil
 	case <-time.After(5 * time.Second):
 		// Force kill
+		p.mu.Lock()
 		if p.cmd.Process != nil {
 			p.cmd.Process.Kill()
 		}
 		p.info.State = StateStopped
+		p.mu.Unlock()
 		return nil
 	}
 }

--- a/internal/ws/tuiclient.go
+++ b/internal/ws/tuiclient.go
@@ -18,6 +18,7 @@ type TUIClient struct {
 	clientID      string
 	conn          *websocket.Conn
 	mu            sync.RWMutex
+	writeMu       sync.Mutex // protects concurrent WriteMessage calls
 	connected     atomic.Bool
 	incoming      chan *Message
 	outgoing      chan *Message
@@ -62,17 +63,23 @@ func NewTUIClient(cfg TUIClientConfig) *TUIClient {
 
 // SetMessageHandler sets the callback for incoming messages
 func (c *TUIClient) SetMessageHandler(handler func(*Message)) {
+	c.mu.Lock()
 	c.onMessage = handler
+	c.mu.Unlock()
 }
 
 // SetConnectHandler sets the callback for successful connection
 func (c *TUIClient) SetConnectHandler(handler func()) {
+	c.mu.Lock()
 	c.onConnect = handler
+	c.mu.Unlock()
 }
 
 // SetDisconnectHandler sets the callback for disconnection
 func (c *TUIClient) SetDisconnectHandler(handler func(error)) {
+	c.mu.Lock()
 	c.onDisconnect = handler
+	c.mu.Unlock()
 }
 
 // Connect establishes a WebSocket connection to the server
@@ -95,11 +102,12 @@ func (c *TUIClient) Connect(ctx context.Context) error {
 
 	c.mu.Lock()
 	c.conn = conn
+	connectHandler := c.onConnect
 	c.mu.Unlock()
 	c.connected.Store(true)
 
-	if c.onConnect != nil {
-		c.onConnect()
+	if connectHandler != nil {
+		connectHandler()
 	}
 
 	// Start read/write pumps
@@ -152,20 +160,23 @@ func (c *TUIClient) Disconnect() error {
 	c.mu.Lock()
 	conn := c.conn
 	c.conn = nil
+	handler := c.onDisconnect
 	c.mu.Unlock()
 
 	var err error
 	if conn != nil {
-		// Send close message
+		// Use writeMu to prevent race with writePump's WriteMessage
+		c.writeMu.Lock()
 		deadline := time.Now().Add(time.Second)
 		conn.SetWriteDeadline(deadline)
 		conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		c.writeMu.Unlock()
 		err = conn.Close()
 	}
 
 	// Call disconnect handler
-	if c.onDisconnect != nil {
-		c.onDisconnect(nil)
+	if handler != nil {
+		handler(nil)
 	}
 
 	return err
@@ -274,20 +285,38 @@ func (c *TUIClient) writePump() {
 			return
 
 		case msg := <-c.outgoing:
-			conn.SetWriteDeadline(time.Now().Add(writeWait))
+			c.mu.RLock()
+			currentConn := c.conn
+			c.mu.RUnlock()
+			if currentConn == nil {
+				return
+			}
 			data, err := msg.ToJSON()
 			if err != nil {
 				continue
 			}
-			if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
-				c.handleDisconnect(err)
+			c.writeMu.Lock()
+			currentConn.SetWriteDeadline(time.Now().Add(writeWait))
+			writeErr := currentConn.WriteMessage(websocket.TextMessage, data)
+			c.writeMu.Unlock()
+			if writeErr != nil {
+				c.handleDisconnect(writeErr)
 				return
 			}
 
 		case <-ticker.C:
-			conn.SetWriteDeadline(time.Now().Add(writeWait))
-			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
-				c.handleDisconnect(err)
+			c.mu.RLock()
+			currentConn := c.conn
+			c.mu.RUnlock()
+			if currentConn == nil {
+				return
+			}
+			c.writeMu.Lock()
+			currentConn.SetWriteDeadline(time.Now().Add(writeWait))
+			writeErr := currentConn.WriteMessage(websocket.PingMessage, nil)
+			c.writeMu.Unlock()
+			if writeErr != nil {
+				c.handleDisconnect(writeErr)
 				return
 			}
 		}
@@ -297,8 +326,11 @@ func (c *TUIClient) writePump() {
 // deliverMessage delivers a message to handlers
 func (c *TUIClient) deliverMessage(msg *Message) {
 	// Deliver to handler if set
-	if c.onMessage != nil {
-		c.onMessage(msg)
+	c.mu.RLock()
+	handler := c.onMessage
+	c.mu.RUnlock()
+	if handler != nil {
+		handler(msg)
 	}
 
 	// Also send to channel for polling
@@ -338,10 +370,11 @@ func (c *TUIClient) handleDisconnect(err error) {
 		c.conn.Close()
 		c.conn = nil
 	}
+	handler := c.onDisconnect
 	c.mu.Unlock()
 
-	if c.onDisconnect != nil {
-		c.onDisconnect(err)
+	if handler != nil {
+		handler(err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- TUIClient: protect handler access with mutex, add writeMu for concurrent WriteMessage calls
- procmgr: use sync.Once for cmd.Wait() to prevent double-wait race between monitor() and stop()

## Test plan
- [ ] `go test -race ./internal/ws/...` passes
- [ ] `go test -race ./internal/procmgr/...` passes

Closes #274
Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)