### PR TITLE
fix: remove non-existent agents directory from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
             GOOS=$GOOS GOARCH=$GOARCH go build -ldflags="-s -w" -o "dist/${PKG_NAME}/maxam" ./cmd/maxam
 
             cp CLAUDE.md "dist/${PKG_NAME}/"
-            cp -r agents "dist/${PKG_NAME}/"
 
             cd dist
             zip -r "${PKG_NAME}.zip" "${PKG_NAME}"


### PR DESCRIPTION
## Summary
- リリースワークフローで存在しない `agents` ディレクトリをコピーしようとして失敗していた問題を修正
- 該当行を削除

## Test plan
- [ ] CIが通ること
- [ ] 次回タグプッシュ時にリリースが成功すること

## Reviewer (Required)
- [x] @priya-reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)