### PR TITLE
fix: prevent viewport panic on small terminal size

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -875,16 +875,30 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		footerHeight := 3
 		verticalMargin := headerHeight + footerHeight
 
+		// Ensure minimum dimensions to prevent slice bounds panic
+		vpWidth := msg.Width
+		if vpWidth < 1 {
+			vpWidth = 1
+		}
+		vpHeight := msg.Height - verticalMargin
+		if vpHeight < 1 {
+			vpHeight = 1
+		}
+		inputWidth := msg.Width - 8
+		if inputWidth < 1 {
+			inputWidth = 1
+		}
+
 		if !m.ready {
-			m.viewport = viewport.New(msg.Width, msg.Height-verticalMargin)
+			m.viewport = viewport.New(vpWidth, vpHeight)
 			m.viewport.YPosition = headerHeight
 			m.analyzeProject()
 			m.ready = true
 		} else {
-			m.viewport.Width = msg.Width
-			m.viewport.Height = msg.Height - verticalMargin
+			m.viewport.Width = vpWidth
+			m.viewport.Height = vpHeight
 		}
-		m.textInput.Width = msg.Width - 8
+		m.textInput.Width = inputWidth
 		m.updateViewport()
 
 	case analysisTickMsg:

--- a/cmd/maxam/tui_viewport_test.go
+++ b/cmd/maxam/tui_viewport_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/bubbles/viewport"
+)
+
+func TestWindowSizeMsg_MinimumDimensions(t *testing.T) {
+	tests := []struct {
+		name       string
+		width      int
+		height     int
+		wantVPW    int
+		wantVPH    int
+		wantInputW int
+	}{
+		{
+			name:       "normal size",
+			width:      80,
+			height:     24,
+			wantVPW:    80,
+			wantVPH:    19, // 24 - 5 (headerHeight + footerHeight)
+			wantInputW: 72, // 80 - 8
+		},
+		{
+			name:       "zero width",
+			width:      0,
+			height:     24,
+			wantVPW:    1,
+			wantVPH:    19,
+			wantInputW: 1,
+		},
+		{
+			name:       "zero height",
+			width:      80,
+			height:     0,
+			wantVPW:    80,
+			wantVPH:    1,
+			wantInputW: 72,
+		},
+		{
+			name:       "very small terminal",
+			width:      5,
+			height:     3,
+			wantVPW:    5,
+			wantVPH:    1,  // 3 - 5 = -2 -> clamped to 1
+			wantInputW: 1, // 5 - 8 = -3 -> clamped to 1
+		},
+		{
+			name:       "negative would overflow",
+			width:      1,
+			height:     1,
+			wantVPW:    1,
+			wantVPH:    1,
+			wantInputW: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the clamping logic directly
+			headerHeight := 2
+			footerHeight := 3
+			verticalMargin := headerHeight + footerHeight
+
+			vpWidth := tt.width
+			if vpWidth < 1 {
+				vpWidth = 1
+			}
+			vpHeight := tt.height - verticalMargin
+			if vpHeight < 1 {
+				vpHeight = 1
+			}
+			inputWidth := tt.width - 8
+			if inputWidth < 1 {
+				inputWidth = 1
+			}
+
+			if vpWidth != tt.wantVPW {
+				t.Errorf("viewport width = %d, want %d", vpWidth, tt.wantVPW)
+			}
+			if vpHeight != tt.wantVPH {
+				t.Errorf("viewport height = %d, want %d", vpHeight, tt.wantVPH)
+			}
+			if inputWidth != tt.wantInputW {
+				t.Errorf("input width = %d, want %d", inputWidth, tt.wantInputW)
+			}
+		})
+	}
+}
+
+func TestViewport_SmallDimensions_NoPanic(t *testing.T) {
+	// Ensure viewport.New with minimum dimensions doesn't panic
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("viewport.New panicked with minimum dimensions: %v", r)
+		}
+	}()
+
+	vp := viewport.New(1, 1)
+	vp.SetContent("test content\nline 2\nline 3")
+	vp.GotoBottom()
+	_ = vp.View()
+}
+
+func TestViewport_SetContent_NoPanic(t *testing.T) {
+	// Test that setting content on a very small viewport doesn't panic
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("viewport operations panicked: %v", r)
+		}
+	}()
+
+	vp := viewport.New(1, 1)
+	// Long content that would normally cause issues
+	content := ""
+	for i := 0; i < 1000; i++ {
+		content += "line of content\n"
+	}
+	vp.SetContent(content)
+	vp.GotoBottom()
+	_ = vp.View()
+}
+
+// Ensure tea.WindowSizeMsg type is correct
+var _ tea.Msg = tea.WindowSizeMsg{}


### PR DESCRIPTION
## Summary
- Clamp viewport width/height and text input width to minimum of 1
- Prevents `slice bounds out of range` panic when terminal is resized to very small dimensions
- Add unit tests for viewport dimension clamping

## Root Cause
When terminal is resized to a very small size (height < 5 or width < 8), the viewport dimensions become negative:
- `msg.Height - verticalMargin` could become negative (e.g., 3 - 5 = -2)
- `msg.Width - 8` could become negative (e.g., 5 - 8 = -3)

These negative values caused `slice bounds out of range [54974:54971]` panic in bubbles/viewport.

## Test plan
- [x] Run existing tests: `go test ./...`
- [x] Add viewport dimension tests
- [x] Verify no panic with minimum dimensions

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)