### PR TITLE
feat(healthmgr): add health monitoring loop

### DIFF
--- a/internal/healthmgr/monitor.go
+++ b/internal/healthmgr/monitor.go
@@ -1,0 +1,184 @@
+package healthmgr
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// HealthChecker defines the interface for checking agent health.
+type HealthChecker interface {
+	// CheckHealth checks the health of an agent.
+	// Returns nil if healthy, error otherwise.
+	CheckHealth(ctx context.Context, agentName string) error
+}
+
+// Monitor runs periodic health checks for all registered agents.
+type Monitor struct {
+	mu            sync.RWMutex
+	manager       *Manager
+	checker       HealthChecker
+	interval      time.Duration
+	running       bool
+	stopCh        chan struct{}
+	onRecovery    func(result RecoveryResult)
+	checkTimeout  time.Duration
+	failThreshold int
+}
+
+// MonitorOption is a functional option for Monitor.
+type MonitorOption func(*Monitor)
+
+// NewMonitor creates a new health monitor.
+func NewMonitor(manager *Manager, checker HealthChecker, opts ...MonitorOption) *Monitor {
+	m := &Monitor{
+		manager:       manager,
+		checker:       checker,
+		interval:      30 * time.Second,
+		checkTimeout:  10 * time.Second,
+		failThreshold: 3,
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+// WithMonitorInterval sets the monitoring interval.
+func WithMonitorInterval(d time.Duration) MonitorOption {
+	return func(m *Monitor) {
+		m.interval = d
+	}
+}
+
+// WithCheckTimeout sets the timeout for each health check.
+func WithCheckTimeout(d time.Duration) MonitorOption {
+	return func(m *Monitor) {
+		m.checkTimeout = d
+	}
+}
+
+// WithFailThreshold sets the number of consecutive failures before triggering recovery.
+func WithFailThreshold(n int) MonitorOption {
+	return func(m *Monitor) {
+		m.failThreshold = n
+	}
+}
+
+// WithOnRecovery sets a callback for recovery events.
+func WithOnRecovery(fn func(result RecoveryResult)) MonitorOption {
+	return func(m *Monitor) {
+		m.onRecovery = fn
+	}
+}
+
+// Start begins the health monitoring loop.
+func (m *Monitor) Start(ctx context.Context) error {
+	m.mu.Lock()
+	if m.running {
+		m.mu.Unlock()
+		return nil
+	}
+	m.running = true
+	m.stopCh = make(chan struct{})
+	m.mu.Unlock()
+
+	go m.run(ctx)
+	return nil
+}
+
+// Stop stops the health monitoring loop.
+func (m *Monitor) Stop() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.running {
+		return
+	}
+
+	close(m.stopCh)
+	m.running = false
+}
+
+// IsRunning returns whether the monitor is running.
+func (m *Monitor) IsRunning() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.running
+}
+
+func (m *Monitor) run(ctx context.Context) {
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+
+	// Run initial check immediately.
+	m.checkAll(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			m.mu.Lock()
+			m.running = false
+			m.mu.Unlock()
+			return
+		case <-m.stopCh:
+			return
+		case <-ticker.C:
+			m.checkAll(ctx)
+		}
+	}
+}
+
+func (m *Monitor) checkAll(ctx context.Context) {
+	agents := m.manager.GetAllHealth()
+
+	for agentName := range agents {
+		select {
+		case <-ctx.Done():
+			return
+		case <-m.stopCh:
+			return
+		default:
+			m.checkAgent(ctx, agentName)
+		}
+	}
+}
+
+func (m *Monitor) checkAgent(ctx context.Context, agentName string) {
+	checkCtx, cancel := context.WithTimeout(ctx, m.checkTimeout)
+	defer cancel()
+
+	err := m.checker.CheckHealth(checkCtx, agentName)
+
+	if err != nil {
+		m.manager.UpdateHealth(agentName, HealthStatusUnresponsive, err)
+
+		// Check if we should trigger recovery.
+		health := m.manager.GetHealth(agentName)
+		if health != nil && health.FailCount >= m.failThreshold {
+			m.triggerRecovery(ctx, agentName)
+		}
+	} else {
+		m.manager.UpdateHealth(agentName, HealthStatusHealthy, nil)
+	}
+}
+
+func (m *Monitor) triggerRecovery(ctx context.Context, agentName string) {
+	result := m.manager.RecoverAgent(ctx, agentName)
+
+	if m.onRecovery != nil {
+		m.onRecovery(result)
+	}
+}
+
+// CheckNow triggers an immediate health check for all agents.
+func (m *Monitor) CheckNow(ctx context.Context) {
+	m.checkAll(ctx)
+}
+
+// CheckAgentNow triggers an immediate health check for a specific agent.
+func (m *Monitor) CheckAgentNow(ctx context.Context, agentName string) {
+	m.checkAgent(ctx, agentName)
+}

