### PR TITLE
chore: update Go to 1.25.7 for security fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
 
       - name: Get version from tag
         id: version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ytnobody/MAXAM
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0


### PR DESCRIPTION
## Summary
- Go 1.25.7 へのセキュリティアップデート
- GO-2026-4337 (crypto/tls脆弱性) 対応
- CIのGoバージョンも 1.23 → 1.25 に統一

## Changes
- `go.mod`: 1.25.6 → 1.25.7
- `.github/workflows/ci.yml`: 1.23 → 1.25
- `.github/workflows/release.yml`: 1.23 → 1.25

## Test plan
- [x] `go build ./...` 成功
- [x] `go test ./...` 全件パス

## Action Required
- [ ] Priya によるセキュリティレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)