### PR TITLE
feat: CI監視・自動通知機能の実装

### DIFF
--- a/internal/cinotify/service.go
+++ b/internal/cinotify/service.go
@@ -1,0 +1,166 @@
+// Package cinotify provides CI notification service
+package cinotify
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	ghlib "github.com/ytnobody/MAXAM/internal/github"
+)
+
+// Notifier is the interface for sending CI notifications
+type Notifier interface {
+	NotifyCI(ctx context.Context, message string) error
+}
+
+// ServiceConfig holds configuration for the CI notify service
+type ServiceConfig struct {
+	// PollInterval is the interval between polling
+	PollInterval time.Duration
+	// Timeout is the maximum time to wait for CI completion
+	Timeout time.Duration
+}
+
+// DefaultServiceConfig returns default configuration
+func DefaultServiceConfig() ServiceConfig {
+	return ServiceConfig{
+		PollInterval: 30 * time.Second,
+		Timeout:      24 * time.Hour,
+	}
+}
+
+// Service monitors CI status and sends notifications
+type Service struct {
+	watcher  *ghlib.CIWatcher
+	notifier Notifier
+	mu       sync.RWMutex
+	running  bool
+	cancel   context.CancelFunc
+}
+
+// NewService creates a new CI notification service
+func NewService(client *ghlib.Client, notifier Notifier, config ServiceConfig) *Service {
+	watcherConfig := ghlib.CIWatcherConfig{
+		PollInterval: config.PollInterval,
+		Timeout:      config.Timeout,
+	}
+	watcher := ghlib.NewCIWatcher(client, watcherConfig)
+
+	return &Service{
+		watcher:  watcher,
+		notifier: notifier,
+	}
+}
+
+// Start begins the notification service
+func (s *Service) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return fmt.Errorf("service already running")
+	}
+
+	ctx, s.cancel = context.WithCancel(ctx)
+	s.running = true
+	s.mu.Unlock()
+
+	// Start notification loop
+	go s.notificationLoop(ctx)
+
+	return nil
+}
+
+// Stop stops the notification service
+func (s *Service) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.running = false
+}
+
+// IsRunning returns true if the service is running
+func (s *Service) IsRunning() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.running
+}
+
+// WatchPR starts watching a PR for CI completion
+func (s *Service) WatchPR(ctx context.Context, prNumber int) error {
+	return s.watcher.WatchPR(ctx, prNumber)
+}
+
+// StopWatching stops watching a PR
+func (s *Service) StopWatching(prNumber int) {
+	s.watcher.StopWatching(prNumber)
+}
+
+// WatchingPRs returns the list of PRs being watched
+func (s *Service) WatchingPRs() []int {
+	return s.watcher.WatchingPRs()
+}
+
+// GetCIStatus gets the current CI status for a PR
+func (s *Service) GetCIStatus(ctx context.Context, prNumber int) (*ghlib.CIResult, error) {
+	return s.watcher.GetCIStatus(ctx, prNumber)
+}
+
+func (s *Service) notificationLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case result := <-s.watcher.NotifyCh():
+			s.sendNotification(ctx, result)
+		}
+	}
+}
+
+func (s *Service) sendNotification(ctx context.Context, result ghlib.CIResult) {
+	message := formatNotification(result)
+
+	if s.notifier != nil {
+		// Best effort notification
+		_ = s.notifier.NotifyCI(ctx, message)
+	}
+}
+
+func formatNotification(result ghlib.CIResult) string {
+	var status string
+	switch result.Status {
+	case ghlib.CIStatusSuccess:
+		status = "✅ **CI passed**"
+	case ghlib.CIStatusFailure:
+		status = "❌ **CI failed**"
+	case ghlib.CIStatusCancelled:
+		status = "⏹️ **CI cancelled/timeout**"
+	default:
+		status = "⏳ **CI status unknown**"
+	}
+
+	msg := fmt.Sprintf("%s\n\nPR #%d: %s\n%d/%d checks passed\n%s",
+		status,
+		result.PRNumber,
+		result.PRTitle,
+		result.Passed,
+		result.TotalChecks,
+		result.PRURL,
+	)
+
+	// Add failed check details
+	if result.Status == ghlib.CIStatusFailure {
+		msg += "\n\n**Failed checks:**"
+		for _, detail := range result.Details {
+			if detail.Status == ghlib.CIStatusFailure {
+				msg += fmt.Sprintf("\n- %s", detail.Name)
+			}
+		}
+	}
+
+	return msg
+}

