### PR TITLE
feat: セルフメンション検知機能を追加

### DIFF
--- a/internal/mention/checker.go
+++ b/internal/mention/checker.go
@@ -8,8 +8,9 @@ import (
 
 // Result represents the result of a mention check
 type Result struct {
-	HasMention   bool // メンションが含まれているか
-	NeedsWarning bool // 警告が必要か（メンションなし）
+	HasMention    bool // メンションが含まれているか
+	NeedsWarning  bool // 警告が必要か（メンションなし）
+	IsSelfMention bool // セルフメンションか（自分で自分にメンション）
 }
 
 // Checker detects mention leaks in messages
@@ -109,4 +110,62 @@ func FormatWarning() string {
 // FormatSystemWarning returns a system warning message for chat display
 func FormatSystemWarning(sender string) string {
 	return "[System] @" + sender + " メンションが漏れている可能性があります。宛先を確認してください"
+}
+
+// CheckWithSender analyzes a message for mention leaks and self-mentions
+// sender is the name of the person sending the message (without @)
+func (c *Checker) CheckWithSender(message, sender string) Result {
+	// まず通常のチェックを実行
+	result := c.Check(message)
+
+	// 空メッセージまたはメンションなしの場合はそのまま返す
+	if strings.TrimSpace(message) == "" || !result.HasMention {
+		return result
+	}
+
+	// セルフメンション検知
+	// @sender または @sender-{instance} 形式を検出
+	senderLower := strings.ToLower(sender)
+
+	// メンションを抽出して確認
+	matches := c.mentionPattern.FindAllString(message, -1)
+	for _, match := range matches {
+		// @を取り除いてメンション名を取得
+		mentionedName := strings.TrimPrefix(match, "@")
+		mentionedLower := strings.ToLower(mentionedName)
+
+		// 完全一致チェック（大文字小文字無視）
+		if mentionedLower == senderLower {
+			result.IsSelfMention = true
+			break
+		}
+
+		// インスタンス形式チェック: sender-1, sender-2 など
+		// 例: yuki が @yuki-1 にメンション → セルフメンション
+		if strings.HasPrefix(mentionedLower, senderLower+"-") {
+			result.IsSelfMention = true
+			break
+		}
+
+		// 逆パターン: yuki-1 が @yuki にメンション → セルフメンション
+		if strings.HasPrefix(senderLower, mentionedLower+"-") {
+			result.IsSelfMention = true
+			break
+		}
+	}
+
+	return result
+}
+
+// CheckWithSenderPackageLevel analyzes a message using the default checker with sender info
+func CheckWithSender(message, sender string) Result {
+	if defaultChecker == nil {
+		defaultChecker = NewChecker([]string{})
+	}
+	return defaultChecker.CheckWithSender(message, sender)
+}
+
+// FormatSelfMentionWarning returns a warning message for self-mention
+func FormatSelfMentionWarning(sender string) string {
+	return "[System] @" + sender + " 自分自身へのメンションは不要です。宛先を確認してください"
 }

--- a/internal/mention/checker_test.go
+++ b/internal/mention/checker_test.go
@@ -282,3 +282,164 @@ func TestFormatSystemWarning(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckWithSender(t *testing.T) {
+	testAgents := []string{"mei", "yuki", "rin", "shiori", "priya", "amara", "yuki-1", "yuki-2"}
+	checker := NewChecker(testAgents)
+
+	tests := []struct {
+		name            string
+		message         string
+		sender          string
+		wantSelfMention bool
+		wantMention     bool
+	}{
+		// セルフメンション検知ケース
+		{
+			name:            "self mention - exact match",
+			message:         "@yuki これやります",
+			sender:          "yuki",
+			wantSelfMention: true,
+			wantMention:     true,
+		},
+		{
+			name:            "self mention - case insensitive",
+			message:         "@Yuki これやります",
+			sender:          "yuki",
+			wantSelfMention: true,
+			wantMention:     true,
+		},
+		{
+			name:            "self mention - sender uppercase",
+			message:         "@yuki これやります",
+			sender:          "Yuki",
+			wantSelfMention: true,
+			wantMention:     true,
+		},
+		{
+			name:            "self mention - instance format",
+			message:         "@yuki-1 これやります",
+			sender:          "yuki",
+			wantSelfMention: true,
+			wantMention:     true,
+		},
+		{
+			name:            "self mention - sender is instance",
+			message:         "@yuki これやります",
+			sender:          "yuki-1",
+			wantSelfMention: true,
+			wantMention:     true,
+		},
+		{
+			name:            "self mention - both instance",
+			message:         "@yuki-1 これやります",
+			sender:          "yuki-1",
+			wantSelfMention: true,
+			wantMention:     true,
+		},
+
+		// セルフメンションではないケース
+		{
+			name:            "not self mention - different person",
+			message:         "@priya レビューお願い",
+			sender:          "yuki",
+			wantSelfMention: false,
+			wantMention:     true,
+		},
+		{
+			name:            "not self mention - multiple mentions but not self",
+			message:         "@mei @priya 確認お願い",
+			sender:          "yuki",
+			wantSelfMention: false,
+			wantMention:     true,
+		},
+
+		// 複数メンションでセルフメンション混在
+		{
+			name:            "mixed mentions - self included",
+			message:         "@yuki @priya 一緒に確認する",
+			sender:          "yuki",
+			wantSelfMention: true,
+			wantMention:     true,
+		},
+
+		// メンションなし
+		{
+			name:            "no mention",
+			message:         "これお願い",
+			sender:          "yuki",
+			wantSelfMention: false,
+			wantMention:     false,
+		},
+
+		// 空メッセージ
+		{
+			name:            "empty message",
+			message:         "",
+			sender:          "yuki",
+			wantSelfMention: false,
+			wantMention:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checker.CheckWithSender(tt.message, tt.sender)
+
+			if result.IsSelfMention != tt.wantSelfMention {
+				t.Errorf("CheckWithSender(%q, %q).IsSelfMention = %v, want %v",
+					tt.message, tt.sender, result.IsSelfMention, tt.wantSelfMention)
+			}
+			if result.HasMention != tt.wantMention {
+				t.Errorf("CheckWithSender(%q, %q).HasMention = %v, want %v",
+					tt.message, tt.sender, result.HasMention, tt.wantMention)
+			}
+		})
+	}
+}
+
+func TestCheckWithSenderPackageLevel(t *testing.T) {
+	// Save original
+	original := defaultChecker
+	defer func() { defaultChecker = original }()
+
+	// Set up test checker
+	testAgents := []string{"mei", "yuki", "rin"}
+	SetDefaultChecker(NewChecker(testAgents))
+
+	// Test package-level function
+	result := CheckWithSender("@yuki やります", "yuki")
+	if !result.IsSelfMention {
+		t.Error("Package-level CheckWithSender should detect self-mention")
+	}
+
+	result = CheckWithSender("@mei お願い", "yuki")
+	if result.IsSelfMention {
+		t.Error("Package-level CheckWithSender should not detect self-mention for different person")
+	}
+}
+
+func TestFormatSelfMentionWarning(t *testing.T) {
+	tests := []struct {
+		sender   string
+		expected string
+	}{
+		{
+			sender:   "yuki",
+			expected: "[System] @yuki 自分自身へのメンションは不要です。宛先を確認してください",
+		},
+		{
+			sender:   "Priya",
+			expected: "[System] @Priya 自分自身へのメンションは不要です。宛先を確認してください",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sender, func(t *testing.T) {
+			result := FormatSelfMentionWarning(tt.sender)
+			if result != tt.expected {
+				t.Errorf("FormatSelfMentionWarning(%q) = %q, want %q", tt.sender, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `CheckWithSender(message, sender)` メソッドを追加し、送信者が自分自身にメンションしていないかを検知
- `Result` 構造体に `IsSelfMention` フィールドを追加
- インスタンス形式（`@yuki-1` 等）にも対応
- `FormatSelfMentionWarning()` で警告メッセージ生成

## Test plan
- [ ] `go test ./internal/mention/...` で全テストパス
- [ ] セルフメンション検知: `@yuki` が `yuki` として送信 → 検知
- [ ] 通常メンション: `@priya` が `yuki` として送信 → 検知しない
- [ ] インスタンス形式: `@yuki-1` が `yuki` として送信 → 検知
- [ ] 複数メンション混在: `@yuki @priya` が `yuki` として送信 → セルフメンション検知

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)