### PR TITLE
feat(healthmgr): add health monitoring loop

### DIFF
--- a/internal/healthmgr/monitor.go
+++ b/internal/healthmgr/monitor.go
@@ -1,0 +1,128 @@
+package healthmgr
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Monitor runs periodic health checks for all registered agents.
+type Monitor struct {
+	manager  *Manager
+	interval time.Duration
+	checker  HealthChecker
+
+	mu      sync.Mutex
+	running bool
+	cancel  context.CancelFunc
+}
+
+// HealthChecker defines the interface for checking agent health.
+type HealthChecker interface {
+	// CheckHealth checks if an agent is healthy.
+	// Returns an error if the agent is unresponsive or unhealthy.
+	CheckHealth(ctx context.Context, agentName string) error
+}
+
+// NewMonitor creates a new health monitor.
+func NewMonitor(manager *Manager, interval time.Duration, checker HealthChecker) *Monitor {
+	return &Monitor{
+		manager:  manager,
+		interval: interval,
+		checker:  checker,
+	}
+}
+
+// Start begins the monitoring loop.
+// Returns immediately; monitoring runs in a goroutine.
+func (m *Monitor) Start(ctx context.Context) {
+	m.mu.Lock()
+	if m.running {
+		m.mu.Unlock()
+		return
+	}
+	m.running = true
+
+	monitorCtx, cancel := context.WithCancel(ctx)
+	m.cancel = cancel
+	m.mu.Unlock()
+
+	go m.run(monitorCtx)
+}
+
+// Stop stops the monitoring loop.
+func (m *Monitor) Stop() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.running {
+		return
+	}
+
+	if m.cancel != nil {
+		m.cancel()
+	}
+	m.running = false
+}
+
+// IsRunning returns whether the monitor is currently running.
+func (m *Monitor) IsRunning() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.running
+}
+
+// run is the main monitoring loop.
+func (m *Monitor) run(ctx context.Context) {
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+
+	// Run initial check immediately.
+	m.checkAll(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			m.mu.Lock()
+			m.running = false
+			m.mu.Unlock()
+			return
+		case <-ticker.C:
+			m.checkAll(ctx)
+		}
+	}
+}
+
+// checkAll checks the health of all registered agents.
+func (m *Monitor) checkAll(ctx context.Context) {
+	agents := m.manager.GetAllHealth()
+
+	for agentName := range agents {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			m.checkAgent(ctx, agentName)
+		}
+	}
+}
+
+// checkAgent checks the health of a single agent and triggers recovery if needed.
+func (m *Monitor) checkAgent(ctx context.Context, agentName string) {
+	// Skip if no checker configured.
+	if m.checker == nil {
+		return
+	}
+
+	err := m.checker.CheckHealth(ctx, agentName)
+	if err != nil {
+		// Update health status to unresponsive.
+		m.manager.UpdateHealth(agentName, HealthStatusUnresponsive, err)
+
+		// Attempt recovery.
+		m.manager.RecoverAgent(ctx, agentName)
+	} else {
+		// Agent is healthy.
+		m.manager.UpdateHealth(agentName, HealthStatusHealthy, nil)
+	}
+}