--- a/internal/cinotify/service_test.go
+++ b/internal/cinotify/service_test.go
@@ -1,0 +1,148 @@
+package cinotify
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	ghlib "github.com/ytnobody/MAXAM/internal/github"
+)
+
+func TestDefaultServiceConfig(t *testing.T) {
+	config := DefaultServiceConfig()
+
+	if config.PollInterval != 30*time.Second {
+		t.Errorf("expected PollInterval to be 30s, got %v", config.PollInterval)
+	}
+
+	if config.Timeout != 24*time.Hour {
+		t.Errorf("expected Timeout to be 24h, got %v", config.Timeout)
+	}
+}
+
+func TestFormatNotification(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   ghlib.CIResult
+		contains []string
+	}{
+		{
+			name: "success notification",
+			result: ghlib.CIResult{
+				PRNumber:    123,
+				PRTitle:     "Add feature X",
+				PRURL:       "https://github.com/test/repo/pull/123",
+				Status:      ghlib.CIStatusSuccess,
+				TotalChecks: 5,
+				Passed:      5,
+			},
+			contains: []string{"✅", "CI passed", "#123", "Add feature X", "5/5"},
+		},
+		{
+			name: "failure notification",
+			result: ghlib.CIResult{
+				PRNumber:    456,
+				PRTitle:     "Fix bug Y",
+				PRURL:       "https://github.com/test/repo/pull/456",
+				Status:      ghlib.CIStatusFailure,
+				TotalChecks: 3,
+				Passed:      2,
+				Failed:      1,
+				Details: []ghlib.CheckDetail{
+					{Name: "lint", Status: ghlib.CIStatusSuccess},
+					{Name: "test", Status: ghlib.CIStatusSuccess},
+					{Name: "build", Status: ghlib.CIStatusFailure},
+				},
+			},
+			contains: []string{"❌", "CI failed", "#456", "2/3", "Failed checks", "build"},
+		},
+		{
+			name: "cancelled notification",
+			result: ghlib.CIResult{
+				PRNumber:    789,
+				PRTitle:     "Update docs",
+				PRURL:       "https://github.com/test/repo/pull/789",
+				Status:      ghlib.CIStatusCancelled,
+				TotalChecks: 0,
+			},
+			contains: []string{"⏹️", "cancelled", "#789"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := formatNotification(tt.result)
+
+			for _, substr := range tt.contains {
+				if !strings.Contains(msg, substr) {
+					t.Errorf("expected message to contain %q, got: %s", substr, msg)
+				}
+			}
+		})
+	}
+}
+
+type mockNotifier struct {
+	messages []string
+}
+
+func (m *mockNotifier) NotifyCI(ctx context.Context, message string) error {
+	m.messages = append(m.messages, message)
+	return nil
+}
+
+func TestServiceStartStop(t *testing.T) {
+	notifier := &mockNotifier{}
+	config := ServiceConfig{
+		PollInterval: 100 * time.Millisecond,
+		Timeout:      1 * time.Second,
+	}
+
+	// Create service with nil client (won't actually poll)
+	service := NewService(nil, notifier, config)
+
+	// Initially not running
+	if service.IsRunning() {
+		t.Error("expected service to not be running initially")
+	}
+
+	// Start service
+	ctx := context.Background()
+	err := service.Start(ctx)
+	if err != nil {
+		t.Fatalf("failed to start service: %v", err)
+	}
+
+	// Should be running
+	if !service.IsRunning() {
+		t.Error("expected service to be running after Start")
+	}
+
+	// Start again should fail
+	err = service.Start(ctx)
+	if err == nil {
+		t.Error("expected error when starting already running service")
+	}
+
+	// Stop service
+	service.Stop()
+
+	// Should not be running
+	if service.IsRunning() {
+		t.Error("expected service to not be running after Stop")
+	}
+}
+
+func TestServiceWatchingPRs(t *testing.T) {
+	notifier := &mockNotifier{}
+	config := DefaultServiceConfig()
+
+	service := NewService(nil, notifier, config)
+
+	// Initially no PRs being watched
+	prs := service.WatchingPRs()
+	if len(prs) != 0 {
+		t.Errorf("expected 0 watching PRs, got %d", len(prs))
+	}
+}

