### PR TITLE
feat(taskqueue): add task handover mechanism for agent failure recovery

### DIFF
--- a/internal/taskqueue/integration.go
+++ b/internal/taskqueue/integration.go
@@ -1,0 +1,169 @@
+package taskqueue
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// TaskHandoverHandler is called when a task needs to be handed over.
+type TaskHandoverHandler func(ctx context.Context, result HandoverResult) error
+
+// NotifyHandler is called to send notifications.
+type NotifyHandler func(ctx context.Context, target, message string) error
+
+// Coordinator integrates task queue with health management.
+type Coordinator struct {
+	mu              sync.RWMutex
+	queue           *Queue
+	handoverHandler TaskHandoverHandler
+	notifyHandler   NotifyHandler
+	pmAgent         string
+}
+
+// CoordinatorOption is a functional option for Coordinator.
+type CoordinatorOption func(*Coordinator)
+
+// WithHandoverHandler sets the handover handler.
+func WithHandoverHandler(h TaskHandoverHandler) CoordinatorOption {
+	return func(c *Coordinator) {
+		c.handoverHandler = h
+	}
+}
+
+// WithNotifyHandler sets the notify handler.
+func WithNotifyHandler(h NotifyHandler) CoordinatorOption {
+	return func(c *Coordinator) {
+		c.notifyHandler = h
+	}
+}
+
+// WithPMAgent sets the PM agent name for notifications.
+func WithPMAgent(pm string) CoordinatorOption {
+	return func(c *Coordinator) {
+		c.pmAgent = pm
+	}
+}
+
+// NewCoordinator creates a new task coordinator.
+func NewCoordinator(queue *Queue, opts ...CoordinatorOption) *Coordinator {
+	c := &Coordinator{
+		queue:   queue,
+		pmAgent: "mei", // default PM
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// OnAgentFailure handles agent failure by attempting task handover.
+// Returns list of tasks that were successfully handed over.
+func (c *Coordinator) OnAgentFailure(ctx context.Context, agentName string, reason string) []HandoverResult {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Get handoverable tasks for the failed agent.
+	tasks := c.queue.GetHandoverableTasks(agentName)
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	var results []HandoverResult
+
+	for _, task := range tasks {
+		result := c.queue.Handover(HandoverRequest{
+			TaskID:    task.ID,
+			FromAgent: agentName,
+			ToAgent:   "", // Auto-assign.
+			Reason:    reason,
+		})
+
+		results = append(results, result)
+
+		// Call handover handler if set.
+		if result.Success && c.handoverHandler != nil {
+			_ = c.handoverHandler(ctx, result)
+		}
+	}
+
+	// Notify PM about handovers.
+	c.notifyHandovers(ctx, agentName, results)
+
+	return results
+}
+
+// notifyHandovers sends a summary notification to PM.
+func (c *Coordinator) notifyHandovers(ctx context.Context, failedAgent string, results []HandoverResult) {
+	if c.notifyHandler == nil || len(results) == 0 {
+		return
+	}
+
+	successCount := 0
+	failedCount := 0
+	for _, r := range results {
+		if r.Success {
+			successCount++
+		} else {
+			failedCount++
+		}
+	}
+
+	var message string
+	if failedCount == 0 {
+		message = fmt.Sprintf(
+			"エージェント %s 障害発生。%d タスクを他エージェントに引き継ぎ完了。",
+			failedAgent, successCount,
+		)
+	} else {
+		message = fmt.Sprintf(
+			"エージェント %s 障害発生。引き継ぎ: %d 成功, %d 失敗。手動対応が必要です。",
+			failedAgent, successCount, failedCount,
+		)
+	}
+
+	_ = c.notifyHandler(ctx, c.pmAgent, message)
+}
+
+// MarkAgentUnavailable marks an agent as unavailable for new tasks.
+func (c *Coordinator) MarkAgentUnavailable(agentName string) error {
+	return c.queue.SetAgentAvailability(agentName, false)
+}
+
+// MarkAgentAvailable marks an agent as available for new tasks.
+func (c *Coordinator) MarkAgentAvailable(agentName string) error {
+	return c.queue.SetAgentAvailability(agentName, true)
+}
+
+// GetQueue returns the underlying task queue.
+func (c *Coordinator) GetQueue() *Queue {
+	return c.queue
+}
+
+// RegisterTask registers a task and assigns it to an agent.
+func (c *Coordinator) RegisterTask(task *Task, agentName string) error {
+	c.queue.AddTask(task)
+	return c.queue.AssignTask(task.ID, agentName)
+}
+
+// CompleteTask marks a task as completed.
+func (c *Coordinator) CompleteTask(taskID string) error {
+	return c.queue.CompleteTask(taskID)
+}
+
+// FailTask marks a task as failed.
+func (c *Coordinator) FailTask(taskID, reason string) error {
+	return c.queue.FailTask(taskID, reason)
+}
+
+// GetTasksForAgent returns all tasks assigned to an agent.
+func (c *Coordinator) GetTasksForAgent(agentName string) []*Task {
+	return c.queue.GetTasksForAgent(agentName)
+}
+
+// GetPendingTasks returns all pending tasks.
+func (c *Coordinator) GetPendingTasks() []*Task {
+	return c.queue.GetPendingTasks()
+}

--- a/internal/taskqueue/integration_test.go
+++ b/internal/taskqueue/integration_test.go
@@ -1,0 +1,340 @@
+package taskqueue
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCoordinator_OnAgentFailure(t *testing.T) {
+	q := NewQueue()
+
+	// Register agents.
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent1",
+		Available: true,
+	})
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent2",
+		Available: true,
+	})
+
+	// Add tasks to agent1.
+	q.AddTask(&Task{
+		ID:           "task1",
+		AssignedTo:   "agent1",
+		Status:       TaskStatusInProgress,
+		Handoverable: true,
+	})
+	q.AddTask(&Task{
+		ID:           "task2",
+		AssignedTo:   "agent1",
+		Status:       TaskStatusInProgress,
+		Handoverable: true,
+	})
+	q.tasksByAgent["agent1"] = []string{"task1", "task2"}
+
+	// Track handover handler calls.
+	handoverCalls := 0
+	handoverHandler := func(ctx context.Context, result HandoverResult) error {
+		handoverCalls++
+		return nil
+	}
+
+	// Track notify handler calls.
+	notifyCalls := 0
+	var lastNotifyMessage string
+	notifyHandler := func(ctx context.Context, target, message string) error {
+		notifyCalls++
+		lastNotifyMessage = message
+		return nil
+	}
+
+	coord := NewCoordinator(q,
+		WithHandoverHandler(handoverHandler),
+		WithNotifyHandler(notifyHandler),
+	)
+
+	// Simulate agent1 failure.
+	results := coord.OnAgentFailure(context.Background(), "agent1", "agent unresponsive")
+
+	// Verify handovers.
+	if len(results) != 2 {
+		t.Errorf("expected 2 handover results, got %d", len(results))
+	}
+
+	successCount := 0
+	for _, r := range results {
+		if r.Success {
+			successCount++
+			if r.ToAgent != "agent2" {
+				t.Errorf("expected handover to agent2, got %s", r.ToAgent)
+			}
+		}
+	}
+	if successCount != 2 {
+		t.Errorf("expected 2 successful handovers, got %d", successCount)
+	}
+
+	// Verify handler calls.
+	if handoverCalls != 2 {
+		t.Errorf("expected 2 handover handler calls, got %d", handoverCalls)
+	}
+	if notifyCalls != 1 {
+		t.Errorf("expected 1 notify call, got %d", notifyCalls)
+	}
+	if lastNotifyMessage == "" {
+		t.Error("expected notify message to be set")
+	}
+}
+
+func TestCoordinator_OnAgentFailure_NoTasks(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent1",
+		Available: true,
+	})
+
+	coord := NewCoordinator(q)
+
+	results := coord.OnAgentFailure(context.Background(), "agent1", "agent unresponsive")
+
+	if results != nil {
+		t.Errorf("expected nil results, got %v", results)
+	}
+}
+
+func TestCoordinator_OnAgentFailure_PartialSuccess(t *testing.T) {
+	q := NewQueue()
+
+	// Only one other agent, will be at capacity after first handover.
+	q.RegisterAgent(AgentCapability{
+		AgentName:    "agent1",
+		Available:    true,
+		CurrentTasks: 0,
+	})
+	q.RegisterAgent(AgentCapability{
+		AgentName:    "agent2",
+		Available:    true,
+		MaxTasks:     1, // Can only take 1 task.
+		CurrentTasks: 0,
+	})
+
+	// Add 2 tasks to agent1.
+	q.AddTask(&Task{
+		ID:           "task1",
+		AssignedTo:   "agent1",
+		Status:       TaskStatusInProgress,
+		Handoverable: true,
+	})
+	q.AddTask(&Task{
+		ID:           "task2",
+		AssignedTo:   "agent1",
+		Status:       TaskStatusInProgress,
+		Handoverable: true,
+	})
+	q.tasksByAgent["agent1"] = []string{"task1", "task2"}
+
+	var notifyMessage string
+	notifyHandler := func(ctx context.Context, target, message string) error {
+		notifyMessage = message
+		return nil
+	}
+
+	coord := NewCoordinator(q, WithNotifyHandler(notifyHandler))
+
+	results := coord.OnAgentFailure(context.Background(), "agent1", "agent unresponsive")
+
+	// First handover should succeed, second should fail.
+	successCount := 0
+	failCount := 0
+	for _, r := range results {
+		if r.Success {
+			successCount++
+		} else {
+			failCount++
+		}
+	}
+
+	if successCount != 1 {
+		t.Errorf("expected 1 success, got %d", successCount)
+	}
+	if failCount != 1 {
+		t.Errorf("expected 1 failure, got %d", failCount)
+	}
+
+	// Notify message should mention manual intervention.
+	if notifyMessage == "" {
+		t.Error("expected notify message to be set")
+	}
+}
+
+func TestCoordinator_MarkAgentAvailability(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent1",
+		Available: true,
+	})
+
+	coord := NewCoordinator(q)
+
+	// Mark unavailable.
+	err := coord.MarkAgentUnavailable("agent1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	agents := q.GetAvailableAgents()
+	if len(agents) != 0 {
+		t.Errorf("expected 0 available agents, got %d", len(agents))
+	}
+
+	// Mark available.
+	err = coord.MarkAgentAvailable("agent1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	agents = q.GetAvailableAgents()
+	if len(agents) != 1 {
+		t.Errorf("expected 1 available agent, got %d", len(agents))
+	}
+}
+
+func TestCoordinator_RegisterTask(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent1",
+		Available: true,
+	})
+
+	coord := NewCoordinator(q)
+
+	task := &Task{
+		ID:           "task1",
+		Description:  "Test task",
+		Handoverable: true,
+	}
+
+	err := coord.RegisterTask(task, "agent1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := q.GetTask("task1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AssignedTo != "agent1" {
+		t.Errorf("expected agent1, got %s", got.AssignedTo)
+	}
+	if got.Status != TaskStatusInProgress {
+		t.Errorf("expected in_progress status, got %s", got.Status)
+	}
+}
+
+func TestCoordinator_CompleteAndFailTask(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent1",
+		Available: true,
+	})
+
+	coord := NewCoordinator(q)
+
+	// Test CompleteTask.
+	task1 := &Task{ID: "task1", Handoverable: true}
+	_ = coord.RegisterTask(task1, "agent1")
+
+	err := coord.CompleteTask("task1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got1, _ := q.GetTask("task1")
+	if got1.Status != TaskStatusCompleted {
+		t.Errorf("expected completed, got %s", got1.Status)
+	}
+
+	// Test FailTask.
+	task2 := &Task{ID: "task2", Handoverable: true}
+	_ = coord.RegisterTask(task2, "agent1")
+
+	err = coord.FailTask("task2", "test error")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got2, _ := q.GetTask("task2")
+	if got2.Status != TaskStatusFailed {
+		t.Errorf("expected failed, got %s", got2.Status)
+	}
+}
+
+func TestCoordinator_GetTasks(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent1",
+		Available: true,
+	})
+
+	coord := NewCoordinator(q)
+
+	// Add some tasks.
+	_ = coord.RegisterTask(&Task{ID: "task1"}, "agent1")
+	q.AddTask(&Task{ID: "task2", Status: TaskStatusPending})
+
+	// Test GetTasksForAgent.
+	tasks := coord.GetTasksForAgent("agent1")
+	if len(tasks) != 1 {
+		t.Errorf("expected 1 task for agent1, got %d", len(tasks))
+	}
+
+	// Test GetPendingTasks.
+	pending := coord.GetPendingTasks()
+	if len(pending) != 1 {
+		t.Errorf("expected 1 pending task, got %d", len(pending))
+	}
+}
+
+func TestCoordinator_WithPMAgent(t *testing.T) {
+	q := NewQueue()
+
+	var notifyTarget string
+	notifyHandler := func(ctx context.Context, target, message string) error {
+		notifyTarget = target
+		return nil
+	}
+
+	coord := NewCoordinator(q,
+		WithPMAgent("custom_pm"),
+		WithNotifyHandler(notifyHandler),
+	)
+
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent1",
+		Available: true,
+	})
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent2",
+		Available: true,
+	})
+
+	q.AddTask(&Task{
+		ID:           "task1",
+		AssignedTo:   "agent1",
+		Status:       TaskStatusInProgress,
+		Handoverable: true,
+	})
+	q.tasksByAgent["agent1"] = []string{"task1"}
+
+	coord.OnAgentFailure(context.Background(), "agent1", "test")
+
+	if notifyTarget != "custom_pm" {
+		t.Errorf("expected custom_pm, got %s", notifyTarget)
+	}
+}