--- a/internal/healthmgr/monitor_test.go
+++ b/internal/healthmgr/monitor_test.go
@@ -1,0 +1,232 @@
+package healthmgr
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// mockChecker is a mock implementation of HealthChecker for testing.
+type mockChecker struct {
+	mu        sync.Mutex
+	responses map[string]error
+	callCount atomic.Int32
+}
+
+func newMockChecker() *mockChecker {
+	return &mockChecker{
+		responses: make(map[string]error),
+	}
+}
+
+func (m *mockChecker) SetResponse(agentName string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.responses[agentName] = err
+}
+
+func (m *mockChecker) CheckHealth(_ context.Context, agentName string) error {
+	m.callCount.Add(1)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.responses[agentName]
+}
+
+func (m *mockChecker) GetCallCount() int {
+	return int(m.callCount.Load())
+}
+
+func TestMonitor_StartStop(t *testing.T) {
+	manager := NewManager()
+	manager.RegisterAgent("agent1")
+
+	checker := newMockChecker()
+	monitor := NewMonitor(manager, 50*time.Millisecond, checker)
+
+	// Initially not running.
+	if monitor.IsRunning() {
+		t.Error("monitor should not be running initially")
+	}
+
+	// Start monitoring.
+	ctx := context.Background()
+	monitor.Start(ctx)
+
+	// Give it time to start.
+	time.Sleep(10 * time.Millisecond)
+
+	if !monitor.IsRunning() {
+		t.Error("monitor should be running after Start()")
+	}
+
+	// Stop monitoring.
+	monitor.Stop()
+
+	// Give it time to stop.
+	time.Sleep(10 * time.Millisecond)
+
+	if monitor.IsRunning() {
+		t.Error("monitor should not be running after Stop()")
+	}
+}
+
+func TestMonitor_DoubleStart(t *testing.T) {
+	manager := NewManager()
+	checker := newMockChecker()
+	monitor := NewMonitor(manager, 50*time.Millisecond, checker)
+
+	ctx := context.Background()
+	monitor.Start(ctx)
+	defer monitor.Stop()
+
+	// Double start should be no-op.
+	monitor.Start(ctx)
+
+	if !monitor.IsRunning() {
+		t.Error("monitor should still be running after double Start()")
+	}
+}
+
+func TestMonitor_ChecksAgents(t *testing.T) {
+	manager := NewManager()
+	manager.RegisterAgent("agent1")
+	manager.RegisterAgent("agent2")
+
+	checker := newMockChecker()
+	monitor := NewMonitor(manager, 50*time.Millisecond, checker)
+
+	ctx := context.Background()
+	monitor.Start(ctx)
+	defer monitor.Stop()
+
+	// Wait for at least one check cycle.
+	time.Sleep(80 * time.Millisecond)
+
+	// Should have checked both agents at least once.
+	if checker.GetCallCount() < 2 {
+		t.Errorf("expected at least 2 health checks, got %d", checker.GetCallCount())
+	}
+}
+
+func TestMonitor_DetectsUnhealthy(t *testing.T) {
+	manager := NewManager()
+	manager.RegisterAgent("agent1")
+
+	checker := newMockChecker()
+	checker.SetResponse("agent1", errors.New("timeout"))
+
+	monitor := NewMonitor(manager, 50*time.Millisecond, checker)
+
+	ctx := context.Background()
+	monitor.Start(ctx)
+	defer monitor.Stop()
+
+	// Wait for check.
+	time.Sleep(80 * time.Millisecond)
+
+	health := manager.GetHealth("agent1")
+	if health == nil {
+		t.Fatal("expected health to be set")
+	}
+
+	// Should be unresponsive or dead (depending on recovery attempts).
+	if health.Status == HealthStatusHealthy {
+		t.Error("agent should not be healthy after error")
+	}
+}
+
+func TestMonitor_ContextCancellation(t *testing.T) {
+	manager := NewManager()
+	manager.RegisterAgent("agent1")
+
+	checker := newMockChecker()
+	monitor := NewMonitor(manager, 50*time.Millisecond, checker)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	monitor.Start(ctx)
+
+	// Verify running.
+	time.Sleep(10 * time.Millisecond)
+	if !monitor.IsRunning() {
+		t.Error("monitor should be running")
+	}
+
+	// Cancel context.
+	cancel()
+
+	// Wait for shutdown.
+	time.Sleep(80 * time.Millisecond)
+
+	if monitor.IsRunning() {
+		t.Error("monitor should stop after context cancellation")
+	}
+}
+
+func TestMonitor_NoCheckerNoPanic(t *testing.T) {
+	manager := NewManager()
+	manager.RegisterAgent("agent1")
+
+	// No checker - should not panic.
+	monitor := NewMonitor(manager, 50*time.Millisecond, nil)
+
+	ctx := context.Background()
+	monitor.Start(ctx)
+	defer monitor.Stop()
+
+	// Wait for check cycle.
+	time.Sleep(80 * time.Millisecond)
+
+	// Should complete without panic.
+}
+
+func TestMonitor_RecoveryOnError(t *testing.T) {
+	// Create manager with mock recovery handler.
+	recovered := atomic.Bool{}
+	handler := &mockRecoveryHandler{
+		startFunc: func(_ context.Context, _ string) error {
+			recovered.Store(true)
+			return nil
+		},
+	}
+
+	manager := NewManager(WithRecoveryHandler(handler))
+	manager.RegisterAgent("agent1")
+
+	checker := newMockChecker()
+	checker.SetResponse("agent1", errors.New("agent down"))
+
+	monitor := NewMonitor(manager, 50*time.Millisecond, checker)
+
+	ctx := context.Background()
+	monitor.Start(ctx)
+	defer monitor.Stop()
+
+	// Wait for check and recovery.
+	time.Sleep(200 * time.Millisecond)
+
+	if !recovered.Load() {
+		t.Error("expected recovery handler to be called")
+	}
+}
+
+type mockRecoveryHandler struct {
+	startFunc func(ctx context.Context, agentName string) error
+	stopFunc  func(ctx context.Context, agentName string) error
+}
+
+func (h *mockRecoveryHandler) StartAgent(ctx context.Context, agentName string) error {
+	if h.startFunc != nil {
+		return h.startFunc(ctx, agentName)
+	}
+	return nil
+}
+
+func (h *mockRecoveryHandler) StopAgent(ctx context.Context, agentName string) error {
+	if h.stopFunc != nil {
+		return h.stopFunc(ctx, agentName)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `Monitor` struct that runs periodic health checks for all registered agents
- When an agent fails health check, triggers automatic recovery via `RecoverAgent`
- Uses `HealthChecker` interface for pluggable health check implementations

## Changes
- `internal/healthmgr/monitor.go`: Monitoring loop implementation
- `internal/healthmgr/monitor_test.go`: Comprehensive tests (7 test cases)

## Test Plan
- [x] `go test ./internal/healthmgr/...` - all 35 tests pass
- [x] `gofmt -l .` - no formatting issues
- [x] `go vet ./...` - no issues

## Technical Details
- Monitor runs in background goroutine with configurable interval
- Properly handles context cancellation and graceful shutdown
- Thread-safe start/stop operations with mutex protection

Closes #253 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)