### PR TITLE
feat(taskqueue,coordinator): add auto-recovery and task handover mechanism

### DIFF
--- a/internal/coordinator/api.go
+++ b/internal/coordinator/api.go
@@ -1,0 +1,234 @@
+package coordinator
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/ytnobody/MAXAM/internal/taskqueue"
+)
+
+// API provides HTTP handlers for taskqueue operations.
+type API struct {
+	coordinator *Coordinator
+}
+
+// NewAPI creates a new API handler.
+func NewAPI(coord *Coordinator) *API {
+	return &API{
+		coordinator: coord,
+	}
+}
+
+// PendingTasksResponse represents the response for GET /api/tasks/pending
+type PendingTasksResponse struct {
+	Tasks []PendingTaskItem `json:"tasks"`
+	Total int               `json:"total"`
+}
+
+// PendingTaskItem represents a task in the pending list
+type PendingTaskItem struct {
+	IssueNumber    int    `json:"issue_number"`
+	OriginalAgent  string `json:"original_agent"`
+	Priority       int    `json:"priority"`
+	CreatedAt      string `json:"created_at"`
+	ContextSummary string `json:"context_summary,omitempty"`
+}
+
+// HandoverResponse represents the response for GET /api/tasks/{id}/handover
+type HandoverResponse struct {
+	IssueNumber   int                       `json:"issue_number"`
+	Status        string                    `json:"status"`
+	OriginalAgent string                    `json:"original_agent"`
+	AssignedAgent string                    `json:"assigned_agent,omitempty"`
+	History       []taskqueue.HandoverEvent `json:"history"`
+	Context       string                    `json:"context,omitempty"`
+}
+
+// AssignRequest represents the request body for POST /api/tasks/{id}/assign
+type AssignRequest struct {
+	TargetAgent string `json:"target_agent"`
+}
+
+// AssignResponse represents the response for POST /api/tasks/{id}/assign
+type AssignResponse struct {
+	Success     bool   `json:"success"`
+	IssueNumber int    `json:"issue_number"`
+	AssignedTo  string `json:"assigned_to"`
+}
+
+// ErrorResponse represents an error response
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// HandlePendingTasks handles GET /api/tasks/pending
+func (a *API) HandlePendingTasks(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		a.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	queue := a.coordinator.GetQueue()
+	if queue == nil {
+		a.writeError(w, http.StatusServiceUnavailable, "task queue not available")
+		return
+	}
+
+	tasks, err := queue.ListPending()
+	if err != nil {
+		a.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	items := make([]PendingTaskItem, len(tasks))
+	for i, task := range tasks {
+		items[i] = PendingTaskItem{
+			IssueNumber:    task.IssueNumber,
+			OriginalAgent:  task.OriginalAgent,
+			Priority:       task.Priority,
+			CreatedAt:      task.CreatedAt.Format("2006-01-02T15:04:05Z"),
+			ContextSummary: task.ContextSummary,
+		}
+	}
+
+	resp := PendingTasksResponse{
+		Tasks: items,
+		Total: len(items),
+	}
+
+	a.writeJSON(w, http.StatusOK, resp)
+}
+
+// HandleTaskHandover handles GET /api/tasks/{id}/handover
+func (a *API) HandleTaskHandover(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		a.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// Extract issue number from path
+	issueNumber, err := a.extractIssueNumber(r.URL.Path, "/api/tasks/", "/handover")
+	if err != nil {
+		a.writeError(w, http.StatusBadRequest, "invalid issue number")
+		return
+	}
+
+	queue := a.coordinator.GetQueue()
+	if queue == nil {
+		a.writeError(w, http.StatusServiceUnavailable, "task queue not available")
+		return
+	}
+
+	task, err := queue.Get(issueNumber)
+	if err != nil {
+		if err == taskqueue.ErrTaskNotFound {
+			a.writeError(w, http.StatusNotFound, "task not found")
+			return
+		}
+		a.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	resp := HandoverResponse{
+		IssueNumber:   task.IssueNumber,
+		Status:        string(task.Status),
+		OriginalAgent: task.OriginalAgent,
+		AssignedAgent: task.AssignedAgent,
+		History:       task.History,
+		Context:       task.Context,
+	}
+
+	a.writeJSON(w, http.StatusOK, resp)
+}
+
+// HandleTaskAssign handles POST /api/tasks/{id}/assign
+func (a *API) HandleTaskAssign(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		a.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// Extract issue number from path
+	issueNumber, err := a.extractIssueNumber(r.URL.Path, "/api/tasks/", "/assign")
+	if err != nil {
+		a.writeError(w, http.StatusBadRequest, "invalid issue number")
+		return
+	}
+
+	// Parse request body
+	var req AssignRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		a.writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.TargetAgent == "" {
+		a.writeError(w, http.StatusBadRequest, "target_agent is required")
+		return
+	}
+
+	queue := a.coordinator.GetQueue()
+	if queue == nil {
+		a.writeError(w, http.StatusServiceUnavailable, "task queue not available")
+		return
+	}
+
+	err = queue.Assign(issueNumber, req.TargetAgent)
+	if err != nil {
+		if err == taskqueue.ErrTaskNotFound {
+			a.writeError(w, http.StatusNotFound, "task not found")
+			return
+		}
+		a.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	resp := AssignResponse{
+		Success:     true,
+		IssueNumber: issueNumber,
+		AssignedTo:  req.TargetAgent,
+	}
+
+	a.writeJSON(w, http.StatusOK, resp)
+}
+
+// extractIssueNumber extracts issue number from URL path
+// e.g., /api/tasks/123/handover -> 123
+func (a *API) extractIssueNumber(path, prefix, suffix string) (int, error) {
+	// Remove prefix and suffix
+	path = strings.TrimPrefix(path, prefix)
+	path = strings.TrimSuffix(path, suffix)
+	return strconv.Atoi(path)
+}
+
+// writeJSON writes a JSON response
+func (a *API) writeJSON(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(data)
+}
+
+// writeError writes an error response
+func (a *API) writeError(w http.ResponseWriter, status int, message string) {
+	a.writeJSON(w, status, ErrorResponse{Error: message})
+}
+
+// RegisterRoutes registers API routes with the given ServeMux
+func (a *API) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/tasks/pending", a.HandlePendingTasks)
+
+	// For path parameters, we need a catch-all handler
+	// In production, use a proper router like chi or gorilla/mux
+	mux.HandleFunc("/api/tasks/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if strings.HasSuffix(path, "/handover") {
+			a.HandleTaskHandover(w, r)
+		} else if strings.HasSuffix(path, "/assign") {
+			a.HandleTaskAssign(w, r)
+		} else {
+			http.NotFound(w, r)
+		}
+	})
+}

