### PR TITLE
feat: change default model to opus

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -148,7 +148,7 @@ func (r *Runner) Run(ctx context.Context, prompt string) (string, error) {
 type Model string
 
 const (
-	ModelDefault Model = ""       // Use claude's default
+	ModelDefault Model = "opus"   // Default to most capable model
 	ModelHaiku   Model = "haiku"  // Fast, lightweight
 	ModelSonnet  Model = "sonnet" // Balanced
 	ModelOpus    Model = "opus"   // Most capable

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -197,7 +197,7 @@ func TestModelConstants(t *testing.T) {
 		model Model
 		want  string
 	}{
-		{ModelDefault, ""},
+		{ModelDefault, "opus"},
 		{ModelHaiku, "haiku"},
 		{ModelSonnet, "sonnet"},
 		{ModelOpus, "opus"},


### PR DESCRIPTION
## Summary
- デフォルトモデルをopusに変更
- 新規インストールユーザーも自動的にopusを使用
- config.yamlで上書き可能

## Changes
- `ModelDefault` を `""` → `"opus"` に変更
- テストの期待値を更新

## Test plan
- [x] `go test ./...` 全件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)