### PR TITLE
feat: ロールベースのデフォルト応答者を実装

### DIFF
--- a/cmd/maxam/chat.go
+++ b/cmd/maxam/chat.go
@@ -38,6 +38,7 @@ type ChatSession struct {
 	mentionCheck bool
 	daemon       bool
 	wsServer     *ws.Server
+	defaultAgent string
 }
 
 type chatMessage struct {
@@ -125,14 +126,26 @@ func runChat() {
 		os.Exit(1)
 	}
 
+	members := member.NewMembers(workDir)
+
+	// Determine default agent: role-based (オーナーフェイシング) > config > fallback
+	defaultAgent := members.FindByRoleContains("オーナーフェイシング")
+	if defaultAgent == "" {
+		defaultAgent = cfg.DefaultAgent
+	}
+	if defaultAgent == "" {
+		defaultAgent = "mei" // final fallback
+	}
+
 	session := &ChatSession{
 		agents:       agent.NewAgents(workDir),
-		members:      member.NewMembers(workDir),
+		members:      members,
 		logMgr:       logger.NewManagerWithLevel(logger.GetDefaultLogDir(), workDir, logger.ParseLogLevel(cfg.GetLogLevel())),
 		workDir:      workDir,
 		history:      make([]chatMessage, 0),
 		mentionCheck: flags.mentionCheck,
 		daemon:       flags.daemon,
+		defaultAgent: defaultAgent,
 	}
 	defer session.logMgr.Close()
 
@@ -248,7 +261,7 @@ func (s *ChatSession) runTeamChat() {
 	if interactive {
 		fmt.Println("Chat with MAXAM Team")
 		fmt.Println("Mention members with @name. Example: @yuki, @priya")
-		fmt.Println("Default: Mei will respond if no mention.")
+		fmt.Printf("Default: %s will respond if no mention.\n", s.members.GetFullName(s.defaultAgent))
 		fmt.Println("Type 'exit' to quit")
 		fmt.Println(strings.Repeat("-", 50))
 	}
@@ -277,8 +290,8 @@ func (s *ChatSession) runTeamChat() {
 		// Detect all mentioned agents
 		mentioned := s.members.DetectMentions(input)
 		if len(mentioned) == 0 {
-			// Default to Mei if no one is mentioned
-			mentioned = []string{"mei"}
+			// Default to configured agent if no one is mentioned
+			mentioned = []string{s.defaultAgent}
 		}
 
 		// Call each mentioned agent in order
@@ -371,7 +384,7 @@ func (s *ChatSession) processTeamMessage(input string) {
 	// Detect all mentioned agents
 	mentioned := s.members.DetectMentions(input)
 	if len(mentioned) == 0 {
-		mentioned = []string{"mei"}
+		mentioned = []string{s.defaultAgent}
 	}
 
 	// Call each mentioned agent in order

--- a/internal/member/member.go
+++ b/internal/member/member.go
@@ -104,6 +104,17 @@ func (m *Members) Names() []string {
 	return result
 }
 
+// FindByRoleContains returns the name of the first member whose role contains the given keyword
+// Returns empty string if no member is found
+func (m *Members) FindByRoleContains(keyword string) string {
+	for name, member := range m.members {
+		if strings.Contains(member.Role, keyword) {
+			return name
+		}
+	}
+	return ""
+}
+
 // ParseMemberTable extracts members from CLAUDE.md table format
 // Expects format:
 // | Name | Role |

--- a/internal/member/member_test.go
+++ b/internal/member/member_test.go
@@ -123,6 +123,35 @@ No table here.
 	}
 }
 
+func TestFindByRoleContains(t *testing.T) {
+	m := &Members{
+		members: map[string]*Member{
+			"mei":   {Name: "mei", Role: "PM + アーキテクト"},
+			"yuki":  {Name: "yuki", Role: "バックエンド + インフラ"},
+			"amara": {Name: "amara", Role: "分析 + 法的基礎知識 + オーナーフェイシング"},
+		},
+	}
+
+	tests := []struct {
+		keyword  string
+		expected string
+	}{
+		{"オーナーフェイシング", "amara"},
+		{"PM", "mei"},
+		{"インフラ", "yuki"},
+		{"存在しないロール", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.keyword, func(t *testing.T) {
+			got := m.FindByRoleContains(tt.keyword)
+			if got != tt.expected {
+				t.Errorf("FindByRoleContains(%q) = %q, want %q", tt.keyword, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestExtractShortName(t *testing.T) {
 	tests := []struct {
 		fullName  string


### PR DESCRIPTION
## Summary
- メンションなしの場合、「オーナーフェイシング」ロールを持つエージェントがデフォルトで応答
- `FindByRoleContains()` メソッドを `Members` に追加
- chat.go のハードコード `"mei"` を削除

## フォールバック順序
1. オーナーフェイシング ロールを持つエージェント
2. config.yaml の `default_agent`
3. "mei"（最終フォールバック）

## Reviewer (Required)
- [x] @priya - レビュー完了済み

## Test plan
- [x] `go test ./internal/member/...` パス確認
- [x] `go test ./cmd/maxam/...` パス確認
- [ ] 実際にチャットでメンションなしメッセージ → Amara が応答することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)