### PR TITLE
chore: apply gofmt to tui_viewport_test.go

### DIFF
--- a/cmd/maxam/tui_viewport_test.go
+++ b/cmd/maxam/tui_viewport_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"testing"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestWindowSizeMsg_MinimumDimensions(t *testing.T) {
@@ -45,7 +45,7 @@ func TestWindowSizeMsg_MinimumDimensions(t *testing.T) {
 			width:      5,
 			height:     3,
 			wantVPW:    5,
-			wantVPH:    1,  // 3 - 5 = -2 -> clamped to 1
+			wantVPH:    1, // 3 - 5 = -2 -> clamped to 1
 			wantInputW: 1, // 5 - 8 = -3 -> clamped to 1
 		},
 		{


### PR DESCRIPTION
## Summary
- `gofmt -l .` で検出された `cmd/maxam/tui_viewport_test.go` のフォーマット差分を修正

## Test plan
- [x] `gofmt -l .` → 出力なし（修正確認済み）
- [x] `go vet ./...` → エラーなし
- [x] `go test ./...` → 全件パス

## Action Required
- Priya によるレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)