### PR TITLE
feat: LLM関連エラー発生時のエージェント自動リセット機能

### DIFF
--- a/internal/errorwatch/auto_reset.go
+++ b/internal/errorwatch/auto_reset.go
@@ -1,0 +1,265 @@
+package errorwatch
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+// ResetFunc is called to reset an agent.
+type ResetFunc func(ctx context.Context, agentName string) error
+
+// NotifyFunc is called to send notifications.
+type NotifyFunc func(ctx context.Context, target, message string) error
+
+// AutoResetConfig holds configuration for automatic reset.
+type AutoResetConfig struct {
+	// CooldownPeriod is the minimum time between reset attempts for the same agent.
+	CooldownPeriod time.Duration
+	// MaxConsecutiveFailures is the maximum number of consecutive reset failures
+	// before escalating to PM.
+	MaxConsecutiveFailures int
+	// ResetTimeout is the timeout for each reset attempt.
+	ResetTimeout time.Duration
+	// PMAgent is the PM agent name for notifications.
+	PMAgent string
+	// Logger for reset events.
+	Logger *log.Logger
+}
+
+// DefaultAutoResetConfig returns the default configuration.
+func DefaultAutoResetConfig() AutoResetConfig {
+	return AutoResetConfig{
+		CooldownPeriod:         30 * time.Second,
+		MaxConsecutiveFailures: 3,
+		ResetTimeout:           10 * time.Second,
+		PMAgent:                "mei",
+		Logger:                 log.Default(),
+	}
+}
+
+// agentResetState tracks reset state for an agent.
+type agentResetState struct {
+	lastResetAttempt    time.Time
+	consecutiveFailures int
+	lastError           error
+}
+
+// AutoResetter automatically resets agents when LLM errors are detected.
+type AutoResetter struct {
+	mu       sync.Mutex
+	cfg      AutoResetConfig
+	resetFn  ResetFunc
+	notifyFn NotifyFunc
+	states   map[string]*agentResetState
+
+	// Callback for reset events
+	onResetAttempt func(agentName string, success bool, err error)
+	onPMEscalation func(agentName string, failCount int)
+}
+
+// NewAutoResetter creates a new auto resetter.
+func NewAutoResetter(cfg AutoResetConfig, resetFn ResetFunc) *AutoResetter {
+	if cfg.CooldownPeriod <= 0 {
+		cfg.CooldownPeriod = DefaultAutoResetConfig().CooldownPeriod
+	}
+	if cfg.MaxConsecutiveFailures <= 0 {
+		cfg.MaxConsecutiveFailures = DefaultAutoResetConfig().MaxConsecutiveFailures
+	}
+	if cfg.ResetTimeout <= 0 {
+		cfg.ResetTimeout = DefaultAutoResetConfig().ResetTimeout
+	}
+	if cfg.PMAgent == "" {
+		cfg.PMAgent = DefaultAutoResetConfig().PMAgent
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = log.Default()
+	}
+
+	return &AutoResetter{
+		cfg:     cfg,
+		resetFn: resetFn,
+		states:  make(map[string]*agentResetState),
+	}
+}
+
+// SetNotifyFunc sets the notification function for PM escalation.
+func (r *AutoResetter) SetNotifyFunc(fn NotifyFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.notifyFn = fn
+}
+
+// SetOnResetAttempt sets the callback for reset attempts.
+func (r *AutoResetter) SetOnResetAttempt(fn func(agentName string, success bool, err error)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.onResetAttempt = fn
+}
+
+// SetOnPMEscalation sets the callback for PM escalation.
+func (r *AutoResetter) SetOnPMEscalation(fn func(agentName string, failCount int)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.onPMEscalation = fn
+}
+
+// HandleError handles an LLM error and triggers auto reset if applicable.
+// Returns true if reset was attempted, and any error from the reset.
+func (r *AutoResetter) HandleError(ctx context.Context, agentName string, errMsg string) (attempted bool, resetErr error) {
+	// Check if this is a recoverable error
+	if !IsRecoverableError(errMsg) {
+		return false, nil
+	}
+
+	r.mu.Lock()
+	state, exists := r.states[agentName]
+	if !exists {
+		state = &agentResetState{}
+		r.states[agentName] = state
+	}
+
+	// Check cooldown
+	if time.Since(state.lastResetAttempt) < r.cfg.CooldownPeriod {
+		r.mu.Unlock()
+		r.cfg.Logger.Printf("[auto-reset] Skipping reset for %s: cooldown active (last attempt: %v ago)",
+			agentName, time.Since(state.lastResetAttempt).Round(time.Second))
+		return false, nil
+	}
+
+	state.lastResetAttempt = time.Now()
+	resetFn := r.resetFn
+	onResetAttempt := r.onResetAttempt
+	r.mu.Unlock()
+
+	// Attempt reset
+	r.cfg.Logger.Printf("[auto-reset] Attempting reset for agent %s (error: %s)", agentName, errMsg)
+
+	if resetFn == nil {
+		err := fmt.Errorf("reset function not set")
+		r.recordFailure(agentName, err)
+		return true, err
+	}
+
+	resetCtx, cancel := context.WithTimeout(ctx, r.cfg.ResetTimeout)
+	defer cancel()
+
+	resetErr = resetFn(resetCtx, agentName)
+
+	if resetErr != nil {
+		r.cfg.Logger.Printf("[auto-reset] Reset failed for agent %s: %v", agentName, resetErr)
+		r.recordFailure(agentName, resetErr)
+	} else {
+		r.cfg.Logger.Printf("[auto-reset] Reset successful for agent %s", agentName)
+		r.recordSuccess(agentName)
+	}
+
+	if onResetAttempt != nil {
+		onResetAttempt(agentName, resetErr == nil, resetErr)
+	}
+
+	return true, resetErr
+}
+
+// recordFailure records a failed reset attempt.
+func (r *AutoResetter) recordFailure(agentName string, err error) {
+	r.mu.Lock()
+	state := r.states[agentName]
+	state.consecutiveFailures++
+	state.lastError = err
+	failCount := state.consecutiveFailures
+	maxFailures := r.cfg.MaxConsecutiveFailures
+	notifyFn := r.notifyFn
+	onPMEscalation := r.onPMEscalation
+	pmAgent := r.cfg.PMAgent
+	r.mu.Unlock()
+
+	// Check if we need to escalate to PM
+	if failCount >= maxFailures {
+		r.cfg.Logger.Printf("[auto-reset] Escalating to PM: agent %s failed %d consecutive resets", agentName, failCount)
+
+		if onPMEscalation != nil {
+			onPMEscalation(agentName, failCount)
+		}
+
+		if notifyFn != nil {
+			message := fmt.Sprintf("エージェント %s の自動リセットが %d 回連続で失敗しました。手動確認が必要です。最後のエラー: %v",
+				agentName, failCount, err)
+			// Best effort notification
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			_ = notifyFn(ctx, pmAgent, message)
+		}
+	}
+}
+
+// recordSuccess records a successful reset.
+func (r *AutoResetter) recordSuccess(agentName string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	state := r.states[agentName]
+	state.consecutiveFailures = 0
+	state.lastError = nil
+}
+
+// GetState returns the reset state for an agent.
+func (r *AutoResetter) GetState(agentName string) (lastAttempt time.Time, failures int, lastErr error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	state, exists := r.states[agentName]
+	if !exists {
+		return time.Time{}, 0, nil
+	}
+	return state.lastResetAttempt, state.consecutiveFailures, state.lastError
+}
+
+// ResetState clears the reset state for an agent.
+func (r *AutoResetter) ResetState(agentName string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.states, agentName)
+}
+
+// ResetAllStates clears all reset states.
+func (r *AutoResetter) ResetAllStates() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.states = make(map[string]*agentResetState)
+}
+
+// AutoResetResult holds the result of an auto reset check.
+type AutoResetResult struct {
+	// ErrorDetected is true if a recoverable error was detected.
+	ErrorDetected bool
+	// ResetAttempted is true if a reset was attempted.
+	ResetAttempted bool
+	// ResetSucceeded is true if the reset succeeded.
+	ResetSucceeded bool
+	// Error is the error from the reset attempt, if any.
+	Error error
+	// CooldownActive is true if reset was skipped due to cooldown.
+	CooldownActive bool
+}
+
+// CheckAndReset checks for LLM errors and triggers auto reset.
+// This is a convenience method that combines error detection and reset.
+func (r *AutoResetter) CheckAndReset(ctx context.Context, agentName string, errMsg string) AutoResetResult {
+	result := AutoResetResult{}
+
+	if !IsRecoverableError(errMsg) {
+		return result
+	}
+	result.ErrorDetected = true
+
+	attempted, err := r.HandleError(ctx, agentName, errMsg)
+	result.ResetAttempted = attempted
+	result.Error = err
+	result.ResetSucceeded = attempted && err == nil
+	result.CooldownActive = !attempted && result.ErrorDetected
+
+	return result
+}