--- a/internal/coordinator/api_test.go
+++ b/internal/coordinator/api_test.go
@@ -1,0 +1,267 @@
+package coordinator
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ytnobody/MAXAM/internal/taskqueue"
+)
+
+func setupTestAPI() (*API, *taskqueue.Queue) {
+	store := taskqueue.NewMemoryStore()
+	queue := taskqueue.NewQueue(store)
+	coord := NewCoordinator(DefaultConfig(), queue)
+	api := NewAPI(coord)
+	return api, queue
+}
+
+func TestAPI_HandlePendingTasks_Empty(t *testing.T) {
+	api, _ := setupTestAPI()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/pending", nil)
+	w := httptest.NewRecorder()
+
+	api.HandlePendingTasks(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp PendingTasksResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if resp.Total != 0 {
+		t.Errorf("Total = %d, want 0", resp.Total)
+	}
+}
+
+func TestAPI_HandlePendingTasks_WithTasks(t *testing.T) {
+	api, queue := setupTestAPI()
+
+	// Add some tasks
+	_ = queue.Add(taskqueue.PendingTask{
+		IssueNumber:    123,
+		OriginalAgent:  "yuki-1",
+		Priority:       1,
+		ContextSummary: "PR review",
+	})
+	_ = queue.Add(taskqueue.PendingTask{
+		IssueNumber:    456,
+		OriginalAgent:  "rin-1",
+		Priority:       2,
+		ContextSummary: "Bug fix",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/pending", nil)
+	w := httptest.NewRecorder()
+
+	api.HandlePendingTasks(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp PendingTasksResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if resp.Total != 2 {
+		t.Errorf("Total = %d, want 2", resp.Total)
+	}
+
+	// Higher priority should come first
+	if resp.Tasks[0].IssueNumber != 456 {
+		t.Errorf("First task IssueNumber = %d, want 456 (higher priority)", resp.Tasks[0].IssueNumber)
+	}
+}
+
+func TestAPI_HandlePendingTasks_MethodNotAllowed(t *testing.T) {
+	api, _ := setupTestAPI()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/pending", nil)
+	w := httptest.NewRecorder()
+
+	api.HandlePendingTasks(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestAPI_HandleTaskHandover(t *testing.T) {
+	api, queue := setupTestAPI()
+
+	// Add a task
+	_ = queue.Add(taskqueue.PendingTask{
+		IssueNumber:   123,
+		OriginalAgent: "yuki-1",
+		Context:       "Working on PR #456",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/123/handover", nil)
+	w := httptest.NewRecorder()
+
+	api.HandleTaskHandover(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp HandoverResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if resp.IssueNumber != 123 {
+		t.Errorf("IssueNumber = %d, want 123", resp.IssueNumber)
+	}
+	if resp.OriginalAgent != "yuki-1" {
+		t.Errorf("OriginalAgent = %s, want yuki-1", resp.OriginalAgent)
+	}
+	if resp.Status != "pending" {
+		t.Errorf("Status = %s, want pending", resp.Status)
+	}
+	if len(resp.History) != 1 {
+		t.Errorf("History length = %d, want 1", len(resp.History))
+	}
+}
+
+func TestAPI_HandleTaskHandover_NotFound(t *testing.T) {
+	api, _ := setupTestAPI()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/999/handover", nil)
+	w := httptest.NewRecorder()
+
+	api.HandleTaskHandover(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestAPI_HandleTaskAssign(t *testing.T) {
+	api, queue := setupTestAPI()
+
+	// Add a task
+	_ = queue.Add(taskqueue.PendingTask{
+		IssueNumber:   123,
+		OriginalAgent: "yuki-1",
+	})
+
+	body := bytes.NewBufferString(`{"target_agent": "yuki-2"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/123/assign", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	api.HandleTaskAssign(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp AssignResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if !resp.Success {
+		t.Error("Success = false, want true")
+	}
+	if resp.IssueNumber != 123 {
+		t.Errorf("IssueNumber = %d, want 123", resp.IssueNumber)
+	}
+	if resp.AssignedTo != "yuki-2" {
+		t.Errorf("AssignedTo = %s, want yuki-2", resp.AssignedTo)
+	}
+
+	// Verify task was updated
+	task, _ := queue.Get(123)
+	if task.Status != taskqueue.HandoverStatusAssigned {
+		t.Errorf("Task status = %s, want assigned", task.Status)
+	}
+	if task.AssignedAgent != "yuki-2" {
+		t.Errorf("Task AssignedAgent = %s, want yuki-2", task.AssignedAgent)
+	}
+}
+
+func TestAPI_HandleTaskAssign_MissingTargetAgent(t *testing.T) {
+	api, queue := setupTestAPI()
+
+	_ = queue.Add(taskqueue.PendingTask{
+		IssueNumber:   123,
+		OriginalAgent: "yuki-1",
+	})
+
+	body := bytes.NewBufferString(`{}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/123/assign", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	api.HandleTaskAssign(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAPI_HandleTaskAssign_NotFound(t *testing.T) {
+	api, _ := setupTestAPI()
+
+	body := bytes.NewBufferString(`{"target_agent": "yuki-2"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/999/assign", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	api.HandleTaskAssign(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestAPI_RegisterRoutes(t *testing.T) {
+	api, queue := setupTestAPI()
+
+	// Add a task
+	_ = queue.Add(taskqueue.PendingTask{
+		IssueNumber:   123,
+		OriginalAgent: "yuki-1",
+	})
+
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	// Test /api/tasks/pending
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/pending", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/tasks/pending: Status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	// Test /api/tasks/123/handover
+	req = httptest.NewRequest(http.MethodGet, "/api/tasks/123/handover", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/tasks/123/handover: Status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	// Test /api/tasks/123/assign
+	body := bytes.NewBufferString(`{"target_agent": "rin-1"}`)
+	req = httptest.NewRequest(http.MethodPost, "/api/tasks/123/assign", body)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("POST /api/tasks/123/assign: Status = %d, want %d", w.Code, http.StatusOK)
+	}
+}

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -1,0 +1,272 @@
+// Package coordinator provides unified coordination between
+// heartbeat monitoring, recovery handling, and task handover.
+package coordinator
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/ytnobody/MAXAM/internal/taskqueue"
+)
+
+// AgentState represents the health state of an agent.
+type AgentState string
+
+const (
+	// StateHealthy indicates the agent is responding normally.
+	StateHealthy AgentState = "healthy"
+	// StateUnresponsive indicates the agent is not responding.
+	StateUnresponsive AgentState = "unresponsive"
+	// StateRecovering indicates recovery is in progress.
+	StateRecovering AgentState = "recovering"
+	// StateFailed indicates recovery failed after max retries.
+	StateFailed AgentState = "failed"
+)
+
+// Config holds coordinator configuration.
+type Config struct {
+	HealthCheckInterval time.Duration // Interval between health checks
+	ResponseTimeout     time.Duration // Timeout for agent responses
+	MaxRetries          int           // Maximum retry attempts
+	BackoffBase         time.Duration // Base duration for exponential backoff
+	BackoffMax          time.Duration // Maximum backoff duration
+}
+
+// DefaultConfig returns the default coordinator configuration.
+func DefaultConfig() Config {
+	return Config{
+		HealthCheckInterval: 5 * time.Second,
+		ResponseTimeout:     10 * time.Second,
+		MaxRetries:          3,
+		BackoffBase:         5 * time.Second,
+		BackoffMax:          60 * time.Second,
+	}
+}
+
+// AgentInfo holds information about an agent's state.
+type AgentInfo struct {
+	Name         string
+	State        AgentState
+	FailCount    int
+	LastCheck    time.Time
+	LastResponse time.Time
+	Tasks        []int // Issue numbers assigned to this agent
+}
+
+// RecoverFunc is called to attempt recovery of an agent.
+type RecoverFunc func(ctx context.Context, agentName string) error
+
+// NotifyFunc is called to send notifications.
+type NotifyFunc func(ctx context.Context, target, message string) error
+
+// GetTasksFunc returns the tasks assigned to an agent.
+type GetTasksFunc func(agentName string) []int
+
+// Coordinator manages the coordination between heartbeat, recovery, and task queue.
+type Coordinator struct {
+	cfg        Config
+	queue      *taskqueue.Queue
+	recoverFn  RecoverFunc
+	notifyFn   NotifyFunc
+	getTasksFn GetTasksFunc
+	agents     map[string]*AgentInfo
+	mu         sync.RWMutex
+}
+
+// NewCoordinator creates a new coordinator.
+func NewCoordinator(cfg Config, queue *taskqueue.Queue) *Coordinator {
+	if cfg.HealthCheckInterval <= 0 {
+		cfg.HealthCheckInterval = DefaultConfig().HealthCheckInterval
+	}
+	if cfg.ResponseTimeout <= 0 {
+		cfg.ResponseTimeout = DefaultConfig().ResponseTimeout
+	}
+	if cfg.MaxRetries <= 0 {
+		cfg.MaxRetries = DefaultConfig().MaxRetries
+	}
+	if cfg.BackoffBase <= 0 {
+		cfg.BackoffBase = DefaultConfig().BackoffBase
+	}
+	if cfg.BackoffMax <= 0 {
+		cfg.BackoffMax = DefaultConfig().BackoffMax
+	}
+
+	return &Coordinator{
+		cfg:    cfg,
+		queue:  queue,
+		agents: make(map[string]*AgentInfo),
+	}
+}
+
+// SetRecoverFunc sets the recovery function.
+func (c *Coordinator) SetRecoverFunc(fn RecoverFunc) {
+	c.recoverFn = fn
+}
+
+// SetNotifyFunc sets the notification function.
+func (c *Coordinator) SetNotifyFunc(fn NotifyFunc) {
+	c.notifyFn = fn
+}
+
+// SetGetTasksFunc sets the function to get tasks for an agent.
+func (c *Coordinator) SetGetTasksFunc(fn GetTasksFunc) {
+	c.getTasksFn = fn
+}
+
+// RegisterAgent registers an agent for monitoring.
+func (c *Coordinator) RegisterAgent(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.agents[name] = &AgentInfo{
+		Name:         name,
+		State:        StateHealthy,
+		LastCheck:    time.Now(),
+		LastResponse: time.Now(),
+	}
+}
+
+// UnregisterAgent removes an agent from monitoring.
+func (c *Coordinator) UnregisterAgent(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.agents, name)
+}
+
+// HandleHeartbeat processes a successful heartbeat from an agent.
+func (c *Coordinator) HandleHeartbeat(agentName string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	agent, exists := c.agents[agentName]
+	if !exists {
+		// Auto-register if not exists
+		agent = &AgentInfo{
+			Name: agentName,
+		}
+		c.agents[agentName] = agent
+	}
+
+	agent.State = StateHealthy
+	agent.FailCount = 0
+	agent.LastCheck = time.Now()
+	agent.LastResponse = time.Now()
+}
+
+// HandleFailure processes a failure detection for an agent.
+// Returns true if recovery was successful.
+func (c *Coordinator) HandleFailure(ctx context.Context, agentName string) bool {
+	c.mu.Lock()
+	agent, exists := c.agents[agentName]
+	if !exists {
+		c.mu.Unlock()
+		return false
+	}
+
+	agent.FailCount++
+	agent.LastCheck = time.Now()
+	agent.State = StateUnresponsive
+	failCount := agent.FailCount
+	c.mu.Unlock()
+
+	// Step 1: Try recovery with exponential backoff
+	if failCount <= c.cfg.MaxRetries {
+		agent.State = StateRecovering
+
+		backoff := c.calculateBackoff(failCount)
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(backoff):
+		}
+
+		if c.recoverFn != nil {
+			if err := c.recoverFn(ctx, agentName); err == nil {
+				c.HandleHeartbeat(agentName) // Reset state on success
+				return true
+			}
+		}
+	}
+
+	// Step 2: Recovery failed - move tasks to queue
+	if failCount >= c.cfg.MaxRetries {
+		c.mu.Lock()
+		agent.State = StateFailed
+		c.mu.Unlock()
+
+		c.handoverTasks(ctx, agentName)
+	}
+
+	return false
+}
+
+// calculateBackoff calculates the backoff duration using exponential formula.
+// backoff = base * 2^(attempt-1), capped at backoff_max
+func (c *Coordinator) calculateBackoff(attempt int) time.Duration {
+	if attempt <= 0 {
+		return c.cfg.BackoffBase
+	}
+
+	backoff := c.cfg.BackoffBase
+	for i := 1; i < attempt; i++ {
+		backoff *= 2
+		if backoff > c.cfg.BackoffMax {
+			return c.cfg.BackoffMax
+		}
+	}
+	return backoff
+}
+
+// handoverTasks moves tasks from a failed agent to the queue.
+func (c *Coordinator) handoverTasks(ctx context.Context, agentName string) {
+	if c.getTasksFn == nil || c.queue == nil {
+		return
+	}
+
+	tasks := c.getTasksFn(agentName)
+	for _, issueNumber := range tasks {
+		task := taskqueue.PendingTask{
+			IssueNumber:    issueNumber,
+			OriginalAgent:  agentName,
+			Priority:       1, // Default priority
+			ContextSummary: "Handed over due to agent failure",
+		}
+		_ = c.queue.Add(task) // Best effort
+	}
+
+	// Notify PM about the handover
+	if c.notifyFn != nil {
+		message := "Agent " + agentName + " failed. Tasks queued for reassignment."
+		_ = c.notifyFn(ctx, "mei", message)
+	}
+}
+
+// GetAgentState returns the current state of an agent.
+func (c *Coordinator) GetAgentState(agentName string) (AgentInfo, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	agent, exists := c.agents[agentName]
+	if !exists {
+		return AgentInfo{}, false
+	}
+	return *agent, true
+}
+
+// GetAllAgents returns all registered agents.
+func (c *Coordinator) GetAllAgents() map[string]AgentInfo {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	result := make(map[string]AgentInfo, len(c.agents))
+	for name, agent := range c.agents {
+		result[name] = *agent
+	}
+	return result
+}
+
+// GetQueue returns the task queue.
+func (c *Coordinator) GetQueue() *taskqueue.Queue {
+	return c.queue
+}

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -1,0 +1,181 @@
+package coordinator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ytnobody/MAXAM/internal/taskqueue"
+)
+
+func TestCoordinator_RegisterAgent(t *testing.T) {
+	store := taskqueue.NewMemoryStore()
+	queue := taskqueue.NewQueue(store)
+	coord := NewCoordinator(DefaultConfig(), queue)
+
+	coord.RegisterAgent("yuki-1")
+
+	info, exists := coord.GetAgentState("yuki-1")
+	if !exists {
+		t.Fatal("Agent should exist after registration")
+	}
+	if info.State != StateHealthy {
+		t.Errorf("State = %s, want healthy", info.State)
+	}
+}
+
+func TestCoordinator_HandleHeartbeat(t *testing.T) {
+	store := taskqueue.NewMemoryStore()
+	queue := taskqueue.NewQueue(store)
+	coord := NewCoordinator(DefaultConfig(), queue)
+
+	// Auto-register via heartbeat
+	coord.HandleHeartbeat("rin-1")
+
+	info, exists := coord.GetAgentState("rin-1")
+	if !exists {
+		t.Fatal("Agent should exist after heartbeat")
+	}
+	if info.State != StateHealthy {
+		t.Errorf("State = %s, want healthy", info.State)
+	}
+	if info.FailCount != 0 {
+		t.Errorf("FailCount = %d, want 0", info.FailCount)
+	}
+}
+
+func TestCoordinator_HandleFailure_WithRecovery(t *testing.T) {
+	store := taskqueue.NewMemoryStore()
+	queue := taskqueue.NewQueue(store)
+
+	cfg := Config{
+		HealthCheckInterval: 100 * time.Millisecond,
+		ResponseTimeout:     100 * time.Millisecond,
+		MaxRetries:          3,
+		BackoffBase:         10 * time.Millisecond, // Short for testing
+		BackoffMax:          50 * time.Millisecond,
+	}
+	coord := NewCoordinator(cfg, queue)
+
+	// Set recovery function that succeeds
+	recoverCalled := false
+	coord.SetRecoverFunc(func(ctx context.Context, name string) error {
+		recoverCalled = true
+		return nil
+	})
+
+	coord.RegisterAgent("shiori-1")
+
+	ctx := context.Background()
+	recovered := coord.HandleFailure(ctx, "shiori-1")
+
+	if !recoverCalled {
+		t.Error("Recovery function should have been called")
+	}
+	if !recovered {
+		t.Error("HandleFailure should return true when recovery succeeds")
+	}
+
+	info, _ := coord.GetAgentState("shiori-1")
+	if info.State != StateHealthy {
+		t.Errorf("State = %s, want healthy after recovery", info.State)
+	}
+}
+
+func TestCoordinator_HandleFailure_MaxRetries(t *testing.T) {
+	store := taskqueue.NewMemoryStore()
+	queue := taskqueue.NewQueue(store)
+
+	cfg := Config{
+		MaxRetries:  2,
+		BackoffBase: 1 * time.Millisecond,
+		BackoffMax:  5 * time.Millisecond,
+	}
+	coord := NewCoordinator(cfg, queue)
+
+	// Set recovery function that always fails
+	coord.SetRecoverFunc(func(ctx context.Context, name string) error {
+		return context.DeadlineExceeded
+	})
+
+	// Track tasks for the agent
+	coord.SetGetTasksFunc(func(name string) []int {
+		return []int{123, 456}
+	})
+
+	coord.RegisterAgent("priya-1")
+
+	ctx := context.Background()
+
+	// Fail multiple times
+	for i := 0; i < cfg.MaxRetries; i++ {
+		coord.HandleFailure(ctx, "priya-1")
+	}
+
+	info, _ := coord.GetAgentState("priya-1")
+	if info.State != StateFailed {
+		t.Errorf("State = %s, want failed after max retries", info.State)
+	}
+
+	// Check that tasks were added to queue
+	pending, _ := queue.ListPending()
+	if len(pending) != 2 {
+		t.Errorf("Pending tasks = %d, want 2", len(pending))
+	}
+}
+
+func TestCoordinator_CalculateBackoff(t *testing.T) {
+	cfg := Config{
+		BackoffBase: 5 * time.Second,
+		BackoffMax:  60 * time.Second,
+	}
+	coord := NewCoordinator(cfg, nil)
+
+	tests := []struct {
+		attempt  int
+		expected time.Duration
+	}{
+		{1, 5 * time.Second},  // base * 2^0 = 5
+		{2, 10 * time.Second}, // base * 2^1 = 10
+		{3, 20 * time.Second}, // base * 2^2 = 20
+		{4, 40 * time.Second}, // base * 2^3 = 40
+		{5, 60 * time.Second}, // capped at max
+		{6, 60 * time.Second}, // capped at max
+	}
+
+	for _, tt := range tests {
+		got := coord.calculateBackoff(tt.attempt)
+		if got != tt.expected {
+			t.Errorf("calculateBackoff(%d) = %v, want %v", tt.attempt, got, tt.expected)
+		}
+	}
+}
+
+func TestCoordinator_GetAllAgents(t *testing.T) {
+	store := taskqueue.NewMemoryStore()
+	queue := taskqueue.NewQueue(store)
+	coord := NewCoordinator(DefaultConfig(), queue)
+
+	coord.RegisterAgent("yuki-1")
+	coord.RegisterAgent("rin-1")
+	coord.RegisterAgent("shiori-1")
+
+	agents := coord.GetAllAgents()
+	if len(agents) != 3 {
+		t.Errorf("GetAllAgents() = %d agents, want 3", len(agents))
+	}
+}
+
+func TestCoordinator_UnregisterAgent(t *testing.T) {
+	store := taskqueue.NewMemoryStore()
+	queue := taskqueue.NewQueue(store)
+	coord := NewCoordinator(DefaultConfig(), queue)
+
+	coord.RegisterAgent("amara-1")
+	coord.UnregisterAgent("amara-1")
+
+	_, exists := coord.GetAgentState("amara-1")
+	if exists {
+		t.Error("Agent should not exist after unregistration")
+	}
+}

--- a/internal/taskqueue/memory_store.go
+++ b/internal/taskqueue/memory_store.go
@@ -1,0 +1,90 @@
+package taskqueue
+
+import (
+	"errors"
+	"sort"
+)
+
+var (
+	// ErrTaskNotFound is returned when a task is not found.
+	ErrTaskNotFound = errors.New("task not found")
+	// ErrTaskAlreadyExists is returned when adding a task that already exists.
+	ErrTaskAlreadyExists = errors.New("task already exists")
+)
+
+// MemoryStore provides an in-memory implementation of TaskStore.
+// Phase 1 implementation - tasks are lost on restart.
+type MemoryStore struct {
+	tasks map[int]PendingTask
+}
+
+// NewMemoryStore creates a new in-memory task store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		tasks: make(map[int]PendingTask),
+	}
+}
+
+// Add adds a task to the store.
+func (s *MemoryStore) Add(task PendingTask) error {
+	if _, exists := s.tasks[task.IssueNumber]; exists {
+		return ErrTaskAlreadyExists
+	}
+	s.tasks[task.IssueNumber] = task
+	return nil
+}
+
+// Get retrieves a task by issue number.
+func (s *MemoryStore) Get(issueNumber int) (*PendingTask, error) {
+	task, exists := s.tasks[issueNumber]
+	if !exists {
+		return nil, ErrTaskNotFound
+	}
+	return &task, nil
+}
+
+// List returns all tasks sorted by priority (higher first) and creation time.
+func (s *MemoryStore) List() ([]PendingTask, error) {
+	tasks := make([]PendingTask, 0, len(s.tasks))
+	for _, task := range s.tasks {
+		tasks = append(tasks, task)
+	}
+
+	// Sort by priority (descending) then by created_at (ascending)
+	sort.Slice(tasks, func(i, j int) bool {
+		if tasks[i].Priority != tasks[j].Priority {
+			return tasks[i].Priority > tasks[j].Priority
+		}
+		return tasks[i].CreatedAt.Before(tasks[j].CreatedAt)
+	})
+
+	return tasks, nil
+}
+
+// Update updates a task in the store.
+func (s *MemoryStore) Update(task PendingTask) error {
+	if _, exists := s.tasks[task.IssueNumber]; !exists {
+		return ErrTaskNotFound
+	}
+	s.tasks[task.IssueNumber] = task
+	return nil
+}
+
+// Remove removes a task from the store.
+func (s *MemoryStore) Remove(issueNumber int) error {
+	if _, exists := s.tasks[issueNumber]; !exists {
+		return ErrTaskNotFound
+	}
+	delete(s.tasks, issueNumber)
+	return nil
+}
+
+// Clear removes all tasks from the store.
+func (s *MemoryStore) Clear() {
+	s.tasks = make(map[int]PendingTask)
+}
+
+// Count returns the number of tasks in the store.
+func (s *MemoryStore) Count() int {
+	return len(s.tasks)
+}

--- a/internal/taskqueue/queue.go
+++ b/internal/taskqueue/queue.go
@@ -1,0 +1,198 @@
+// Package taskqueue provides task handover queue management.
+package taskqueue
+
+import (
+	"sync"
+	"time"
+)
+
+// HandoverStatus represents the status of a pending task.
+type HandoverStatus string
+
+const (
+	// HandoverStatusPending indicates the task is waiting for reassignment.
+	HandoverStatusPending HandoverStatus = "pending"
+	// HandoverStatusAssigned indicates the task has been assigned to another agent.
+	HandoverStatusAssigned HandoverStatus = "assigned"
+	// HandoverStatusCompleted indicates the handover was completed successfully.
+	HandoverStatusCompleted HandoverStatus = "completed"
+	// HandoverStatusFailed indicates the handover failed.
+	HandoverStatusFailed HandoverStatus = "failed"
+)
+
+// HandoverEvent represents a single event in the handover history.
+type HandoverEvent struct {
+	Timestamp time.Time `json:"timestamp"`
+	Event     string    `json:"event"`
+	From      string    `json:"from,omitempty"`
+	To        string    `json:"to,omitempty"`
+	Reason    string    `json:"reason,omitempty"`
+}
+
+// PendingTask represents a task waiting for handover.
+type PendingTask struct {
+	IssueNumber    int             `json:"issue_number"`
+	OriginalAgent  string          `json:"original_agent"`
+	AssignedAgent  string          `json:"assigned_agent,omitempty"`
+	Context        string          `json:"context,omitempty"`
+	ContextSummary string          `json:"context_summary,omitempty"`
+	Priority       int             `json:"priority"`
+	Status         HandoverStatus  `json:"status"`
+	CreatedAt      time.Time       `json:"created_at"`
+	History        []HandoverEvent `json:"history,omitempty"`
+}
+
+// TaskStore defines the interface for task storage.
+// Phase 1: MemoryStore implementation
+// Phase 2: FileStore implementation (future)
+type TaskStore interface {
+	// Add adds a task to the queue.
+	Add(task PendingTask) error
+	// Get retrieves a task by issue number.
+	Get(issueNumber int) (*PendingTask, error)
+	// List returns all pending tasks.
+	List() ([]PendingTask, error)
+	// Update updates a task in the queue.
+	Update(task PendingTask) error
+	// Remove removes a task from the queue.
+	Remove(issueNumber int) error
+}
+
+// Queue manages pending tasks with thread-safe operations.
+type Queue struct {
+	store TaskStore
+	mu    sync.RWMutex
+}
+
+// NewQueue creates a new task queue with the given store.
+func NewQueue(store TaskStore) *Queue {
+	return &Queue{
+		store: store,
+	}
+}
+
+// Add adds a new pending task to the queue.
+func (q *Queue) Add(task PendingTask) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	// Set defaults
+	if task.Status == "" {
+		task.Status = HandoverStatusPending
+	}
+	if task.CreatedAt.IsZero() {
+		task.CreatedAt = time.Now()
+	}
+
+	// Add initial event to history
+	task.History = append(task.History, HandoverEvent{
+		Timestamp: time.Now(),
+		Event:     "queued",
+		From:      task.OriginalAgent,
+		Reason:    "agent_unresponsive",
+	})
+
+	return q.store.Add(task)
+}
+
+// Get retrieves a task by issue number.
+func (q *Queue) Get(issueNumber int) (*PendingTask, error) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.store.Get(issueNumber)
+}
+
+// List returns all pending tasks.
+func (q *Queue) List() ([]PendingTask, error) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.store.List()
+}
+
+// ListPending returns only tasks with pending status.
+func (q *Queue) ListPending() ([]PendingTask, error) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	allTasks, err := q.store.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var pending []PendingTask
+	for _, task := range allTasks {
+		if task.Status == HandoverStatusPending {
+			pending = append(pending, task)
+		}
+	}
+	return pending, nil
+}
+
+// Assign assigns a pending task to a new agent.
+func (q *Queue) Assign(issueNumber int, targetAgent string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	task, err := q.store.Get(issueNumber)
+	if err != nil {
+		return err
+	}
+
+	task.AssignedAgent = targetAgent
+	task.Status = HandoverStatusAssigned
+	task.History = append(task.History, HandoverEvent{
+		Timestamp: time.Now(),
+		Event:     "assigned",
+		To:        targetAgent,
+		Reason:    "auto_reassignment",
+	})
+
+	return q.store.Update(*task)
+}
+
+// Complete marks a task as completed.
+func (q *Queue) Complete(issueNumber int) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	task, err := q.store.Get(issueNumber)
+	if err != nil {
+		return err
+	}
+
+	task.Status = HandoverStatusCompleted
+	task.History = append(task.History, HandoverEvent{
+		Timestamp: time.Now(),
+		Event:     "completed",
+		Reason:    "handover_success",
+	})
+
+	return q.store.Update(*task)
+}
+
+// Fail marks a task as failed.
+func (q *Queue) Fail(issueNumber int, reason string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	task, err := q.store.Get(issueNumber)
+	if err != nil {
+		return err
+	}
+
+	task.Status = HandoverStatusFailed
+	task.History = append(task.History, HandoverEvent{
+		Timestamp: time.Now(),
+		Event:     "failed",
+		Reason:    reason,
+	})
+
+	return q.store.Update(*task)
+}
+
+// Remove removes a task from the queue.
+func (q *Queue) Remove(issueNumber int) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.store.Remove(issueNumber)
+}

--- a/internal/taskqueue/queue_test.go
+++ b/internal/taskqueue/queue_test.go
@@ -1,0 +1,206 @@
+package taskqueue
+
+import (
+	"testing"
+	"time"
+)
+
+func TestQueue_Add(t *testing.T) {
+	store := NewMemoryStore()
+	queue := NewQueue(store)
+
+	task := PendingTask{
+		IssueNumber:   123,
+		OriginalAgent: "yuki-1",
+		Context:       "PR review in progress",
+		Priority:      1,
+	}
+
+	err := queue.Add(task)
+	if err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	// Verify task was added
+	got, err := queue.Get(123)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if got.IssueNumber != 123 {
+		t.Errorf("IssueNumber = %d, want 123", got.IssueNumber)
+	}
+	if got.OriginalAgent != "yuki-1" {
+		t.Errorf("OriginalAgent = %s, want yuki-1", got.OriginalAgent)
+	}
+	if got.Status != HandoverStatusPending {
+		t.Errorf("Status = %s, want pending", got.Status)
+	}
+	if len(got.History) != 1 {
+		t.Errorf("History length = %d, want 1", len(got.History))
+	}
+	if got.History[0].Event != "queued" {
+		t.Errorf("History[0].Event = %s, want queued", got.History[0].Event)
+	}
+}
+
+func TestQueue_AddDuplicate(t *testing.T) {
+	store := NewMemoryStore()
+	queue := NewQueue(store)
+
+	task := PendingTask{
+		IssueNumber:   123,
+		OriginalAgent: "yuki-1",
+	}
+
+	_ = queue.Add(task)
+	err := queue.Add(task)
+	if err != ErrTaskAlreadyExists {
+		t.Errorf("Add() duplicate error = %v, want ErrTaskAlreadyExists", err)
+	}
+}
+
+func TestQueue_Assign(t *testing.T) {
+	store := NewMemoryStore()
+	queue := NewQueue(store)
+
+	task := PendingTask{
+		IssueNumber:   123,
+		OriginalAgent: "yuki-1",
+	}
+	_ = queue.Add(task)
+
+	err := queue.Assign(123, "yuki-2")
+	if err != nil {
+		t.Fatalf("Assign() error = %v", err)
+	}
+
+	got, _ := queue.Get(123)
+	if got.AssignedAgent != "yuki-2" {
+		t.Errorf("AssignedAgent = %s, want yuki-2", got.AssignedAgent)
+	}
+	if got.Status != HandoverStatusAssigned {
+		t.Errorf("Status = %s, want assigned", got.Status)
+	}
+	if len(got.History) != 2 {
+		t.Errorf("History length = %d, want 2", len(got.History))
+	}
+}
+
+func TestQueue_Complete(t *testing.T) {
+	store := NewMemoryStore()
+	queue := NewQueue(store)
+
+	task := PendingTask{
+		IssueNumber:   123,
+		OriginalAgent: "yuki-1",
+	}
+	_ = queue.Add(task)
+	_ = queue.Assign(123, "yuki-2")
+
+	err := queue.Complete(123)
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+
+	got, _ := queue.Get(123)
+	if got.Status != HandoverStatusCompleted {
+		t.Errorf("Status = %s, want completed", got.Status)
+	}
+}
+
+func TestQueue_Fail(t *testing.T) {
+	store := NewMemoryStore()
+	queue := NewQueue(store)
+
+	task := PendingTask{
+		IssueNumber:   123,
+		OriginalAgent: "yuki-1",
+	}
+	_ = queue.Add(task)
+
+	err := queue.Fail(123, "no available agent")
+	if err != nil {
+		t.Fatalf("Fail() error = %v", err)
+	}
+
+	got, _ := queue.Get(123)
+	if got.Status != HandoverStatusFailed {
+		t.Errorf("Status = %s, want failed", got.Status)
+	}
+}
+
+func TestQueue_ListPending(t *testing.T) {
+	store := NewMemoryStore()
+	queue := NewQueue(store)
+
+	// Add multiple tasks
+	_ = queue.Add(PendingTask{IssueNumber: 1, OriginalAgent: "yuki-1"})
+	_ = queue.Add(PendingTask{IssueNumber: 2, OriginalAgent: "rin-1"})
+	_ = queue.Add(PendingTask{IssueNumber: 3, OriginalAgent: "shiori-1"})
+
+	// Assign one task
+	_ = queue.Assign(2, "yuki-2")
+
+	pending, err := queue.ListPending()
+	if err != nil {
+		t.Fatalf("ListPending() error = %v", err)
+	}
+
+	if len(pending) != 2 {
+		t.Errorf("ListPending() count = %d, want 2", len(pending))
+	}
+}
+
+func TestMemoryStore_PrioritySort(t *testing.T) {
+	store := NewMemoryStore()
+
+	now := time.Now()
+	_ = store.Add(PendingTask{IssueNumber: 1, Priority: 1, CreatedAt: now})
+	_ = store.Add(PendingTask{IssueNumber: 2, Priority: 3, CreatedAt: now.Add(time.Second)})
+	_ = store.Add(PendingTask{IssueNumber: 3, Priority: 2, CreatedAt: now.Add(2 * time.Second)})
+
+	tasks, _ := store.List()
+
+	// Should be sorted by priority descending
+	if tasks[0].IssueNumber != 2 {
+		t.Errorf("First task should be issue 2 (priority 3), got %d", tasks[0].IssueNumber)
+	}
+	if tasks[1].IssueNumber != 3 {
+		t.Errorf("Second task should be issue 3 (priority 2), got %d", tasks[1].IssueNumber)
+	}
+	if tasks[2].IssueNumber != 1 {
+		t.Errorf("Third task should be issue 1 (priority 1), got %d", tasks[2].IssueNumber)
+	}
+}
+
+func TestQueue_Remove(t *testing.T) {
+	store := NewMemoryStore()
+	queue := NewQueue(store)
+
+	task := PendingTask{
+		IssueNumber:   123,
+		OriginalAgent: "yuki-1",
+	}
+	_ = queue.Add(task)
+
+	err := queue.Remove(123)
+	if err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+
+	_, err = queue.Get(123)
+	if err != ErrTaskNotFound {
+		t.Errorf("Get() after Remove should return ErrTaskNotFound, got %v", err)
+	}
+}
+
+func TestQueue_GetNotFound(t *testing.T) {
+	store := NewMemoryStore()
+	queue := NewQueue(store)
+
+	_, err := queue.Get(999)
+	if err != ErrTaskNotFound {
+		t.Errorf("Get() nonexistent = %v, want ErrTaskNotFound", err)
+	}
+}


### PR DESCRIPTION
## Summary
- 🚑 エージェント障害時の自動復旧機構を実装
- 📦 復旧失敗時のタスク引き継ぎキューを追加
- 🔌 HTTP API で引き継ぎタスクの管理が可能に

## Changes

### taskqueue パッケージ
| ファイル | 内容 |
|---------|------|
| `queue.go` | PendingTask、HandoverStatus、キュー操作 |
| `memory_store.go` | インメモリストア（Phase 1） |
| `queue_test.go` | 9テストケース |

### coordinator パッケージ
| ファイル | 内容 |
|---------|------|
| `coordinator.go` | 障害検知、自動復旧、引き継ぎ統合 |
| `api.go` | HTTP API（/api/tasks/pending 等） |
| `*_test.go` | 16テストケース |

## Key Features
- ✅ 自動リトライ（configurable max retries）
- ✅ 指数バックオフ（base * 2^attempt, capped at max）
- ✅ 復旧失敗時のみ PM に通知
- ✅ 優先度付きタスクキュー

## Test plan
- [x] `go test ./internal/taskqueue/...` → 9 tests PASS
- [x] `go test ./internal/coordinator/...` → 16 tests PASS
- [x] `gofmt -l .` → 出力なし
- [x] `go vet ./...` → エラーなし

## API Endpoints
```
GET  /api/tasks/pending       # 引き継ぎ待ちタスク一覧
GET  /api/tasks/{id}/handover # タスク詳細
POST /api/tasks/{id}/assign   # タスク割り当て
```

## Reviewer (Required)
- [x] @priya

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)