--- a/internal/github/ci_watcher.go
+++ b/internal/github/ci_watcher.go
@@ -1,0 +1,330 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/go-github/v60/github"
+)
+
+// CIStatus represents the status of CI checks
+type CIStatus string
+
+const (
+	CIStatusPending   CIStatus = "pending"
+	CIStatusRunning   CIStatus = "running"
+	CIStatusSuccess   CIStatus = "success"
+	CIStatusFailure   CIStatus = "failure"
+	CIStatusCancelled CIStatus = "cancelled"
+)
+
+// CIResult represents the result of CI check monitoring
+type CIResult struct {
+	PRNumber    int
+	PRTitle     string
+	PRURL       string
+	PRAuthor    string
+	Status      CIStatus
+	TotalChecks int
+	Passed      int
+	Failed      int
+	Pending     int
+	Details     []CheckDetail
+	CompletedAt time.Time
+}
+
+// CheckDetail represents details of a single check
+type CheckDetail struct {
+	Name       string
+	Status     CIStatus
+	Conclusion string
+	URL        string
+}
+
+// CIWatcherConfig holds configuration for CI watcher
+type CIWatcherConfig struct {
+	// PollInterval is the interval between polling
+	PollInterval time.Duration
+	// Timeout is the maximum time to wait for CI completion
+	Timeout time.Duration
+}
+
+// DefaultCIWatcherConfig returns default configuration
+func DefaultCIWatcherConfig() CIWatcherConfig {
+	return CIWatcherConfig{
+		PollInterval: 30 * time.Second,
+		Timeout:      24 * time.Hour,
+	}
+}
+
+// CIWatcher monitors CI status for PRs
+type CIWatcher struct {
+	client   *Client
+	config   CIWatcherConfig
+	watching map[int]*watchEntry
+	mu       sync.RWMutex
+	notifyCh chan CIResult
+}
+
+type watchEntry struct {
+	prNumber  int
+	startTime time.Time
+	cancel    context.CancelFunc
+}
+
+// NewCIWatcher creates a new CI watcher
+func NewCIWatcher(client *Client, config CIWatcherConfig) *CIWatcher {
+	return &CIWatcher{
+		client:   client,
+		config:   config,
+		watching: make(map[int]*watchEntry),
+		notifyCh: make(chan CIResult, 100),
+	}
+}
+
+// NotifyCh returns the notification channel
+func (w *CIWatcher) NotifyCh() <-chan CIResult {
+	return w.notifyCh
+}
+
+// WatchPR starts watching CI status for a PR
+func (w *CIWatcher) WatchPR(ctx context.Context, prNumber int) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Already watching
+	if _, ok := w.watching[prNumber]; ok {
+		return nil
+	}
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	entry := &watchEntry{
+		prNumber:  prNumber,
+		startTime: time.Now(),
+		cancel:    cancel,
+	}
+	w.watching[prNumber] = entry
+
+	go w.watchLoop(watchCtx, entry)
+	return nil
+}
+
+// StopWatching stops watching a PR
+func (w *CIWatcher) StopWatching(prNumber int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if entry, ok := w.watching[prNumber]; ok {
+		entry.cancel()
+		delete(w.watching, prNumber)
+	}
+}
+
+// IsWatching returns true if the PR is being watched
+func (w *CIWatcher) IsWatching(prNumber int) bool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	_, ok := w.watching[prNumber]
+	return ok
+}
+
+// WatchingPRs returns the list of PRs being watched
+func (w *CIWatcher) WatchingPRs() []int {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	prs := make([]int, 0, len(w.watching))
+	for prNum := range w.watching {
+		prs = append(prs, prNum)
+	}
+	return prs
+}
+
+// GetCIStatus gets the current CI status for a PR
+func (w *CIWatcher) GetCIStatus(ctx context.Context, prNumber int) (*CIResult, error) {
+	pr, err := w.client.GetPR(ctx, prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("get PR: %w", err)
+	}
+
+	return w.checkCIStatus(ctx, pr)
+}
+
+func (w *CIWatcher) watchLoop(ctx context.Context, entry *watchEntry) {
+	ticker := time.NewTicker(w.config.PollInterval)
+	defer ticker.Stop()
+
+	timeout := time.After(w.config.Timeout)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timeout:
+			// Timeout reached, send timeout result
+			w.sendTimeoutResult(entry.prNumber)
+			w.StopWatching(entry.prNumber)
+			return
+		case <-ticker.C:
+			pr, err := w.client.GetPR(ctx, entry.prNumber)
+			if err != nil {
+				continue // Retry on error
+			}
+
+			result, err := w.checkCIStatus(ctx, pr)
+			if err != nil {
+				continue // Retry on error
+			}
+
+			// Check if CI is complete
+			if result.Status == CIStatusSuccess || result.Status == CIStatusFailure || result.Status == CIStatusCancelled {
+				w.notifyCh <- *result
+				w.StopWatching(entry.prNumber)
+				return
+			}
+		}
+	}
+}
+
+func (w *CIWatcher) checkCIStatus(ctx context.Context, pr *github.PullRequest) (*CIResult, error) {
+	ref := pr.GetHead().GetSHA()
+
+	// Get combined status (for status checks)
+	combinedStatus, _, err := w.client.client.Repositories.GetCombinedStatus(ctx, w.client.owner, w.client.repo, ref, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get combined status: %w", err)
+	}
+
+	// Get check runs (for GitHub Actions)
+	checkRuns, _, err := w.client.client.Checks.ListCheckRunsForRef(ctx, w.client.owner, w.client.repo, ref, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list check runs: %w", err)
+	}
+
+	result := &CIResult{
+		PRNumber: pr.GetNumber(),
+		PRTitle:  pr.GetTitle(),
+		PRURL:    pr.GetHTMLURL(),
+		PRAuthor: pr.GetUser().GetLogin(),
+		Details:  make([]CheckDetail, 0),
+	}
+
+	// Process status checks
+	for _, status := range combinedStatus.Statuses {
+		detail := CheckDetail{
+			Name:   status.GetContext(),
+			URL:    status.GetTargetURL(),
+			Status: mapStatusState(status.GetState()),
+		}
+		result.Details = append(result.Details, detail)
+
+		switch detail.Status {
+		case CIStatusSuccess:
+			result.Passed++
+		case CIStatusFailure:
+			result.Failed++
+		default:
+			result.Pending++
+		}
+	}
+
+	// Process check runs
+	for _, run := range checkRuns.CheckRuns {
+		detail := CheckDetail{
+			Name:       run.GetName(),
+			URL:        run.GetHTMLURL(),
+			Status:     mapCheckRunStatus(run.GetStatus(), run.GetConclusion()),
+			Conclusion: run.GetConclusion(),
+		}
+		result.Details = append(result.Details, detail)
+
+		switch detail.Status {
+		case CIStatusSuccess:
+			result.Passed++
+		case CIStatusFailure, CIStatusCancelled:
+			result.Failed++
+		default:
+			result.Pending++
+		}
+	}
+
+	result.TotalChecks = len(result.Details)
+
+	// Determine overall status
+	if result.TotalChecks == 0 {
+		result.Status = CIStatusPending
+	} else if result.Pending > 0 {
+		result.Status = CIStatusRunning
+	} else if result.Failed > 0 {
+		result.Status = CIStatusFailure
+	} else {
+		result.Status = CIStatusSuccess
+		result.CompletedAt = time.Now()
+	}
+
+	return result, nil
+}
+
+func (w *CIWatcher) sendTimeoutResult(prNumber int) {
+	w.notifyCh <- CIResult{
+		PRNumber: prNumber,
+		Status:   CIStatusCancelled,
+	}
+}
+
+func mapStatusState(state string) CIStatus {
+	switch state {
+	case "success":
+		return CIStatusSuccess
+	case "failure", "error":
+		return CIStatusFailure
+	case "pending":
+		return CIStatusPending
+	default:
+		return CIStatusPending
+	}
+}
+
+func mapCheckRunStatus(status, conclusion string) CIStatus {
+	if status != "completed" {
+		if status == "in_progress" {
+			return CIStatusRunning
+		}
+		return CIStatusPending
+	}
+
+	switch conclusion {
+	case "success":
+		return CIStatusSuccess
+	case "failure":
+		return CIStatusFailure
+	case "cancelled", "skipped":
+		return CIStatusCancelled
+	case "neutral":
+		return CIStatusSuccess // neutral is treated as success
+	default:
+		return CIStatusFailure
+	}
+}
+
+// FormatCIResult formats a CI result for display
+func FormatCIResult(r CIResult) string {
+	var icon string
+	switch r.Status {
+	case CIStatusSuccess:
+		icon = "✅"
+	case CIStatusFailure:
+		icon = "❌"
+	case CIStatusRunning:
+		icon = "🔄"
+	case CIStatusCancelled:
+		icon = "⏹️"
+	default:
+		icon = "⏳"
+	}
+
+	return fmt.Sprintf("%s CI %s for PR #%d: %s (%d/%d passed)\n   %s",
+		icon, r.Status, r.PRNumber, r.PRTitle, r.Passed, r.TotalChecks, r.PRURL)
+}

