### PR TITLE
feat: add /reset command for graceful agent restart

### DIFF
--- a/cmd/maxam/tui.go
+++ b/cmd/maxam/tui.go
@@ -2327,6 +2327,75 @@ func (m *tuiModel) handleModeCommand(result mode.ParseResult) (tea.Model, tea.Cm
 				})
 			}
 		}
+
+	case mode.CommandReset:
+		// Gracefully restart agent(s)
+		if m.workerPool == nil {
+			m.messages = append(m.messages, tuiMessage{
+				role:    "system",
+				content: "⚠️ ワーカープールが初期化されていません。",
+			})
+			m.updateViewport()
+			return m, nil
+		}
+
+		args := strings.TrimSpace(result.Args)
+		if args == "" || args == "all" {
+			// Reset all agents
+			allAgents := m.workerPool.All()
+			resetCount := 0
+			for _, name := range allAgents {
+				m.workerPool.Kill(name)
+				if m.workerPool.Restart(name) {
+					resetCount++
+				}
+			}
+			m.messages = append(m.messages, tuiMessage{
+				role:    "system",
+				content: fmt.Sprintf("🔄 全エージェント(%d/%d)をリセットしました。", resetCount, len(allAgents)),
+			})
+		} else {
+			// Reset specific agent(s)
+			// Support: /reset @mei or /reset mei or /reset @mei @yuki
+			targets := strings.Fields(args)
+			reset := []string{}
+			notFound := []string{}
+
+			for _, target := range targets {
+				// Remove @ prefix if present
+				agentName := strings.TrimPrefix(target, "@")
+				agentName = strings.ToLower(agentName)
+
+				// Case-insensitive lookup
+				found := false
+				for _, name := range m.workerPool.All() {
+					if strings.ToLower(name) == agentName {
+						m.workerPool.Kill(name)
+						if m.workerPool.Restart(name) {
+							reset = append(reset, name)
+						}
+						found = true
+						break
+					}
+				}
+				if !found {
+					notFound = append(notFound, target)
+				}
+			}
+
+			if len(reset) > 0 {
+				m.messages = append(m.messages, tuiMessage{
+					role:    "system",
+					content: fmt.Sprintf("🔄 %s をリセットしました。", strings.Join(reset, ", ")),
+				})
+			}
+			if len(notFound) > 0 {
+				m.messages = append(m.messages, tuiMessage{
+					role:    "system",
+					content: fmt.Sprintf("❌ エージェントが見つかりません: %s", strings.Join(notFound, ", ")),
+				})
+			}
+		}
 	}
 
 	m.updateViewport()

--- a/internal/mode/command.go
+++ b/internal/mode/command.go
@@ -20,6 +20,8 @@ const (
 	CommandResetAuto Command = "/resetauto"
 	// CommandKill force kills agent(s) immediately
 	CommandKill Command = "/kill"
+	// CommandReset gracefully restarts agent(s)
+	CommandReset Command = "/reset"
 )
 
 // ParseResult contains the result of parsing user input for commands
@@ -34,7 +36,7 @@ func Parse(input string) ParseResult {
 	trimmed := strings.TrimSpace(input)
 
 	// Check for known commands
-	commands := []Command{CommandPlan, CommandAuto, CommandStop, CommandStatus, CommandResetAuto, CommandKill}
+	commands := []Command{CommandPlan, CommandAuto, CommandStop, CommandStatus, CommandResetAuto, CommandKill, CommandReset}
 	for _, cmd := range commands {
 		cmdStr := string(cmd)
 		if trimmed == cmdStr {

--- a/internal/mode/command_test.go
+++ b/internal/mode/command_test.go
@@ -109,6 +109,34 @@ func TestParse(t *testing.T) {
 			wantCmd:     CommandKill,
 			wantArgs:    "all",
 		},
+		{
+			name:        "/reset command",
+			input:       "/reset",
+			wantCommand: true,
+			wantCmd:     CommandReset,
+			wantArgs:    "",
+		},
+		{
+			name:        "/reset with agent",
+			input:       "/reset @mei",
+			wantCommand: true,
+			wantCmd:     CommandReset,
+			wantArgs:    "@mei",
+		},
+		{
+			name:        "/reset with multiple agents",
+			input:       "/reset @mei @yuki",
+			wantCommand: true,
+			wantCmd:     CommandReset,
+			wantArgs:    "@mei @yuki",
+		},
+		{
+			name:        "/reset all",
+			input:       "/reset all",
+			wantCommand: true,
+			wantCmd:     CommandReset,
+			wantArgs:    "all",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- TUIに `/reset @agent` コマンドを追加
- `/kill` とは異なり、graceful restart（kill → restart の組み合わせ）
- `@agent resume` を手動実行する必要がない

## 使い方
```
/reset @mei        # 特定エージェントをリセット
/reset @mei @yuki  # 複数エージェントをリセット
/reset all         # 全エージェントをリセット
/reset             # 全エージェントをリセット（all省略可）
```

## Test plan
- [ ] `go test ./internal/mode/...` でコマンドパース確認済み
- [ ] `go test ./...` 全テスト通過
- [ ] TUIで `/reset @mei` が動作すること

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)