### PR TITLE
fix: remove non-existent agents directory copy in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
             GOOS=$GOOS GOARCH=$GOARCH go build -ldflags="-s -w" -o "dist/${PKG_NAME}/maxam" ./cmd/maxam
 
             cp CLAUDE.md "dist/${PKG_NAME}/"
-            cp -r agents "dist/${PKG_NAME}/"
 
             cd dist
             zip -r "${PKG_NAME}.zip" "${PKG_NAME}"


### PR DESCRIPTION
## Summary
- Removed the unnecessary `cp -r agents` command from the release workflow
- The `agents/` directory does not exist in the repository and was causing release failures

## Test plan
- [x] Verified the change removes only the problematic line
- [x] YAML syntax is valid
- Next: Release workflow will be tested on next tag push

🤖 Generated with Claude Code