--- a/internal/github/ci_watcher_test.go
+++ b/internal/github/ci_watcher_test.go
@@ -1,0 +1,166 @@
+package github
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultCIWatcherConfig(t *testing.T) {
+	config := DefaultCIWatcherConfig()
+
+	if config.PollInterval != 30*time.Second {
+		t.Errorf("expected PollInterval to be 30s, got %v", config.PollInterval)
+	}
+
+	if config.Timeout != 24*time.Hour {
+		t.Errorf("expected Timeout to be 24h, got %v", config.Timeout)
+	}
+}
+
+func TestMapStatusState(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected CIStatus
+	}{
+		{"success", CIStatusSuccess},
+		{"failure", CIStatusFailure},
+		{"error", CIStatusFailure},
+		{"pending", CIStatusPending},
+		{"unknown", CIStatusPending},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := mapStatusState(tt.input)
+			if result != tt.expected {
+				t.Errorf("mapStatusState(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMapCheckRunStatus(t *testing.T) {
+	tests := []struct {
+		status     string
+		conclusion string
+		expected   CIStatus
+	}{
+		{"in_progress", "", CIStatusRunning},
+		{"queued", "", CIStatusPending},
+		{"completed", "success", CIStatusSuccess},
+		{"completed", "failure", CIStatusFailure},
+		{"completed", "cancelled", CIStatusCancelled},
+		{"completed", "skipped", CIStatusCancelled},
+		{"completed", "neutral", CIStatusSuccess},
+		{"completed", "timed_out", CIStatusFailure},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status+"_"+tt.conclusion, func(t *testing.T) {
+			result := mapCheckRunStatus(tt.status, tt.conclusion)
+			if result != tt.expected {
+				t.Errorf("mapCheckRunStatus(%q, %q) = %v, want %v", tt.status, tt.conclusion, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatCIResult(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   CIResult
+		contains string
+	}{
+		{
+			name: "success",
+			result: CIResult{
+				PRNumber:    123,
+				PRTitle:     "Test PR",
+				PRURL:       "https://github.com/test/repo/pull/123",
+				Status:      CIStatusSuccess,
+				TotalChecks: 5,
+				Passed:      5,
+			},
+			contains: "✅",
+		},
+		{
+			name: "failure",
+			result: CIResult{
+				PRNumber:    456,
+				PRTitle:     "Failing PR",
+				PRURL:       "https://github.com/test/repo/pull/456",
+				Status:      CIStatusFailure,
+				TotalChecks: 3,
+				Passed:      2,
+				Failed:      1,
+			},
+			contains: "❌",
+		},
+		{
+			name: "running",
+			result: CIResult{
+				PRNumber:    789,
+				PRTitle:     "In Progress PR",
+				PRURL:       "https://github.com/test/repo/pull/789",
+				Status:      CIStatusRunning,
+				TotalChecks: 2,
+				Passed:      1,
+				Pending:     1,
+			},
+			contains: "🔄",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatCIResult(tt.result)
+			if len(result) == 0 {
+				t.Error("expected non-empty result")
+			}
+			// Check that PR number is included
+			if !strings.Contains(result, "123") && !strings.Contains(result, "456") && !strings.Contains(result, "789") {
+				t.Errorf("expected result to contain PR number, got %s", result)
+			}
+		})
+	}
+}
+
+func TestCIWatcherWatchingPRs(t *testing.T) {
+	// Create a watcher without client (nil client is ok for this test)
+	config := CIWatcherConfig{
+		PollInterval: 1 * time.Second,
+		Timeout:      1 * time.Minute,
+	}
+	watcher := NewCIWatcher(nil, config)
+
+	// Initially no PRs being watched
+	prs := watcher.WatchingPRs()
+	if len(prs) != 0 {
+		t.Errorf("expected 0 watching PRs, got %d", len(prs))
+	}
+
+	// IsWatching should return false
+	if watcher.IsWatching(123) {
+		t.Error("expected IsWatching(123) to be false")
+	}
+}
+
+func TestCIStatusConstants(t *testing.T) {
+	// Verify status constants are distinct
+	statuses := []CIStatus{
+		CIStatusPending,
+		CIStatusRunning,
+		CIStatusSuccess,
+		CIStatusFailure,
+		CIStatusCancelled,
+	}
+
+	seen := make(map[CIStatus]bool)
+	for _, s := range statuses {
+		if seen[s] {
+			t.Errorf("duplicate status: %v", s)
+		}
+		seen[s] = true
+	}
+}


### PR DESCRIPTION
## Summary

- CIWatcher: GitHub APIでPRのCI状態をポーリング監視
- CINotifyService: CI完了時にチャットへ自動通知
- 設定可能なポーリング間隔とタイムアウト

## 実装内容

### `internal/github/ci_watcher.go`
- `CIWatcher`: PRのチェック実行状態を監視
- Status ChecksとGitHub Actions両方に対応
- 複数PRの同時監視をサポート

### `internal/cinotify/service.go`
- `Service`: CI完了を検知して通知を送信
- `Notifier` インターフェースで通知先を抽象化

## Test plan
- [x] `go test ./internal/github/... -run "CI"` 通過
- [x] `go test ./internal/cinotify/...` 通過
- [x] `go test ./...` 全体テスト通過

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)