### PR TITLE
feat: add /kill command for force terminating agents

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -2250,6 +2250,69 @@ func (m *tuiModel) handleModeCommand(result mode.ParseResult) (tea.Model, tea.Cm
 				})
 			}
 		}
+
+	case mode.CommandKill:
+		// Force kill agent(s) immediately
+		if m.workerPool == nil {
+			m.messages = append(m.messages, tuiMessage{
+				role:    "system",
+				content: "⚠️ ワーカープールが初期化されていません。",
+			})
+			m.updateViewport()
+			return m, nil
+		}
+
+		args := strings.TrimSpace(result.Args)
+		if args == "" || args == "all" {
+			// Kill all agents
+			allAgents := m.workerPool.All()
+			for _, name := range allAgents {
+				m.workerPool.Kill(name)
+			}
+			m.messages = append(m.messages, tuiMessage{
+				role:    "system",
+				content: fmt.Sprintf("⚠️ 全エージェント(%d)を強制終了しました。再起動するには @agent resume を実行してください。", len(allAgents)),
+			})
+		} else {
+			// Kill specific agent(s)
+			// Support: /kill @mei or /kill mei or /kill @mei @yuki
+			targets := strings.Fields(args)
+			killed := []string{}
+			notFound := []string{}
+
+			for _, target := range targets {
+				// Remove @ prefix if present
+				agentName := strings.TrimPrefix(target, "@")
+				agentName = strings.ToLower(agentName)
+
+				// Case-insensitive lookup
+				found := false
+				for _, name := range m.workerPool.All() {
+					if strings.ToLower(name) == agentName {
+						m.workerPool.Kill(name)
+						killed = append(killed, name)
+						found = true
+						break
+					}
+				}
+				if !found {
+					notFound = append(notFound, target)
+				}
+			}
+
+			if len(killed) > 0 {
+				m.messages = append(m.messages, tuiMessage{
+					role:    "system",
+					content: fmt.Sprintf("⚠️ %s を強制終了しました。再起動するには @agent resume を実行してください。", strings.Join(killed, ", ")),
+				})
+			}
+			if len(notFound) > 0 {
+				m.messages = append(m.messages, tuiMessage{
+					role:    "system",
+					content: fmt.Sprintf("❌ エージェントが見つかりません: %s", strings.Join(notFound, ", ")),
+				})
+			}
+		}
 	}
 
 	m.updateViewport()

--- a/internal/mode/command.go
+++ b/internal/mode/command.go
@@ -18,6 +18,8 @@ const (
 	CommandStatus Command = "/status"
 	// CommandResetAuto resets agent auto mode
 	CommandResetAuto Command = "/resetauto"
+	// CommandKill force kills agent(s) immediately
+	CommandKill Command = "/kill"
 )
 
 // ParseResult contains the result of parsing user input for commands
@@ -32,7 +34,7 @@ func Parse(input string) ParseResult {
 	trimmed := strings.TrimSpace(input)
 
 	// Check for known commands
-	commands := []Command{CommandPlan, CommandAuto, CommandStop, CommandStatus, CommandResetAuto}
+	commands := []Command{CommandPlan, CommandAuto, CommandStop, CommandStatus, CommandResetAuto, CommandKill}
 	for _, cmd := range commands {
 		cmdStr := string(cmd)
 		if trimmed == cmdStr {

--- a/internal/mode/command_test.go
+++ b/internal/mode/command_test.go
@@ -81,6 +81,34 @@ func TestParse(t *testing.T) {
 			input:       "let's /plan this",
 			wantCommand: false,
 		},
+		{
+			name:        "/kill command",
+			input:       "/kill",
+			wantCommand: true,
+			wantCmd:     CommandKill,
+			wantArgs:    "",
+		},
+		{
+			name:        "/kill with agent",
+			input:       "/kill @mei",
+			wantCommand: true,
+			wantCmd:     CommandKill,
+			wantArgs:    "@mei",
+		},
+		{
+			name:        "/kill with multiple agents",
+			input:       "/kill @mei @yuki",
+			wantCommand: true,
+			wantCmd:     CommandKill,
+			wantArgs:    "@mei @yuki",
+		},
+		{
+			name:        "/kill all",
+			input:       "/kill all",
+			wantCommand: true,
+			wantCmd:     CommandKill,
+			wantArgs:    "all",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `/kill` スラッシュコマンドを追加
- エージェントを即座に強制終了（作業完了を待たない）
- `@agent kill` パターンがマッチしない場合でも確実に終了可能

## Usage
```
/kill @mei       - 特定エージェントをkill
/kill mei        - @ なしでも可
/kill @mei @yuki - 複数エージェントをkill
/kill all        - 全エージェントをkill
/kill            - 全エージェントをkill（/kill all と同等）
```

## 変更内容
- `internal/mode/command.go`: `CommandKill` 定数追加
- `cmd/maxam/tui.go`: `/kill` コマンドのハンドリング追加
- `internal/mode/command_test.go`: テストケース追加

## 背景
`@mei kill` コマンドは正規表現 `^@(\w+)\s+(stop|resume|kill)\s*$` でパースされるため、
追加のテキストがあるとマッチしない。`/kill` スラッシュコマンドはTUIレベルで直接処理されるため、
確実にインターセプトされる。

## Test plan
- [x] `go test ./internal/mode/...` パス
- [x] `go test ./...` 全テストパス
- [x] `go build ./cmd/maxam/...` ビルド成功

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)