### PR TITLE
fix: viewport slice bounds panic on small terminal

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -875,16 +875,30 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		footerHeight := 3
 		verticalMargin := headerHeight + footerHeight
 
+		// viewportの高さが負にならないよう最小値を確保
+		viewportHeight := msg.Height - verticalMargin
+		if viewportHeight < 1 {
+			viewportHeight = 1
+		}
+		viewportWidth := msg.Width
+		if viewportWidth < 1 {
+			viewportWidth = 1
+		}
+
 		if !m.ready {
-			m.viewport = viewport.New(msg.Width, msg.Height-verticalMargin)
+			m.viewport = viewport.New(viewportWidth, viewportHeight)
 			m.viewport.YPosition = headerHeight
 			m.analyzeProject()
 			m.ready = true
 		} else {
-			m.viewport.Width = msg.Width
-			m.viewport.Height = msg.Height - verticalMargin
+			m.viewport.Width = viewportWidth
+			m.viewport.Height = viewportHeight
 		}
-		m.textInput.Width = msg.Width - 8
+		textInputWidth := msg.Width - 8
+		if textInputWidth < 1 {
+			textInputWidth = 1
+		}
+		m.textInput.Width = textInputWidth
 		m.updateViewport()
 
 	case analysisTickMsg:


### PR DESCRIPTION
## Summary

- viewportのWidth/Heightが負の値になるとpanicが発生する問題を修正
- `msg.Height - verticalMargin` が負になるケースで境界値チェックを追加
- textInputのWidth計算にも同様の保護を追加

## 原因

スタックトレースより `viewport.Width` が `0xfffffffffffffffd` (= -3) になっていた。
ターミナルサイズが小さい場合、`msg.Height - verticalMargin` が負になり、
bubbles/viewportの内部でslice境界エラーが発生。

```
runtime error: slice bounds out of range [54974:54971]
```

## Test plan

- [x] `go build ./...` 成功
- [x] `go test ./...` 全件パス

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)