--- a/internal/errorwatch/auto_reset_test.go
+++ b/internal/errorwatch/auto_reset_test.go
@@ -1,0 +1,412 @@
+package errorwatch
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAutoResetter_HandleError(t *testing.T) {
+	t.Run("triggers reset for recoverable error", func(t *testing.T) {
+		var resetCalled atomic.Bool
+		resetFn := func(ctx context.Context, agentName string) error {
+			resetCalled.Store(true)
+			return nil
+		}
+
+		cfg := DefaultAutoResetConfig()
+		cfg.CooldownPeriod = 10 * time.Millisecond
+		r := NewAutoResetter(cfg, resetFn)
+
+		attempted, err := r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+		if !attempted {
+			t.Error("expected reset to be attempted")
+		}
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !resetCalled.Load() {
+			t.Error("expected reset function to be called")
+		}
+	})
+
+	t.Run("does not trigger reset for non-recoverable error", func(t *testing.T) {
+		var resetCalled atomic.Bool
+		resetFn := func(ctx context.Context, agentName string) error {
+			resetCalled.Store(true)
+			return nil
+		}
+
+		r := NewAutoResetter(DefaultAutoResetConfig(), resetFn)
+
+		attempted, _ := r.HandleError(context.Background(), "yuki", "syntax error")
+		if attempted {
+			t.Error("expected reset not to be attempted for non-recoverable error")
+		}
+		if resetCalled.Load() {
+			t.Error("expected reset function not to be called")
+		}
+	})
+
+	t.Run("respects cooldown period", func(t *testing.T) {
+		resetCount := 0
+		resetFn := func(ctx context.Context, agentName string) error {
+			resetCount++
+			return nil
+		}
+
+		cfg := DefaultAutoResetConfig()
+		cfg.CooldownPeriod = 100 * time.Millisecond
+		r := NewAutoResetter(cfg, resetFn)
+
+		// First reset
+		attempted1, _ := r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+		if !attempted1 {
+			t.Error("first reset should be attempted")
+		}
+
+		// Second reset immediately (should be blocked by cooldown)
+		attempted2, _ := r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+		if attempted2 {
+			t.Error("second reset should be blocked by cooldown")
+		}
+
+		if resetCount != 1 {
+			t.Errorf("expected 1 reset, got %d", resetCount)
+		}
+	})
+
+	t.Run("allows reset after cooldown expires", func(t *testing.T) {
+		resetCount := 0
+		resetFn := func(ctx context.Context, agentName string) error {
+			resetCount++
+			return nil
+		}
+
+		cfg := DefaultAutoResetConfig()
+		cfg.CooldownPeriod = 50 * time.Millisecond
+		r := NewAutoResetter(cfg, resetFn)
+
+		// First reset
+		r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+
+		// Wait for cooldown
+		time.Sleep(60 * time.Millisecond)
+
+		// Second reset after cooldown
+		attempted, _ := r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+		if !attempted {
+			t.Error("reset should be attempted after cooldown")
+		}
+
+		if resetCount != 2 {
+			t.Errorf("expected 2 resets, got %d", resetCount)
+		}
+	})
+
+	t.Run("tracks consecutive failures", func(t *testing.T) {
+		resetErr := errors.New("reset failed")
+		resetFn := func(ctx context.Context, agentName string) error {
+			return resetErr
+		}
+
+		cfg := DefaultAutoResetConfig()
+		cfg.CooldownPeriod = 1 * time.Millisecond
+		cfg.MaxConsecutiveFailures = 3
+		r := NewAutoResetter(cfg, resetFn)
+
+		// Fail 3 times
+		for i := 0; i < 3; i++ {
+			time.Sleep(2 * time.Millisecond) // Wait for cooldown
+			r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+		}
+
+		_, failures, lastErr := r.GetState("yuki")
+		if failures != 3 {
+			t.Errorf("expected 3 failures, got %d", failures)
+		}
+		if lastErr != resetErr {
+			t.Errorf("expected last error %v, got %v", resetErr, lastErr)
+		}
+	})
+
+	t.Run("resets failure count on success", func(t *testing.T) {
+		callCount := 0
+		resetFn := func(ctx context.Context, agentName string) error {
+			callCount++
+			if callCount < 3 {
+				return errors.New("failed")
+			}
+			return nil // Success on third call
+		}
+
+		cfg := DefaultAutoResetConfig()
+		cfg.CooldownPeriod = 1 * time.Millisecond
+		r := NewAutoResetter(cfg, resetFn)
+
+		// Fail twice
+		time.Sleep(2 * time.Millisecond)
+		r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+		time.Sleep(2 * time.Millisecond)
+		r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+
+		_, failures, _ := r.GetState("yuki")
+		if failures != 2 {
+			t.Errorf("expected 2 failures, got %d", failures)
+		}
+
+		// Succeed
+		time.Sleep(2 * time.Millisecond)
+		r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+
+		_, failures, lastErr := r.GetState("yuki")
+		if failures != 0 {
+			t.Errorf("expected 0 failures after success, got %d", failures)
+		}
+		if lastErr != nil {
+			t.Errorf("expected nil error after success, got %v", lastErr)
+		}
+	})
+}
+
+func TestAutoResetter_PMEscalation(t *testing.T) {
+	t.Run("escalates to PM after max failures", func(t *testing.T) {
+		resetErr := errors.New("reset failed")
+		resetFn := func(ctx context.Context, agentName string) error {
+			return resetErr
+		}
+
+		var escalationCalled atomic.Bool
+		var escalatedAgent string
+		var escalatedCount int
+
+		cfg := DefaultAutoResetConfig()
+		cfg.CooldownPeriod = 1 * time.Millisecond
+		cfg.MaxConsecutiveFailures = 2
+		r := NewAutoResetter(cfg, resetFn)
+
+		r.SetOnPMEscalation(func(agentName string, failCount int) {
+			escalationCalled.Store(true)
+			escalatedAgent = agentName
+			escalatedCount = failCount
+		})
+
+		// Fail twice (should trigger escalation)
+		time.Sleep(2 * time.Millisecond)
+		r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+		time.Sleep(2 * time.Millisecond)
+		r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+
+		if !escalationCalled.Load() {
+			t.Error("expected PM escalation to be called")
+		}
+		if escalatedAgent != "yuki" {
+			t.Errorf("expected escalated agent 'yuki', got '%s'", escalatedAgent)
+		}
+		if escalatedCount != 2 {
+			t.Errorf("expected escalated count 2, got %d", escalatedCount)
+		}
+	})
+
+	t.Run("sends notification on escalation", func(t *testing.T) {
+		resetFn := func(ctx context.Context, agentName string) error {
+			return errors.New("reset failed")
+		}
+
+		var notifyCalled atomic.Bool
+		var notifyTarget string
+		notifyFn := func(ctx context.Context, target, message string) error {
+			notifyCalled.Store(true)
+			notifyTarget = target
+			return nil
+		}
+
+		cfg := DefaultAutoResetConfig()
+		cfg.CooldownPeriod = 1 * time.Millisecond
+		cfg.MaxConsecutiveFailures = 1
+		cfg.PMAgent = "mei"
+		r := NewAutoResetter(cfg, resetFn)
+		r.SetNotifyFunc(notifyFn)
+
+		// Fail once (should trigger escalation with max=1)
+		time.Sleep(2 * time.Millisecond)
+		r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+
+		// Wait for async notification
+		time.Sleep(50 * time.Millisecond)
+
+		if !notifyCalled.Load() {
+			t.Error("expected notification to be sent")
+		}
+		if notifyTarget != "mei" {
+			t.Errorf("expected notification target 'mei', got '%s'", notifyTarget)
+		}
+	})
+}
+
+func TestAutoResetter_Callbacks(t *testing.T) {
+	t.Run("calls onResetAttempt callback", func(t *testing.T) {
+		resetFn := func(ctx context.Context, agentName string) error {
+			return nil
+		}
+
+		var callbackCalled atomic.Bool
+		var callbackAgent string
+		var callbackSuccess bool
+
+		cfg := DefaultAutoResetConfig()
+		r := NewAutoResetter(cfg, resetFn)
+		r.SetOnResetAttempt(func(agentName string, success bool, err error) {
+			callbackCalled.Store(true)
+			callbackAgent = agentName
+			callbackSuccess = success
+		})
+
+		r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+
+		if !callbackCalled.Load() {
+			t.Error("expected onResetAttempt callback to be called")
+		}
+		if callbackAgent != "yuki" {
+			t.Errorf("expected agent 'yuki', got '%s'", callbackAgent)
+		}
+		if !callbackSuccess {
+			t.Error("expected success to be true")
+		}
+	})
+}
+
+func TestAutoResetter_CheckAndReset(t *testing.T) {
+	t.Run("returns full result for recoverable error", func(t *testing.T) {
+		resetFn := func(ctx context.Context, agentName string) error {
+			return nil
+		}
+
+		r := NewAutoResetter(DefaultAutoResetConfig(), resetFn)
+		result := r.CheckAndReset(context.Background(), "yuki", "context deadline exceeded")
+
+		if !result.ErrorDetected {
+			t.Error("expected ErrorDetected to be true")
+		}
+		if !result.ResetAttempted {
+			t.Error("expected ResetAttempted to be true")
+		}
+		if !result.ResetSucceeded {
+			t.Error("expected ResetSucceeded to be true")
+		}
+		if result.Error != nil {
+			t.Errorf("expected nil error, got %v", result.Error)
+		}
+		if result.CooldownActive {
+			t.Error("expected CooldownActive to be false")
+		}
+	})
+
+	t.Run("returns cooldown active when blocked", func(t *testing.T) {
+		resetFn := func(ctx context.Context, agentName string) error {
+			return nil
+		}
+
+		cfg := DefaultAutoResetConfig()
+		cfg.CooldownPeriod = 1 * time.Hour
+		r := NewAutoResetter(cfg, resetFn)
+
+		// First reset
+		r.CheckAndReset(context.Background(), "yuki", "context deadline exceeded")
+
+		// Second attempt (blocked by cooldown)
+		result := r.CheckAndReset(context.Background(), "yuki", "context deadline exceeded")
+
+		if !result.ErrorDetected {
+			t.Error("expected ErrorDetected to be true")
+		}
+		if result.ResetAttempted {
+			t.Error("expected ResetAttempted to be false (cooldown)")
+		}
+		if !result.CooldownActive {
+			t.Error("expected CooldownActive to be true")
+		}
+	})
+
+	t.Run("returns not detected for non-recoverable error", func(t *testing.T) {
+		resetFn := func(ctx context.Context, agentName string) error {
+			return nil
+		}
+
+		r := NewAutoResetter(DefaultAutoResetConfig(), resetFn)
+		result := r.CheckAndReset(context.Background(), "yuki", "syntax error")
+
+		if result.ErrorDetected {
+			t.Error("expected ErrorDetected to be false")
+		}
+		if result.ResetAttempted {
+			t.Error("expected ResetAttempted to be false")
+		}
+	})
+}
+
+func TestAutoResetter_StateManagement(t *testing.T) {
+	t.Run("ResetState clears agent state", func(t *testing.T) {
+		resetFn := func(ctx context.Context, agentName string) error {
+			return errors.New("failed")
+		}
+
+		cfg := DefaultAutoResetConfig()
+		cfg.CooldownPeriod = 1 * time.Millisecond
+		r := NewAutoResetter(cfg, resetFn)
+
+		time.Sleep(2 * time.Millisecond)
+		r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+
+		_, failures, _ := r.GetState("yuki")
+		if failures != 1 {
+			t.Errorf("expected 1 failure, got %d", failures)
+		}
+
+		r.ResetState("yuki")
+
+		_, failures, _ = r.GetState("yuki")
+		if failures != 0 {
+			t.Errorf("expected 0 failures after reset, got %d", failures)
+		}
+	})
+
+	t.Run("ResetAllStates clears all states", func(t *testing.T) {
+		resetFn := func(ctx context.Context, agentName string) error {
+			return errors.New("failed")
+		}
+
+		cfg := DefaultAutoResetConfig()
+		cfg.CooldownPeriod = 1 * time.Millisecond
+		r := NewAutoResetter(cfg, resetFn)
+
+		time.Sleep(2 * time.Millisecond)
+		r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+		time.Sleep(2 * time.Millisecond)
+		r.HandleError(context.Background(), "rin", "context deadline exceeded")
+
+		r.ResetAllStates()
+
+		_, failures1, _ := r.GetState("yuki")
+		_, failures2, _ := r.GetState("rin")
+		if failures1 != 0 || failures2 != 0 {
+			t.Errorf("expected 0 failures after reset all, got yuki=%d, rin=%d", failures1, failures2)
+		}
+	})
+}
+
+func TestAutoResetter_NilResetFunc(t *testing.T) {
+	t.Run("returns error when reset function is nil", func(t *testing.T) {
+		r := NewAutoResetter(DefaultAutoResetConfig(), nil)
+
+		attempted, err := r.HandleError(context.Background(), "yuki", "context deadline exceeded")
+		if !attempted {
+			t.Error("expected reset to be attempted")
+		}
+		if err == nil {
+			t.Error("expected error for nil reset function")
+		}
+	})
+}

