### PR TITLE
feat(errorwatch): セルフメンション検知サポート追加

### DIFF
--- a/internal/errorwatch/detector.go
+++ b/internal/errorwatch/detector.go
@@ -7,6 +7,10 @@ import (
 	"time"
 )
 
+// SelfMentionError is the error message used when self-mention is detected.
+// Use this constant when triggering shock functionality from self-mention detection.
+const SelfMentionError = "self-mention detected"
+
 // ErrorPatterns defines the patterns to detect recoverable agent errors.
 var ErrorPatterns = []string{
 	// Context and timeout errors
@@ -27,6 +31,8 @@ var ErrorPatterns = []string{
 	"capacity",
 	// General errors that may be recoverable
 	"exit status 1",
+	// Self-mention violations (triggers shock functionality)
+	SelfMentionError,
 }
 
 // Detector detects error patterns and manages follow-up cooldowns.
@@ -130,4 +136,16 @@ func (d *Detector) IsAgentInAutoMode(agentName string) bool {
 // ResetAgentMode resets an agent to normal mode.
 func (d *Detector) ResetAgentMode(agentName string) {
 	d.modeManager.SwitchToNormal(agentName)
+}
+
+// IsSelfMentionError checks if the error message indicates a self-mention violation.
+func IsSelfMentionError(errMsg string) bool {
+	lower := strings.ToLower(errMsg)
+	return strings.Contains(lower, SelfMentionError)
+}
+
+// FormatSelfMentionError creates a formatted error message for self-mention detection.
+// This message will be recognized by IsRecoverableError and trigger the shock functionality.
+func FormatSelfMentionError(agentName string) string {
+	return SelfMentionError + ": " + agentName
 }

--- a/internal/errorwatch/detector_test.go
+++ b/internal/errorwatch/detector_test.go
@@ -92,6 +92,22 @@ func TestIsRecoverableError(t *testing.T) {
 			errMsg:   "No capacity available",
 			expected: true,
 		},
+		// Self-mention errors (triggers shock functionality)
+		{
+			name:     "self-mention detected",
+			errMsg:   SelfMentionError,
+			expected: true,
+		},
+		{
+			name:     "self-mention with context",
+			errMsg:   "agent error: self-mention detected for yuki",
+			expected: true,
+		},
+		{
+			name:     "self-mention case insensitive",
+			errMsg:   "SELF-MENTION DETECTED",
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `SelfMentionError` 定数を追加（ショック機能のトリガー用）
- `IsSelfMentionError()` ヘルパー関数を追加
- `FormatSelfMentionError()` でエージェント名付きエラーメッセージ生成
- エラーパターンに self-mention を追加し、IsRecoverableError で検知可能に

## Reviewer (Required)
- [ ] @priya

## Test plan
- [ ] `go test ./internal/errorwatch/...` でテスト通過確認
- [ ] self-mention のテストケース3種（通常、コンテキスト付き、大文字小文字）がパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)