--- a/internal/healthmgr/monitor_test.go
+++ b/internal/healthmgr/monitor_test.go
@@ -1,0 +1,291 @@
+package healthmgr
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// mockHealthChecker implements HealthChecker for testing.
+type mockHealthChecker struct {
+	mu       sync.RWMutex
+	results  map[string]error
+	checkCnt int32
+}
+
+func newMockHealthChecker() *mockHealthChecker {
+	return &mockHealthChecker{
+		results: make(map[string]error),
+	}
+}
+
+func (m *mockHealthChecker) CheckHealth(_ context.Context, agentName string) error {
+	atomic.AddInt32(&m.checkCnt, 1)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.results[agentName]
+}
+
+func (m *mockHealthChecker) SetResult(agentName string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.results[agentName] = err
+}
+
+func (m *mockHealthChecker) CheckCount() int {
+	return int(atomic.LoadInt32(&m.checkCnt))
+}
+
+// mockRecoveryHandler implements RecoveryHandler for testing.
+type mockRecoveryHandler struct {
+	startErr   error
+	startCount int32
+}
+
+func (m *mockRecoveryHandler) StartAgent(_ context.Context, _ string) error {
+	atomic.AddInt32(&m.startCount, 1)
+	return m.startErr
+}
+
+func (m *mockRecoveryHandler) StopAgent(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *mockRecoveryHandler) StartCount() int {
+	return int(atomic.LoadInt32(&m.startCount))
+}
+
+func TestMonitor_StartStop(t *testing.T) {
+	manager := NewManager()
+	checker := newMockHealthChecker()
+	monitor := NewMonitor(manager, checker, WithMonitorInterval(10*time.Millisecond))
+
+	ctx := context.Background()
+
+	// Initially not running.
+	if monitor.IsRunning() {
+		t.Error("expected monitor to not be running initially")
+	}
+
+	// Start monitoring.
+	if err := monitor.Start(ctx); err != nil {
+		t.Fatalf("failed to start monitor: %v", err)
+	}
+
+	if !monitor.IsRunning() {
+		t.Error("expected monitor to be running after Start")
+	}
+
+	// Starting again should be idempotent.
+	if err := monitor.Start(ctx); err != nil {
+		t.Fatalf("second Start should not fail: %v", err)
+	}
+
+	// Stop monitoring.
+	monitor.Stop()
+
+	// Give it time to stop.
+	time.Sleep(20 * time.Millisecond)
+
+	if monitor.IsRunning() {
+		t.Error("expected monitor to not be running after Stop")
+	}
+
+	// Stopping again should be idempotent.
+	monitor.Stop()
+}
+
+func TestMonitor_PeriodicCheck(t *testing.T) {
+	manager := NewManager()
+	checker := newMockHealthChecker()
+	monitor := NewMonitor(manager, checker, WithMonitorInterval(10*time.Millisecond))
+
+	// Register an agent.
+	manager.RegisterAgent("test-agent")
+	checker.SetResult("test-agent", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := monitor.Start(ctx); err != nil {
+		t.Fatalf("failed to start monitor: %v", err)
+	}
+	defer monitor.Stop()
+
+	// Wait for at least 3 check cycles.
+	time.Sleep(50 * time.Millisecond)
+
+	if checker.CheckCount() < 2 {
+		t.Errorf("expected at least 2 health checks, got %d", checker.CheckCount())
+	}
+}
+
+func TestMonitor_HealthyAgent(t *testing.T) {
+	manager := NewManager()
+	checker := newMockHealthChecker()
+	monitor := NewMonitor(manager, checker, WithMonitorInterval(10*time.Millisecond))
+
+	manager.RegisterAgent("healthy-agent")
+	checker.SetResult("healthy-agent", nil)
+
+	ctx := context.Background()
+	monitor.CheckNow(ctx)
+
+	health := manager.GetHealth("healthy-agent")
+	if health == nil {
+		t.Fatal("expected health to be tracked")
+	}
+
+	if health.Status != HealthStatusHealthy {
+		t.Errorf("expected status %s, got %s", HealthStatusHealthy, health.Status)
+	}
+
+	if health.FailCount != 0 {
+		t.Errorf("expected failCount 0, got %d", health.FailCount)
+	}
+}
+
+func TestMonitor_UnhealthyAgent(t *testing.T) {
+	manager := NewManager()
+	checker := newMockHealthChecker()
+	monitor := NewMonitor(manager, checker,
+		WithMonitorInterval(10*time.Millisecond),
+		WithFailThreshold(3),
+	)
+
+	manager.RegisterAgent("unhealthy-agent")
+	checker.SetResult("unhealthy-agent", errors.New("connection refused"))
+
+	ctx := context.Background()
+
+	// First check - should mark as unresponsive.
+	monitor.CheckAgentNow(ctx, "unhealthy-agent")
+
+	health := manager.GetHealth("unhealthy-agent")
+	if health.Status != HealthStatusUnresponsive {
+		t.Errorf("expected status %s, got %s", HealthStatusUnresponsive, health.Status)
+	}
+
+	if health.FailCount != 1 {
+		t.Errorf("expected failCount 1, got %d", health.FailCount)
+	}
+
+	if health.LastError != "connection refused" {
+		t.Errorf("expected error message 'connection refused', got %s", health.LastError)
+	}
+}
+
+func TestMonitor_RecoveryTrigger(t *testing.T) {
+	handler := &mockRecoveryHandler{}
+	manager := NewManager(
+		WithRecoveryHandler(handler),
+		WithMaxRetries(1),
+		WithRetryDelay(1*time.Millisecond),
+	)
+	checker := newMockHealthChecker()
+
+	var recoveryResults []RecoveryResult
+	var mu sync.Mutex
+
+	monitor := NewMonitor(manager, checker,
+		WithMonitorInterval(10*time.Millisecond),
+		WithFailThreshold(2),
+		WithOnRecovery(func(result RecoveryResult) {
+			mu.Lock()
+			recoveryResults = append(recoveryResults, result)
+			mu.Unlock()
+		}),
+	)
+
+	manager.RegisterAgent("failing-agent")
+	checker.SetResult("failing-agent", errors.New("timeout"))
+
+	ctx := context.Background()
+
+	// First failure - should not trigger recovery.
+	monitor.CheckAgentNow(ctx, "failing-agent")
+	if handler.StartCount() != 0 {
+		t.Error("recovery should not trigger before threshold")
+	}
+
+	// Second failure - should trigger recovery.
+	monitor.CheckAgentNow(ctx, "failing-agent")
+
+	// Give recovery time to complete.
+	time.Sleep(20 * time.Millisecond)
+
+	if handler.StartCount() != 1 {
+		t.Errorf("expected 1 recovery attempt, got %d", handler.StartCount())
+	}
+
+	mu.Lock()
+	if len(recoveryResults) != 1 {
+		t.Errorf("expected 1 recovery result, got %d", len(recoveryResults))
+	}
+	if len(recoveryResults) > 0 && recoveryResults[0].AgentName != "failing-agent" {
+		t.Errorf("expected recovery for 'failing-agent', got %s", recoveryResults[0].AgentName)
+	}
+	mu.Unlock()
+}
+
+func TestMonitor_ContextCancellation(t *testing.T) {
+	manager := NewManager()
+	checker := newMockHealthChecker()
+	monitor := NewMonitor(manager, checker, WithMonitorInterval(100*time.Millisecond))
+
+	manager.RegisterAgent("test-agent")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := monitor.Start(ctx); err != nil {
+		t.Fatalf("failed to start monitor: %v", err)
+	}
+
+	// Cancel context.
+	cancel()
+
+	// Give it time to stop.
+	time.Sleep(20 * time.Millisecond)
+
+	if monitor.IsRunning() {
+		t.Error("expected monitor to stop on context cancellation")
+	}
+}
+
+func TestMonitor_CheckTimeout(t *testing.T) {
+	manager := NewManager()
+
+	// Create a checker that takes longer than timeout.
+	slowChecker := &slowHealthChecker{delay: 100 * time.Millisecond}
+	monitor := NewMonitor(manager, slowChecker,
+		WithCheckTimeout(10*time.Millisecond),
+	)
+
+	manager.RegisterAgent("slow-agent")
+
+	ctx := context.Background()
+	start := time.Now()
+	monitor.CheckAgentNow(ctx, "slow-agent")
+	elapsed := time.Since(start)
+
+	// Should timeout faster than checker delay.
+	if elapsed >= 100*time.Millisecond {
+		t.Errorf("expected check to timeout quickly, took %v", elapsed)
+	}
+}
+
+type slowHealthChecker struct {
+	delay time.Duration
+}
+
+func (s *slowHealthChecker) CheckHealth(ctx context.Context, _ string) error {
+	select {
+	case <-time.After(s.delay):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Monitor` struct that runs periodic health checks for all registered agents
- Add `HealthChecker` interface for pluggable health check implementations
- Trigger automatic recovery via `RecoverAgent` when agent fails health check threshold

## Changes
- `internal/healthmgr/monitor.go`: Monitoring loop implementation
- `internal/healthmgr/monitor_test.go`: Comprehensive tests (7 test cases)

## Technical Details
- Monitor runs in background goroutine with configurable interval
- Properly handles context cancellation and graceful shutdown
- Thread-safe start/stop operations with mutex protection
- Configurable check timeout and fail threshold

## Test Plan
- [x] `go test ./internal/healthmgr/...` - all 35 tests pass
- [x] `gofmt -l .` - no formatting issues
- [x] `go vet ./...` - no issues

## Reviewer (Required)
- [x] @priya

## Action Required
- [x] Priya によるレビュー

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)