--- a/internal/errorwatch/detector.go
+++ b/internal/errorwatch/detector.go
@@ -9,11 +9,23 @@ import (
 
 // ErrorPatterns defines the patterns to detect recoverable agent errors.
 var ErrorPatterns = []string{
+	// Context and timeout errors
 	"context deadline exceeded",
 	"context canceled",
 	"timeout",
+	// Connection errors
 	"connection refused",
 	"connection reset",
+	// LLM API errors
+	"rate limit",
+	"rate_limit",
+	"too many requests",
+	"429",
+	"503",
+	"service unavailable",
+	"overloaded",
+	"capacity",
+	// General errors that may be recoverable
 	"exit status 1",
 }
 

--- a/internal/errorwatch/detector_test.go
+++ b/internal/errorwatch/detector_test.go
@@ -61,6 +61,37 @@ func TestIsRecoverableError(t *testing.T) {
 			errMsg:   "syntax error: unexpected token",
 			expected: false,
 		},
+		// LLM API errors
+		{
+			name:     "rate limit error",
+			errMsg:   "rate limit exceeded",
+			expected: true,
+		},
+		{
+			name:     "rate_limit with underscore",
+			errMsg:   "error: rate_limit_exceeded",
+			expected: true,
+		},
+		{
+			name:     "429 error",
+			errMsg:   "HTTP 429: Too Many Requests",
+			expected: true,
+		},
+		{
+			name:     "503 error",
+			errMsg:   "503 Service Unavailable",
+			expected: true,
+		},
+		{
+			name:     "overloaded",
+			errMsg:   "The model is currently overloaded",
+			expected: true,
+		},
+		{
+			name:     "capacity",
+			errMsg:   "No capacity available",
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `errorwatch` パッケージに `AutoResetter` を追加
- LLMエラー検知時に自動でエージェントをリセット
- クールダウン期間、連続失敗時のPMエスカレーション機能

## Changes
- `internal/errorwatch/auto_reset.go` - 自動リセット機能
- `internal/errorwatch/auto_reset_test.go` - テスト
- `internal/errorwatch/detector.go` - LLMエラーパターン追加
- `internal/errorwatch/detector_test.go` - テスト追加

## 機能詳細
- **エラー検知**: context deadline exceeded, rate limit, 429, 503 等
- **クールダウン**: デフォルト30秒（連続リセット防止）
- **エスカレーション**: 3回連続失敗でPMへ通知
- **コールバック**: リセット成功/失敗時のフック

## Test plan
- [x] gofmt -l . 出力なし
- [x] go vet ./... エラーなし
- [x] go test ./... 全件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)