### PR TITLE
fix: TUI全エージェントのステータス不正表示を修正

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -162,6 +162,7 @@ type tuiModel struct {
 	tempInput        string
 	ready            bool
 	processingAgents map[string]bool // 各エージェントの処理状態
+	startTime        time.Time       // TUI起動時刻（初期分析を遅延実行するため）
 	width            int
 	height           int
 
@@ -461,6 +462,7 @@ func initialTuiModel(workDir string) tuiModel {
 		messages:            messages,
 		inputHist:           make([]string, 0),
 		processingAgents:    make(map[string]bool),
+		startTime:           time.Now(), // Record TUI startup time
 		histIdx:             -1,
 		currentView:         viewChat,
 		prWatcher:           prWatcher,
@@ -888,6 +890,10 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case analysisTickMsg:
 		// 1時間ごとの軽量分析トリガー
 		// Amaraが処理中でなく、直近のメッセージ数が閾値以上の場合のみ実行
+		// ただし、TUI起動後30秒未満は実行しない（初期化直後の不正な状態表示を回避）
+		if time.Since(m.startTime) < 30*time.Second {
+			return m, m.tickAnalysis()
+		}
 		recentMessages := m.getRecentMessages(time.Hour)
 		if !m.processingAgents["amara"] && len(recentMessages) >= m.analysisMinMessages {
 			m.processingAgents["amara"] = true
@@ -1028,6 +1034,8 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var icon string
 		if msg.recovered {
 			icon = "✅"
+			// Clear processing state when worker recovers (treat as completed)
+			delete(m.processingAgents, msg.workerName)
 			m.messages = append(m.messages, tuiMessage{
 				role:    "system",
 				content: fmt.Sprintf("%s エージェント %s が復帰しました", icon, msg.workerName),


### PR DESCRIPTION
## 概要
TUI起動時から全エージェントのステータスが「処理中...」「考え中...」として不正に表示され続ける問題を修正しました。

## 問題の原因

1. TUI起動直後に履歴から復元されたメッセージが存在
2. analysisTickMsg がトリガーされて、Amaraの軽量分析が自動実行
3. 分析結果がagentResponseMsgで削除されるまで processingAgents['amara'] が残存
4. この間、TUIに「amara が処理中」と表示されてしまう

## 修正内容

- startTime をtuiModelに追加して起動時刻を記録
- analysisTickMsg 処理で起動後30秒未満は分析を遅延実行
- heartbeat recovery時にprocessingAgentsをクリア（自動復帰は処理完了扱い）

## テスト
TUI起動時にステータス表示が正常であることを確認。

Closes #285

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>