--- a/internal/taskqueue/queue.go
+++ b/internal/taskqueue/queue.go
@@ -1,0 +1,436 @@
+package taskqueue
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrTaskNotFound is returned when a task is not found.
+	ErrTaskNotFound = errors.New("task not found")
+	// ErrTaskNotHandoverable is returned when a task cannot be handed over.
+	ErrTaskNotHandoverable = errors.New("task is not handoverable")
+	// ErrMaxHandoversExceeded is returned when max handovers are exceeded.
+	ErrMaxHandoversExceeded = errors.New("max handovers exceeded")
+	// ErrNoAvailableAgent is returned when no agent is available for handover.
+	ErrNoAvailableAgent = errors.New("no available agent for handover")
+	// ErrAgentNotFound is returned when an agent is not found.
+	ErrAgentNotFound = errors.New("agent not found")
+)
+
+// Queue manages tasks and their assignments to agents.
+type Queue struct {
+	mu           sync.RWMutex
+	tasks        map[string]*Task
+	agents       map[string]*AgentCapability
+	tasksByAgent map[string][]string // agentName -> []taskID
+}
+
+// NewQueue creates a new task queue.
+func NewQueue() *Queue {
+	return &Queue{
+		tasks:        make(map[string]*Task),
+		agents:       make(map[string]*AgentCapability),
+		tasksByAgent: make(map[string][]string),
+	}
+}
+
+// RegisterAgent registers an agent with its capabilities.
+func (q *Queue) RegisterAgent(cap AgentCapability) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.agents[cap.AgentName] = &cap
+	if _, exists := q.tasksByAgent[cap.AgentName]; !exists {
+		q.tasksByAgent[cap.AgentName] = []string{}
+	}
+}
+
+// UnregisterAgent removes an agent from the queue.
+func (q *Queue) UnregisterAgent(agentName string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	delete(q.agents, agentName)
+	delete(q.tasksByAgent, agentName)
+}
+
+// SetAgentAvailability sets whether an agent is available for new tasks.
+func (q *Queue) SetAgentAvailability(agentName string, available bool) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	agent, exists := q.agents[agentName]
+	if !exists {
+		return ErrAgentNotFound
+	}
+	agent.Available = available
+	return nil
+}
+
+// AddTask adds a new task to the queue.
+func (q *Queue) AddTask(task *Task) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if task.CreatedAt.IsZero() {
+		task.CreatedAt = time.Now()
+	}
+	if task.Status == "" {
+		task.Status = TaskStatusPending
+	}
+	if task.Metadata == nil {
+		task.Metadata = make(map[string]string)
+	}
+	if task.PreviousAgents == nil {
+		task.PreviousAgents = []string{}
+	}
+
+	q.tasks[task.ID] = task
+
+	if task.AssignedTo != "" {
+		q.tasksByAgent[task.AssignedTo] = append(q.tasksByAgent[task.AssignedTo], task.ID)
+		q.updateAgentTaskCount(task.AssignedTo)
+	}
+}
+
+// GetTask returns a task by ID.
+func (q *Queue) GetTask(taskID string) (*Task, error) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	task, exists := q.tasks[taskID]
+	if !exists {
+		return nil, ErrTaskNotFound
+	}
+
+	// Return a copy to prevent external mutations.
+	t := *task
+	t.Metadata = copyMap(task.Metadata)
+	t.PreviousAgents = copySlice(task.PreviousAgents)
+	return &t, nil
+}
+
+// AssignTask assigns a task to an agent.
+func (q *Queue) AssignTask(taskID, agentName string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	task, exists := q.tasks[taskID]
+	if !exists {
+		return ErrTaskNotFound
+	}
+
+	agent, exists := q.agents[agentName]
+	if !exists {
+		return ErrAgentNotFound
+	}
+
+	// Remove from old agent if reassigning.
+	if task.AssignedTo != "" && task.AssignedTo != agentName {
+		q.removeTaskFromAgent(task.AssignedTo, taskID)
+	}
+
+	task.AssignedTo = agentName
+	task.Status = TaskStatusInProgress
+	task.StartedAt = time.Now()
+
+	q.tasksByAgent[agentName] = append(q.tasksByAgent[agentName], taskID)
+	agent.CurrentTasks++
+
+	return nil
+}
+
+// CompleteTask marks a task as completed.
+func (q *Queue) CompleteTask(taskID string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	task, exists := q.tasks[taskID]
+	if !exists {
+		return ErrTaskNotFound
+	}
+
+	task.Status = TaskStatusCompleted
+	task.CompletedAt = time.Now()
+
+	if task.AssignedTo != "" {
+		q.removeTaskFromAgent(task.AssignedTo, taskID)
+	}
+
+	return nil
+}
+
+// FailTask marks a task as failed.
+func (q *Queue) FailTask(taskID, reason string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	task, exists := q.tasks[taskID]
+	if !exists {
+		return ErrTaskNotFound
+	}
+
+	task.Status = TaskStatusFailed
+	task.CompletedAt = time.Now()
+	task.Metadata["fail_reason"] = reason
+
+	if task.AssignedTo != "" {
+		q.removeTaskFromAgent(task.AssignedTo, taskID)
+	}
+
+	return nil
+}
+
+// Handover attempts to hand over a task to another agent.
+func (q *Queue) Handover(req HandoverRequest) HandoverResult {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	result := HandoverResult{
+		TaskID:    req.TaskID,
+		FromAgent: req.FromAgent,
+	}
+
+	task, exists := q.tasks[req.TaskID]
+	if !exists {
+		result.Error = ErrTaskNotFound.Error()
+		return result
+	}
+
+	if !task.Handoverable {
+		result.Error = ErrTaskNotHandoverable.Error()
+		return result
+	}
+
+	if task.MaxHandovers > 0 && task.HandoverCount >= task.MaxHandovers {
+		result.Error = ErrMaxHandoversExceeded.Error()
+		return result
+	}
+
+	// Find target agent.
+	targetAgent := req.ToAgent
+	if targetAgent == "" {
+		// Auto-assign to an available agent.
+		targetAgent = q.findAvailableAgentLocked(req.FromAgent, task.PreviousAgents)
+		if targetAgent == "" {
+			result.Error = ErrNoAvailableAgent.Error()
+			return result
+		}
+	}
+
+	// Verify target agent exists and is available.
+	agent, exists := q.agents[targetAgent]
+	if !exists {
+		result.Error = ErrAgentNotFound.Error()
+		return result
+	}
+	if !agent.Available {
+		result.Error = "target agent is not available"
+		return result
+	}
+	if agent.MaxTasks > 0 && agent.CurrentTasks >= agent.MaxTasks {
+		result.Error = "target agent has reached max tasks"
+		return result
+	}
+
+	// Perform handover.
+	if task.AssignedTo != "" {
+		task.PreviousAgents = append(task.PreviousAgents, task.AssignedTo)
+		q.removeTaskFromAgent(task.AssignedTo, req.TaskID)
+	}
+
+	task.AssignedTo = targetAgent
+	task.Status = TaskStatusHandover
+	task.HandoverCount++
+	task.Metadata["handover_reason"] = req.Reason
+	task.Metadata["handover_time"] = time.Now().Format(time.RFC3339)
+
+	q.tasksByAgent[targetAgent] = append(q.tasksByAgent[targetAgent], req.TaskID)
+	agent.CurrentTasks++
+
+	result.Success = true
+	result.ToAgent = targetAgent
+	return result
+}
+
+// GetTasksForAgent returns all tasks assigned to an agent.
+func (q *Queue) GetTasksForAgent(agentName string) []*Task {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	taskIDs, exists := q.tasksByAgent[agentName]
+	if !exists {
+		return nil
+	}
+
+	tasks := make([]*Task, 0, len(taskIDs))
+	for _, id := range taskIDs {
+		if task, exists := q.tasks[id]; exists {
+			t := *task
+			t.Metadata = copyMap(task.Metadata)
+			t.PreviousAgents = copySlice(task.PreviousAgents)
+			tasks = append(tasks, &t)
+		}
+	}
+
+	return tasks
+}
+
+// GetPendingTasks returns all pending tasks.
+func (q *Queue) GetPendingTasks() []*Task {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	var tasks []*Task
+	for _, task := range q.tasks {
+		if task.Status == TaskStatusPending {
+			t := *task
+			t.Metadata = copyMap(task.Metadata)
+			t.PreviousAgents = copySlice(task.PreviousAgents)
+			tasks = append(tasks, &t)
+		}
+	}
+
+	return tasks
+}
+
+// GetHandoverableTasks returns tasks that can be handed over for a given agent.
+func (q *Queue) GetHandoverableTasks(agentName string) []*Task {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	taskIDs, exists := q.tasksByAgent[agentName]
+	if !exists {
+		return nil
+	}
+
+	var tasks []*Task
+	for _, id := range taskIDs {
+		task, exists := q.tasks[id]
+		if !exists {
+			continue
+		}
+		if !task.Handoverable {
+			continue
+		}
+		if task.MaxHandovers > 0 && task.HandoverCount >= task.MaxHandovers {
+			continue
+		}
+
+		t := *task
+		t.Metadata = copyMap(task.Metadata)
+		t.PreviousAgents = copySlice(task.PreviousAgents)
+		tasks = append(tasks, &t)
+	}
+
+	return tasks
+}
+
+// GetAvailableAgents returns agents that can accept new tasks.
+func (q *Queue) GetAvailableAgents() []AgentCapability {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	var agents []AgentCapability
+	for _, agent := range q.agents {
+		if !agent.Available {
+			continue
+		}
+		if agent.MaxTasks > 0 && agent.CurrentTasks >= agent.MaxTasks {
+			continue
+		}
+		agents = append(agents, *agent)
+	}
+
+	return agents
+}
+
+// RemoveTask removes a task from the queue.
+func (q *Queue) RemoveTask(taskID string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	task, exists := q.tasks[taskID]
+	if !exists {
+		return ErrTaskNotFound
+	}
+
+	if task.AssignedTo != "" {
+		q.removeTaskFromAgent(task.AssignedTo, taskID)
+	}
+
+	delete(q.tasks, taskID)
+	return nil
+}
+
+// --- Internal helpers ---
+
+func (q *Queue) removeTaskFromAgent(agentName, taskID string) {
+	tasks := q.tasksByAgent[agentName]
+	for i, id := range tasks {
+		if id == taskID {
+			q.tasksByAgent[agentName] = append(tasks[:i], tasks[i+1:]...)
+			break
+		}
+	}
+	q.updateAgentTaskCount(agentName)
+}
+
+func (q *Queue) updateAgentTaskCount(agentName string) {
+	if agent, exists := q.agents[agentName]; exists {
+		agent.CurrentTasks = len(q.tasksByAgent[agentName])
+	}
+}
+
+func (q *Queue) findAvailableAgentLocked(excludeAgent string, excludePrevious []string) string {
+	excluded := make(map[string]bool)
+	excluded[excludeAgent] = true
+	for _, agent := range excludePrevious {
+		excluded[agent] = true
+	}
+
+	var bestAgent string
+	minTasks := -1
+
+	for name, agent := range q.agents {
+		if excluded[name] {
+			continue
+		}
+		if !agent.Available {
+			continue
+		}
+		if agent.MaxTasks > 0 && agent.CurrentTasks >= agent.MaxTasks {
+			continue
+		}
+
+		// Choose agent with fewest tasks.
+		if minTasks < 0 || agent.CurrentTasks < minTasks {
+			bestAgent = name
+			minTasks = agent.CurrentTasks
+		}
+	}
+
+	return bestAgent
+}
+
+func copyMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	result := make(map[string]string, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+func copySlice(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	result := make([]string, len(s))
+	copy(result, s)
+	return result
+}

--- a/internal/taskqueue/queue_test.go
+++ b/internal/taskqueue/queue_test.go
@@ -1,0 +1,520 @@
+package taskqueue
+
+import (
+	"testing"
+	"time"
+)
+
+func TestQueue_RegisterAgent(t *testing.T) {
+	q := NewQueue()
+
+	cap := AgentCapability{
+		AgentName:    "agent1",
+		Available:    true,
+		CurrentTasks: 0,
+		MaxTasks:     5,
+	}
+	q.RegisterAgent(cap)
+
+	agents := q.GetAvailableAgents()
+	if len(agents) != 1 {
+		t.Errorf("expected 1 agent, got %d", len(agents))
+	}
+	if agents[0].AgentName != "agent1" {
+		t.Errorf("expected agent1, got %s", agents[0].AgentName)
+	}
+}
+
+func TestQueue_AddTask(t *testing.T) {
+	q := NewQueue()
+
+	task := &Task{
+		ID:           "task1",
+		Description:  "Test task",
+		Handoverable: true,
+	}
+	q.AddTask(task)
+
+	got, err := q.GetTask("task1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != "task1" {
+		t.Errorf("expected task1, got %s", got.ID)
+	}
+	if got.Status != TaskStatusPending {
+		t.Errorf("expected pending status, got %s", got.Status)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set")
+	}
+}
+
+func TestQueue_AssignTask(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent1",
+		Available: true,
+		MaxTasks:  5,
+	})
+
+	task := &Task{
+		ID:           "task1",
+		Description:  "Test task",
+		Handoverable: true,
+	}
+	q.AddTask(task)
+
+	err := q.AssignTask("task1", "agent1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, _ := q.GetTask("task1")
+	if got.AssignedTo != "agent1" {
+		t.Errorf("expected agent1, got %s", got.AssignedTo)
+	}
+	if got.Status != TaskStatusInProgress {
+		t.Errorf("expected in_progress status, got %s", got.Status)
+	}
+
+	tasks := q.GetTasksForAgent("agent1")
+	if len(tasks) != 1 {
+		t.Errorf("expected 1 task, got %d", len(tasks))
+	}
+}
+
+func TestQueue_AssignTask_Errors(t *testing.T) {
+	q := NewQueue()
+
+	// Task not found.
+	err := q.AssignTask("nonexistent", "agent1")
+	if err != ErrTaskNotFound {
+		t.Errorf("expected ErrTaskNotFound, got %v", err)
+	}
+
+	// Agent not found.
+	q.AddTask(&Task{ID: "task1"})
+	err = q.AssignTask("task1", "nonexistent")
+	if err != ErrAgentNotFound {
+		t.Errorf("expected ErrAgentNotFound, got %v", err)
+	}
+}
+
+func TestQueue_CompleteTask(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent1",
+		Available: true,
+	})
+
+	task := &Task{ID: "task1"}
+	q.AddTask(task)
+	_ = q.AssignTask("task1", "agent1")
+
+	err := q.CompleteTask("task1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, _ := q.GetTask("task1")
+	if got.Status != TaskStatusCompleted {
+		t.Errorf("expected completed status, got %s", got.Status)
+	}
+	if got.CompletedAt.IsZero() {
+		t.Error("expected CompletedAt to be set")
+	}
+
+	// Task should be removed from agent's list.
+	tasks := q.GetTasksForAgent("agent1")
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks, got %d", len(tasks))
+	}
+}
+
+func TestQueue_FailTask(t *testing.T) {
+	q := NewQueue()
+
+	task := &Task{ID: "task1"}
+	q.AddTask(task)
+
+	err := q.FailTask("task1", "some error")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, _ := q.GetTask("task1")
+	if got.Status != TaskStatusFailed {
+		t.Errorf("expected failed status, got %s", got.Status)
+	}
+	if got.Metadata["fail_reason"] != "some error" {
+		t.Errorf("expected fail_reason to be set")
+	}
+}
+
+func TestQueue_Handover_Success(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent1",
+		Available: true,
+	})
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent2",
+		Available: true,
+	})
+
+	task := &Task{
+		ID:           "task1",
+		AssignedTo:   "agent1",
+		Status:       TaskStatusInProgress,
+		Handoverable: true,
+	}
+	q.AddTask(task)
+	q.tasksByAgent["agent1"] = []string{"task1"}
+
+	result := q.Handover(HandoverRequest{
+		TaskID:    "task1",
+		FromAgent: "agent1",
+		ToAgent:   "agent2",
+		Reason:    "agent1 is unresponsive",
+	})
+
+	if !result.Success {
+		t.Errorf("expected success, got error: %s", result.Error)
+	}
+	if result.ToAgent != "agent2" {
+		t.Errorf("expected agent2, got %s", result.ToAgent)
+	}
+
+	got, _ := q.GetTask("task1")
+	if got.AssignedTo != "agent2" {
+		t.Errorf("expected agent2, got %s", got.AssignedTo)
+	}
+	if got.HandoverCount != 1 {
+		t.Errorf("expected handover count 1, got %d", got.HandoverCount)
+	}
+	if len(got.PreviousAgents) != 1 || got.PreviousAgents[0] != "agent1" {
+		t.Errorf("expected previous agents [agent1], got %v", got.PreviousAgents)
+	}
+}
+
+func TestQueue_Handover_AutoAssign(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{
+		AgentName:    "agent1",
+		Available:    true,
+		CurrentTasks: 2,
+	})
+	q.RegisterAgent(AgentCapability{
+		AgentName:    "agent2",
+		Available:    true,
+		CurrentTasks: 0, // Fewer tasks, should be chosen.
+	})
+
+	task := &Task{
+		ID:           "task1",
+		AssignedTo:   "agent1",
+		Status:       TaskStatusInProgress,
+		Handoverable: true,
+	}
+	q.AddTask(task)
+	q.tasksByAgent["agent1"] = []string{"task1"}
+
+	result := q.Handover(HandoverRequest{
+		TaskID:    "task1",
+		FromAgent: "agent1",
+		ToAgent:   "", // Auto-assign.
+		Reason:    "agent1 is unresponsive",
+	})
+
+	if !result.Success {
+		t.Errorf("expected success, got error: %s", result.Error)
+	}
+	if result.ToAgent != "agent2" {
+		t.Errorf("expected agent2 (fewer tasks), got %s", result.ToAgent)
+	}
+}
+
+func TestQueue_Handover_NotHandoverable(t *testing.T) {
+	q := NewQueue()
+
+	task := &Task{
+		ID:           "task1",
+		Handoverable: false,
+	}
+	q.AddTask(task)
+
+	result := q.Handover(HandoverRequest{
+		TaskID:    "task1",
+		FromAgent: "agent1",
+	})
+
+	if result.Success {
+		t.Error("expected failure for non-handoverable task")
+	}
+	if result.Error != ErrTaskNotHandoverable.Error() {
+		t.Errorf("expected ErrTaskNotHandoverable, got %s", result.Error)
+	}
+}
+
+func TestQueue_Handover_MaxHandovers(t *testing.T) {
+	q := NewQueue()
+
+	task := &Task{
+		ID:            "task1",
+		Handoverable:  true,
+		MaxHandovers:  2,
+		HandoverCount: 2, // Already at max.
+	}
+	q.AddTask(task)
+
+	result := q.Handover(HandoverRequest{
+		TaskID:    "task1",
+		FromAgent: "agent1",
+	})
+
+	if result.Success {
+		t.Error("expected failure when max handovers exceeded")
+	}
+	if result.Error != ErrMaxHandoversExceeded.Error() {
+		t.Errorf("expected ErrMaxHandoversExceeded, got %s", result.Error)
+	}
+}
+
+func TestQueue_Handover_NoAvailableAgent(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent1",
+		Available: false, // Not available.
+	})
+
+	task := &Task{
+		ID:           "task1",
+		AssignedTo:   "agent1",
+		Handoverable: true,
+	}
+	q.AddTask(task)
+	q.tasksByAgent["agent1"] = []string{"task1"}
+
+	result := q.Handover(HandoverRequest{
+		TaskID:    "task1",
+		FromAgent: "agent1",
+		ToAgent:   "", // Auto-assign.
+	})
+
+	if result.Success {
+		t.Error("expected failure when no available agent")
+	}
+	if result.Error != ErrNoAvailableAgent.Error() {
+		t.Errorf("expected ErrNoAvailableAgent, got %s", result.Error)
+	}
+}
+
+func TestQueue_GetHandoverableTasks(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{AgentName: "agent1"})
+
+	// Handoverable task.
+	q.AddTask(&Task{
+		ID:           "task1",
+		AssignedTo:   "agent1",
+		Handoverable: true,
+	})
+
+	// Non-handoverable task.
+	q.AddTask(&Task{
+		ID:           "task2",
+		AssignedTo:   "agent1",
+		Handoverable: false,
+	})
+
+	// Handoverable but at max handovers.
+	q.AddTask(&Task{
+		ID:            "task3",
+		AssignedTo:    "agent1",
+		Handoverable:  true,
+		MaxHandovers:  1,
+		HandoverCount: 1,
+	})
+
+	q.tasksByAgent["agent1"] = []string{"task1", "task2", "task3"}
+
+	tasks := q.GetHandoverableTasks("agent1")
+	if len(tasks) != 1 {
+		t.Errorf("expected 1 handoverable task, got %d", len(tasks))
+	}
+	if tasks[0].ID != "task1" {
+		t.Errorf("expected task1, got %s", tasks[0].ID)
+	}
+}
+
+func TestQueue_GetPendingTasks(t *testing.T) {
+	q := NewQueue()
+
+	q.AddTask(&Task{ID: "task1", Status: TaskStatusPending})
+	q.AddTask(&Task{ID: "task2", Status: TaskStatusInProgress})
+	q.AddTask(&Task{ID: "task3", Status: TaskStatusPending})
+
+	tasks := q.GetPendingTasks()
+	if len(tasks) != 2 {
+		t.Errorf("expected 2 pending tasks, got %d", len(tasks))
+	}
+}
+
+func TestQueue_SetAgentAvailability(t *testing.T) {
+	q := NewQueue()
+
+	err := q.SetAgentAvailability("nonexistent", true)
+	if err != ErrAgentNotFound {
+		t.Errorf("expected ErrAgentNotFound, got %v", err)
+	}
+
+	q.RegisterAgent(AgentCapability{
+		AgentName: "agent1",
+		Available: true,
+	})
+
+	err = q.SetAgentAvailability("agent1", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	agents := q.GetAvailableAgents()
+	if len(agents) != 0 {
+		t.Errorf("expected 0 available agents, got %d", len(agents))
+	}
+}
+
+func TestQueue_RemoveTask(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{AgentName: "agent1"})
+
+	task := &Task{
+		ID:         "task1",
+		AssignedTo: "agent1",
+	}
+	q.AddTask(task)
+	q.tasksByAgent["agent1"] = []string{"task1"}
+
+	err := q.RemoveTask("task1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = q.GetTask("task1")
+	if err != ErrTaskNotFound {
+		t.Errorf("expected ErrTaskNotFound, got %v", err)
+	}
+
+	tasks := q.GetTasksForAgent("agent1")
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks, got %d", len(tasks))
+	}
+}
+
+func TestQueue_UnregisterAgent(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{AgentName: "agent1"})
+	q.UnregisterAgent("agent1")
+
+	agents := q.GetAvailableAgents()
+	if len(agents) != 0 {
+		t.Errorf("expected 0 agents, got %d", len(agents))
+	}
+}
+
+func TestTask_Metadata(t *testing.T) {
+	q := NewQueue()
+
+	task := &Task{
+		ID: "task1",
+		Metadata: map[string]string{
+			"key": "value",
+		},
+	}
+	q.AddTask(task)
+
+	got, _ := q.GetTask("task1")
+
+	// Verify copy is returned, not original.
+	got.Metadata["key"] = "modified"
+
+	original, _ := q.GetTask("task1")
+	if original.Metadata["key"] != "value" {
+		t.Error("original task metadata should not be modified")
+	}
+}
+
+func TestQueue_AgentMaxTasks(t *testing.T) {
+	q := NewQueue()
+
+	q.RegisterAgent(AgentCapability{
+		AgentName:    "agent1",
+		Available:    true,
+		CurrentTasks: 5,
+		MaxTasks:     5, // At capacity.
+	})
+
+	task := &Task{
+		ID:           "task1",
+		Handoverable: true,
+	}
+	q.AddTask(task)
+
+	result := q.Handover(HandoverRequest{
+		TaskID:    "task1",
+		FromAgent: "other",
+		ToAgent:   "agent1",
+	})
+
+	if result.Success {
+		t.Error("expected failure when agent at max tasks")
+	}
+	if result.Error != "target agent has reached max tasks" {
+		t.Errorf("unexpected error: %s", result.Error)
+	}
+}
+
+// Concurrency test.
+func TestQueue_Concurrent(t *testing.T) {
+	q := NewQueue()
+
+	// Register agents.
+	for i := 0; i < 5; i++ {
+		q.RegisterAgent(AgentCapability{
+			AgentName: "agent" + string(rune('0'+i)),
+			Available: true,
+			MaxTasks:  10,
+		})
+	}
+
+	// Add tasks concurrently.
+	done := make(chan bool, 100)
+	for i := 0; i < 100; i++ {
+		go func(id int) {
+			task := &Task{
+				ID:           "task" + string(rune(id)),
+				Handoverable: true,
+			}
+			q.AddTask(task)
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines.
+	for i := 0; i < 100; i++ {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for concurrent operations")
+		}
+	}
+}

--- a/internal/taskqueue/types.go
+++ b/internal/taskqueue/types.go
@@ -1,0 +1,88 @@
+// Package taskqueue provides task management and handover functionality for agent coordination.
+package taskqueue
+
+import "time"
+
+// TaskStatus represents the current status of a task.
+type TaskStatus string
+
+const (
+	// TaskStatusPending indicates the task is waiting to be processed.
+	TaskStatusPending TaskStatus = "pending"
+	// TaskStatusInProgress indicates the task is currently being processed.
+	TaskStatusInProgress TaskStatus = "in_progress"
+	// TaskStatusCompleted indicates the task has been completed.
+	TaskStatusCompleted TaskStatus = "completed"
+	// TaskStatusFailed indicates the task has failed.
+	TaskStatusFailed TaskStatus = "failed"
+	// TaskStatusHandover indicates the task is being handed over to another agent.
+	TaskStatusHandover TaskStatus = "handover"
+)
+
+// Task represents a unit of work assigned to an agent.
+type Task struct {
+	// ID is the unique identifier for the task.
+	ID string
+	// Description is a human-readable description of the task.
+	Description string
+	// AssignedTo is the name of the agent currently assigned to this task.
+	AssignedTo string
+	// Status is the current status of the task.
+	Status TaskStatus
+	// CreatedAt is when the task was created.
+	CreatedAt time.Time
+	// StartedAt is when the task was started.
+	StartedAt time.Time
+	// CompletedAt is when the task was completed or failed.
+	CompletedAt time.Time
+	// Handoverable indicates if this task can be handed over to another agent.
+	Handoverable bool
+	// HandoverCount tracks how many times this task has been handed over.
+	HandoverCount int
+	// MaxHandovers is the maximum number of handovers allowed (0 = unlimited).
+	MaxHandovers int
+	// Metadata holds additional task-specific data.
+	Metadata map[string]string
+	// PreviousAgents tracks agents who previously worked on this task.
+	PreviousAgents []string
+}
+
+// HandoverRequest represents a request to hand over a task to another agent.
+type HandoverRequest struct {
+	// TaskID is the ID of the task to hand over.
+	TaskID string
+	// FromAgent is the agent handing over the task.
+	FromAgent string
+	// ToAgent is the target agent (empty for auto-assignment).
+	ToAgent string
+	// Reason explains why the handover is happening.
+	Reason string
+}
+
+// HandoverResult represents the outcome of a handover attempt.
+type HandoverResult struct {
+	// Success indicates if the handover was successful.
+	Success bool
+	// TaskID is the ID of the task that was handed over.
+	TaskID string
+	// FromAgent is the agent who handed over the task.
+	FromAgent string
+	// ToAgent is the agent who received the task.
+	ToAgent string
+	// Error contains the error message if handover failed.
+	Error string
+}
+
+// AgentCapability describes what an agent can handle.
+type AgentCapability struct {
+	// AgentName is the name of the agent.
+	AgentName string
+	// Available indicates if the agent is available for new tasks.
+	Available bool
+	// CurrentTasks is the number of tasks currently assigned.
+	CurrentTasks int
+	// MaxTasks is the maximum number of concurrent tasks.
+	MaxTasks int
+	// Tags are capability tags for matching tasks.
+	Tags []string
+}


### PR DESCRIPTION
## Summary

- 新規 `internal/taskqueue/` パッケージを追加し、エージェント障害時のタスク引き継ぎ機構を実装
- `Task` 構造体に引き継ぎ可否フラグ、引き継ぎ回数、前担当エージェント履歴を追加
- `Queue` でタスク管理とエージェントへの割り当てを管理
- `Coordinator` で healthmgr との統合インターフェースを提供
- 最も負荷の少ないエージェントへの自動割り当てロジックを実装
- PMへの引き継ぎ結果通知機能を追加

## Test plan

- [x] `go test ./internal/taskqueue/...` - 27テスト全パス
- [x] `go vet ./internal/taskqueue/...` - エラーなし
- [x] `gofmt -l internal/taskqueue/` - 出力なし
- [x] `go test ./...` - 全体テスト通過

## テストカバレッジ

| カテゴリ | テストケース数 |
|---------|--------------|
| Queue基本操作 | 9 |
| Handover | 6 |
| Coordinator統合 | 8 |
| 並行実行 | 1 |

## Reviewer (Required)
- [x] @priya

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)